### PR TITLE
feat: add note on using aria2 to download snapshots faster

### DIFF
--- a/docs/pages/chain/run-a-base-node.mdx
+++ b/docs/pages/chain/run-a-base-node.mdx
@@ -96,6 +96,8 @@ In the home directory of your Base Node, create a folder named `geth-data` or `r
 
 You'll then need to untar the downloaded snapshot and place the `geth` subfolder inside of it in the `geth-data` folder you created (unless you changed the location of your data directory).
 
+You can use a tool like [`aria2`](https://aria2.github.io/) to download the snapshot faster using parallel range requests.
+
 Return to the root of your Base node folder and start your node.
 
 ```bash [Terminal]


### PR DESCRIPTION
Using `aria2c` can result in much faster download times. Our download CDN supports range requests, so users should take full advantage by downloading over multiple TCP connections (max window size and latency cause actual throughput to be much lower than max per connection).