### PR TITLE
Add missing policy and tos to footer

### DIFF
--- a/docs/cookie-policy.mdx
+++ b/docs/cookie-policy.mdx
@@ -1,0 +1,95 @@
+---
+title: Cookie Policy
+slug: /cookie-policy
+description: Policy explaining how Base uses cookies on our website.
+hide_table_of_contents: true
+---
+
+# Base Cookie Policy
+
+Last updated: January 17, 2024
+
+---
+
+
+This Cookie Policy explains how Base (referred to here as **"we"**, **"us"** and **"our"**)
+uses cookies and similar technologies when you visit [base.org](https://base.org) (the
+**"Site"**) and/or when you explore and use Base through the Base protocol or any other
+applications, tools, and features we operate (collectively referred to as the **"Services"**).
+It explains what these technologies are and why we use them, as well as your rights to
+control our use of them.
+
+In some cases, we may use cookies and similar technologies to collect personal information,
+or information that becomes personal information if we combine it with other information.
+In such cases, the [Base Privacy Policy](/privacy-policy) will apply
+in addition to this Cookie Policy.
+
+## 1. What Are Cookies?
+
+Browser cookies are text files with small pieces of data downloaded onto your computer or
+mobile device. Browser cookies and other similar technologies enable websites and apps to
+store information or facilitate access to information stored on your device to enable
+certain features and distinguish you from other visitors. These technologies are used by
+most website and app providers to let users navigate between pages efficiently, ensure
+security of the webpage or application, understand how their websites are used, remember
+user preferences and generally improve the user experience. More information on cookies
+and their use can be found at [aboutcookies.org](https://www.aboutcookies.org) or
+[allaboutcookies.org](https://www.allaboutcookies.org). Cookies set by the website operator
+are called **"first party cookies"** and Cookies set by parties other than the website
+operator are called **"third party cookies"**. You should check the third-party's website
+for more information on how they use cookies.
+
+## 2. What Do We Use Cookies For?
+
+When you access our Site and Services, we, or companies we work with, may place cookies
+(collectively called **"cookies"** in this Cookie Policy) and similar technologies (such as
+web beacons, software development kits (**"SDKs"**), APIs, tags and local storage) on your
+computer or other device for the following purposes:
+
+### Strictly Necessary purposes
+
+Strictly Necessary cookies are essential for our Services to function and therefore
+cannot be switched off. They are usually only set in response to actions made by you
+which amount to a request for services, such as setting your privacy preferences,
+logging in, or filling in forms. These also include cookies we may rely on for security
+purposes, such as to prevent unauthorised access attempts. You can set your browser to
+block or alert you about these cookies at any time, but some features of our Services
+may not work.
+
+### Performance purposes
+
+We use these cookies to count visits and traffic sources so we can measure and improve
+the performance of our Services. These cookies help us to know which pages are the most
+and least popular and see how visitors move around the Site, and to resolve any errors
+that occur on the Services quickly to provide you with a better experience. For example,
+our first party base_device_id cookie is used to provide analytics on how our Site and
+Services perform. This cookie lasts for 3 months.
+
+## 3. How to Manage Cookies, Similar Technologies and Targeted Online Mobile Advertising
+
+You have the right to decide whether to accept or reject cookies (except strictly necessary
+cookies). You can enable or disable categories of cookies by visiting our CookieManager.
+This includes both first party and third party cookies. You can use the browser with which you
+are viewing this website to enable, disable or delete cookies. To do this, follow the instructions
+provided by your browser (usually located within the "Help", "Tools" or "Edit" settings). However,
+please note, if you set your browser to disable cookies, you may not be able to access secure areas
+of our Services. Also, if you disable cookies, other parts of our Services may not function properly.
+
+There are also additional tools available to manage third party cookies. You can visit the DAA's
+opt-out portal available at [optout.aboutads.info](http://optout.aboutads.info/), the DAA of Canada's
+opt-out portal available at [youradchoices.ca/en/tools](https://youradchoices.ca/en/tools), or visit
+the NAI's opt-out portal available at [optout.networkadvertising.org](http://optout.networkadvertising.org/?c=1).
+Residents of the European Union may opt-out of online behavioural advertising served by the European
+Interactive Digital Advertising Alliance&apos;s participating member organizations by visiting
+[youronlinechoices.eu](https://www.youronlinechoices.eu/) or through your mobile device settings,
+where available and the DAA&apos;s AppChoices mobile application opt-out offering here:
+[youradchoices.com/appchoices](https://youradchoices.com/appchoices).
+
+If you have any questions about our use of cookies or other technologies, please submit
+your request to privacy@base.org.
+
+## 4. Will This Cookie Policy Be Updated?
+
+We may update this Cookie Policy from time to time to reflect, for example, changes to
+the cookies we use or for other operational, legal or regulatory reasons. You can also
+revisit this page if you wish to keep yourself informed.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1107,7 +1107,30 @@
       "x": "https://x.com/mintlify",
       "github": "https://github.com/mintlify",
       "linkedin": "https://linkedin.com/company/mintlify"
-    }
+    },
+    "links": [
+      {
+        "header": "Base",
+        "items": [
+          {
+            "label": "Base.org",
+            "href": "https://base.org"
+          },
+          {
+            "label": "Privacy Policy",
+            "href": "https://docs.base.org/privacy-policy"
+          },
+          {
+            "label": "Terms of Service",
+            "href": "https://docs.base.org/terms-of-service"
+          },
+          {
+            "label": "Cookie Policy",
+            "href": "https://docs.base.org/cookie-policy"
+          }
+        ]
+      }
+    ]
   },
   "redirects": [
     {

--- a/docs/privacy-policy.mdx
+++ b/docs/privacy-policy.mdx
@@ -1,0 +1,105 @@
+---
+title: Privacy Policy
+slug: /privacy-policy
+description: The Privacy Policy for Base. Covers how we collect, use, and share personal information of users and developers through our services, including legal bases and data retention.
+hide_table_of_contents: true
+---
+
+# Base Global Privacy Policy
+
+Last updated: July 12, 2023
+
+---
+
+At Base (referred to here as “**we**”, “**us**” or “**our**”), we respect and protect the privacy of those users and developers (“**you**” and “**your**” or “**Users**” and “**Developers**”, as relevant) who explore and use Base (“**Base**”) through the Base protocol or any other applications, tools, and features we operate  (collectively, the “**Services**”).
+
+This Privacy Policy describes how we collect, use, and disclose personal information when you use our Services, which include the services offered on our website [https://base.org](https://base.org/) ( “**Site**”). This Privacy Policy does not apply to any processing which Base carries out as a processor on behalf of those Users and Developers who explore and use Base. Please note that we do not control websites, applications, or services operated by third parties, and we are not responsible for their actions. We encourage you to review the privacy policies of the other websites, decentralized applications, and services you use to access or interact with our Services.
+
+# 1. WHAT INFORMATION WE COLLECT 
+
+We collect the following personal information when providing the Services:
+
+**Information you provide**
+
+- Your public wallet address (“**Wallet Address**”)
+
+- Publicly available blockchain data (“**Blockchain Data**”)
+
+- Where you agree to engage in our surveys or sign up to receive marketing communications about Base products and offerings, we will ask for the following “**Basic User Information**”
+
+  - Name
+  - Email
+  - Social media handles
+  - Business name
+
+**Information Collected Automatically**
+
+- App, Browser and Device Information:
+
+- Information about the device, operating system, and browser you’re using~~ ~~
+- Other device characteristics or identifiers (e.g. plugins, the network you connect to)
+- IP address/derived location information
+
+**Information we obtain from Affiliates and third parties**
+
+- Information from Coinbase Companies (“**Affiliates**”):  We may obtain information about you, such as Basic User Information from our Affiliates (for instance, if you use Base with your Coinbase-hosted wallet) as part of facilitating, supporting, or providing our Services.
+- Blockchain Data: We may analyze public blockchain data, including timestamps of transactions or events, transaction IDs, digital signatures, transaction amounts and wallet addresses
+- Information from Analytics Providers: We receive information about your website usage and interactions from third party analytics providers. This includes browser fingerprint, device information, and IP address.
+- Error Tracking Data: We utilize information from third party service providers to provide automated error monitoring, reporting, alerting and diagnostic capture for Service and Site errors to allow User or Developers to build more effectively on the Base platform.
+
+# 2. HOW WE USE YOUR INFORMATION 
+
+We may use your personal information for the following purposes or as otherwise described at the time of collection. If you reside outside the United Kingdom or European Economic Area (“**EEA”)**, the legal bases on which we rely in your country may differ from those listed below.
+
+|                                                                                                                                                                          |                                                             |                       |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- | --------------------- |
+| **Purpose**                                                                                                                                                              | **Information Used**                                        | **Our Legal Basis**   |
+| To provide you with the Base Services We use certain information that is necessary to conclude and perform our Terms of Service or other relevant contract(s) with you.  | Wallet Address Blockchain Data                              | Contractual Necessity |
+| To promote the safety, security and integrity of our Services                                                                                                            | Basic User Information Information from Analytics Providers | Contractual Necessity |
+| To allow Users or Developers to build more effectively on the Base platform                                                                                              | Error Tracking Data                                         | Legitimate Interests  |
+| To send you Base Forms for marketing and product development                                                                                                             | Basic User Information                                      | Legitimate Interests  |
+
+# 3. HOW AND WHY WE SHARE YOUR INFORMATION 
+
+We share certain information about you with service providers, partners and other third parties in order to help us provide our Services. Here’s how:
+
+**Affiliates.** Basic User Information that we process and collect may be transferred between Affiliates, Services, and employees affiliated with us as a normal part of conducting business and offering our Services to you.
+
+**Linked Third Party Websites or Services.** When you use third-party services (like when you connect your self-custodial wallet to decentralized applications on the Base network) or websites that are linked through our Services, the providers of those services or products may receive information about you (like your wallet address) from Base, you, or others. Please note that when you use third-party services or connect to third-party websites which are not governed by this Privacy Policy, their own terms and privacy policies will govern your use of those services and products.
+
+**Professional advisors, industry partners, authorities and regulators.** We share your information described in **Section 1. What Information We Collect** with our advisors, regulators, tax authorities, law enforcement, government agencies, and industry partners when needed to:
+
+- respond pursuant to applicable law or regulations, court orders, legal process or government requests;
+- detect, investigate, prevent, or address fraud and other illegal activity or security and technical issues; and
+- protect the rights, property, and safety of our Users, Developers, Affiliates, or others, including to prevent death or imminent bodily harm.
+
+**Vendors and Third-Party Service Providers.** When we share information with third-party service providers to help us provide our Services, we require them to use your information on our behalf in accordance with our instructions and terms and only process as necessary for the purpose of the contract.
+
+# 4. HOW LONG WE RETAIN YOUR PERSONAL INFORMATION
+
+We retain your information as needed to provide our Services, comply with legal obligations or protect our or others’ interests. While retention requirements vary by country, we maintain internal retention policies on the basis of how information needs to be used. This includes considerations such as when the information was collected or created, whether it is necessary in order to continue offering you our Services or to protect the safety, security and integrity of our Services, and whether we are required to hold the information to comply with our legal obligations.
+
+# 5.  CHILDREN’S PERSONAL INFORMATION
+
+The Services are not directed to persons under the age of 18, and we do not knowingly request or collect any information about persons under the age of 18. If you are under the age of 18, please do not provide any personal information through the Site or Services. If a User submitting personal information is suspected of being younger than 18 years of age, we will take steps to delete the individual’s information as soon as possible.
+
+# 6. INTERNATIONAL TRANSFERS
+
+To facilitate our global operations, we and our  third-party partners and service providers may transfer and store throughout the world, including in the United States.
+
+If you reside in the EEA, Switzerland, or the United Kingdom, we rely upon a variety of legal mechanisms to facilitate these transfers of your personal information (collectively, “**European Personal Data”**). \*\*\*\*
+
+- We rely primarily on the European Commission’s Standard Contractual Clauses to facilitate the international and onward transfer of European Personal Data to third countries, including from our EU operating entities to Coinbase, Inc. in the United States, who provides the primary infrastructure for the Services.
+- We also rely on [adequacy decisions](https://ec.europa.eu/info/law/law-topic/data-protection/international-dimension-data-protection/adequacy-decisions_en) from the European Commission where available and exemptions provided for under data protection law (e.g. Article 49 GDPR).
+
+# 7. HOW TO CONTACT US WITH QUESTIONS
+
+If you have questions or concerns regarding this Privacy Policy, or if you have a complaint, please contact us at [privacy@base.org](mailto:privacy@base.org).
+
+# 8. CHANGES TO THIS PRIVACY POLICY
+
+We’re constantly trying to improve our Services, so we may need to change this Privacy Policy from time to time as well. We post any changes we make to our Privacy Policy on this page and, where appropriate, we will provide you with reasonable notice of any material changes before they take effect or as otherwise required by law. The date the Privacy Policy was last updated is identified at the top of this page.
+
+# 9. OUR RELATIONSHIP WITH YOU
+
+Coinbase Technologies, Inc., 251 Little Falls Drive, City of Wilmington, County of New Castle, Delaware 19808, acts as controller of your personal data.

--- a/docs/terms-of-service.mdx
+++ b/docs/terms-of-service.mdx
@@ -1,0 +1,164 @@
+---
+title: Terms of Service
+slug: /terms-of-service
+description: The Terms of Service for using Base, a layer-two optimistic rollup on Ethereum.
+hide_table_of_contents: true
+---
+
+# Sequencer, Testnet, Basenames Interface Terms
+
+Last Updated: October 25, 2024
+
+---
+
+We’re excited you’re interested in Base, a layer-two optimistic rollup on the Ethereum public blockchain. While we do not control Base, these Terms of Service (“Terms”) constitute a legally binding contract made between you and Coinbase Technologies, Inc. (“Coinbase,” “we,” or “us”) that governs your access to and use of the Coinbase Sequencer, Base Testnet, Basenames Interface, and Basenames Profile Pages each of which is defined below (collectively, the “Services”). By using the Services in any way, you agree to be bound by these Terms. If you do not accept the terms and conditions of these Terms, you are not permitted to access or otherwise use the Services.
+
+**BEFORE WE INCLUDE ANY OTHER DETAILS, WE WANT TO GIVE YOU NOTICE OF SOMETHING UP FRONT: BY AGREEING TO THESE TERMS, YOU AND WE AGREE TO RESOLVE ANY DISPUTES WE MAY HAVE WITH EACH OTHER VIA BINDING ARBITRATION OR IN SMALL CLAIMS COURT (INSTEAD OF A COURT OF GENERAL JURISDICTION), AND YOU AGREE TO DO SO AS AN INDIVIDUAL (INSTEAD OF, FOR EXAMPLE, AS A REPRESENTATIVE OR MEMBER OF A CLASS IN A CLASS ACTION). TO THE EXTENT THAT THE LAW ALLOWS, YOU ALSO WAIVE YOUR RIGHT TO A TRIAL BY JURY. FOR MORE INFORMATION, SEE OUR [ARBITRATION AGREEMENT](https://docs.base.org/docs/arbitration) “DISPUTE RESOLUTION, ARBITRATION AGREEMENT, CLASS ACTION WAIVER, AND JURY TRIAL WAIVER.”**
+
+### 1. Base and Bridging Smart Contracts
+
+The Base protocol (“Base”) is an open source, optimistic rollup protocol that operates with the Ethereum blockchain. The Base protocol includes protocol smart contracts that allow you to “bridge” (i.e., lock assets on one blockchain protocol and replicate them on another protocol) digital assets between Ethereum and/or Base (“Bridging Smart Contracts”). **Neither Base nor the Bridging Smart Contracts are part of the Services.** They are both operated through the use of certain open source software such as the OP Stack, an open sourced codebase approved by a decentralized, representative body of Optimism governance (the “Optimism Collective”), and a set of smart contracts that once deployed to the Base protocol are not controlled by Coinbase (even if Coinbase contributed to their initial development). Coinbase does not control what third parties may build on Base, the activity of such parties, any user transacting on Base, or any data stored on Base itself, and Coinbase does not take possession, custody, or control over any virtual currency or other digital asset on Base or the Bridging Smart Contracts, unless expressly stated in a written contract signed by Coinbase. You acknowledge and agree that Coinbase makes no representations or warranties with respect to Base or the Bridging Smart Contracts, and that, if you use Base or the Bridging Smart Contracts, you do so at your own risk.
+
+### 2. Basenames
+
+Basenames is an open source blockchain-based naming protocol that maintains a registry of all domains and subdomains on Base through a series of smart contracts deployed on Base. Basenames is not part of the Services. Users may, through interacting with the Basenames, search such registry, register domains and subdomains and manage their registered names, including by adding metadata and other information (e.g., URLs) to the corresponding text records on the Basenames smart contract (such metadata and other information, the “Basename Profile Information”). The Basenames interface located at https://base.org/names (the “Basenames Interface”) is one, but not the exclusive, means of accessing Basenames. You are responsible for conducting your own diligence on other interfaces enabling you to access Basenames to understand the fees and risks that they present.
+You understand that anyone can register and own a domain name (and its subdomains) that is not already registered on the registry maintained by Basenames. You further understand that names registered on the registry maintained by Basenames may expire and you are responsible for monitoring and renewing the registration of such names. You acknowledge that Coinbase is not able to forcibly remove, prevent or otherwise interfere with the ability of any person to register a domain name on the registry operated by Basenames and you hereby acknowledge that Coinbase will not be liable for any claims or damages whatsoever associated with your use, inability to use any domain names subject of registration, or to be registered, on the registry maintained by Basenames.
+You agree that Basenames is purely non-custodial, meaning you are solely responsible for the custody of the cryptographic private keys to the digital asset wallets you hold and use to access Basenames.
+
+### 3. Who May Use the Services
+
+You may only use the Services if you are legally capable of forming a binding contract with Coinbase in your respective jurisdiction which may require your parents consent if you’re not the legal age of majority (which in many jurisdictions is 18), and not barred from using the Services under the laws of any applicable jurisdiction, for example, that you do not appear on the U.S. Treasury Department’s list of Specially Designated Nationals and are not located or organized in a U.S. sanctioned jurisdiction. If you are using the Services on behalf of an entity or other organization, you agree to these Terms for that entity or organization and represent to Coinbase that you have the authority to bind that entity or organization to these Terms.
+
+### 4. Rights We Grant You
+
+As between you and us, Coinbase is the owner of the Services, including all related intellectual property rights and proprietary content, information, material, software, images, text, graphics, illustrations, logos, trademarks (including the Base logo, the Base name, the Coinbase logo, the Coinbase name, and any other Coinbase or Base marks), service marks, copyrights, photographs, audio, video, music, and the “look and feel” of the Services. We hereby permit you to use and access the Services, provided that you comply with these Terms. If any software, content or other materials owned or controlled by us are distributed to you as part of your use of the Services, we hereby grant you a non-sublicensable, non-transferable, and non-exclusive right and license to execute, access and display such software, content and materials provided to you as part of the Services, in each case for the sole purpose of enabling you to use the Services as permitted by these Terms. To use any parts of the contents of the Services other than for personal and non-commercial use, you must seek permission from Coinbase in writing. Coinbase reserves the right to refuse permission without providing any reasons.
+
+### 5. Accessing the Services
+
+To access the Services, Base, or the Bridging Smart Contracts you must connect a compatible cryptocurrency wallet software (“Wallet”). Your relationship with any given Wallet provider is governed by the applicable terms of that Wallet provider, not these Terms. You are responsible for maintaining the confidentiality of any private key controlled by your Wallet and are fully responsible for any and all messages or conduct signed with your private key. We accept no responsibility or liability to you in connection with your use of a Wallet, and make no representations and warranties regarding how the Services, Base, or the Bridging Smart Contracts will operate or be compatible with any specific Wallet. We reserve the right, in our sole discretion, to prohibit certain Wallet addresses from being able to use or engage in transactions via the Coinbase Sequencer or from using other aspects of the Services.
+
+As between you and Coinbase, you retain ownership and all intellectual property rights to the content and materials you submit to the Services. But, you grant us a limited, non-exclusive, worldwide, royalty free license to use your content solely for the purpose of operating the Services (i.e., the Sequencer and Base Testnet) for so long as we operate the Services. To avoid any doubt, this license does not allow us to use your intellectual property beyond operating the Services (e.g., in advertisements).
+
+### 6. The Services
+
+Coinbase offers the following Services that enable you to access and interact with Base and the Bridging Smart Contracts:
+
+- **The Sequencer:** The Coinbase Sequencer is a node operated by Coinbase that receives, records, and reports transactions on Base. While The Coinbase Sequencer is, initially, the only sequencer node supporting transactions on Base, additional nodes may be provided by third parties in the future and there are other mechanisms for submitting transactions through Ethereum. The Coinbase Sequencer does not store, take custody of, control, send, or receive your virtual currency, except for receiving applicable gas fees. It also does not have the ability to modify, reverse, or otherwise alter any submitted transactions, and will not have access to your private key or the ability to control value on your behalf. We reserve the right to charge and modify the fees in connection with your use of the Coinbase Sequencer. These fees may also be subject to taxes under applicable law.
+- **Base Testnet:** The Base Testnet is a test environment that allows you to build applications integrated with Base. You are permitted to access and use the Base Testnet only to test and improve the experience, security, and design of Base or applications built on Base, subject to these Terms. Base Testnet Tokens will not be converted into any future rewards offered by Coinbase. Coinbase may change, discontinue, or terminate, temporarily or permanently, all or any part of the Base Testnet, at any time and without notice.
+- **Basenames Interface:** The Basenames Interface is a web application and graphical user display operated by Coinbase and located at base.org/names. It enables you to interact with Basenames by creating blockchain messages that you can sign and broadcast to Base using your Wallet. The Basenames Interface will not have access to your private key at any point.
+- **Basenames Profile Pages:** Coinbase also operates a web application and graphical user display (the “Basenames Profile Pages”) that renders information about all registered Basenames domains and subdomains on Base, including any Basename Profile Information associated therewith. You understand that the information displayed on the Basenames Profile Pages, including all Basename Profile Information, is stored and publicly available on the Basenames decentralized protocol. Coinbase provides the Basenames Profile Pages only as a convenience, does not have control over any of third party content appearing therein, and does not warrant or endorse, nor bear responsibility for the availability or legitimacy of, the content on or accessible from any Basenames Profile Page (including any resources, interactive features, or links to Third-Party Services (as defined below) displayed therein). When viewing any Basenames Profile Page, you should assume that Coinbase has not verified the safety or legitimacy of, any content, resources, interactive features, or links appearing on such Basenames Profile Page (including any Farcaster Frames (or other open source products that provide substantially similar functionality) rendered thereon). It is your responsibility to ensure that you fully understand the nature of any links or other interactive features that you may be able to access on a Basenames Profile Page, including any financial risks that you may be exposed to when interacting with a Third-Party Service.
+
+### 7. Acceptable Use
+
+You agree that you will not use the Services in any manner or for any purpose other than as expressly permitted by these Terms. That means, among other things, you will not use the Services to do or encourage any of the following:
+
+- Infringe or violate the intellectual property rights or any other rights of anyone else (including Coinbase) or attempt to decompile, disassemble, or reverse engineer the Services;
+- Violate any applicable law or regulation, including without limitation, any applicable anti-money laundering laws, anti-terrorism laws, export control laws, end user restrictions, privacy laws or economic sanctions laws/regulations, including those administered by the U.S. Department of Treasury’s Office of Foreign Assets Control;
+- Use the Services in a way that is illegal, dangerous, harmful, fraudulent, misleading, deceptive, threatening, harassing, defamatory, obscene, or otherwise objectionable;
+- Violate, compromise, or interfere with the security, integrity, or availability of any computer, network, or technology associated with the Services, including using the Services in a manner that constitutes excessive or abusive usage, attempts to disrupt, attack, or interfere with other users, or otherwise impacts the stability of the Services.
+- Use any Coinbase brands, logos, or trademarks (or any brands, logos, or trademarks that are confusingly similar) without our express prior written approval, which we may withhold at our discretion for any reason.
+
+### 8. Release and Assumption of Risk
+
+‍By using the Services, Base, or the Bridging Smart Contracts, you represent that you understand there are risks inherent in using cryptographic and public blockchain-based systems, including, but not limited, to the Services and digital assets such as bitcoin (BTC) and ether (ETH). You expressly agree that you assume all risks in connection with your access and use of Base, the Bridging Smart Contracts, Basenames, and the separate Services offered by Coinbase. That means, among other things, you understand and acknowledge that:
+
+- The Base, the Bridging Smart Contracts, Basenames, and the separate Services may be subject to cyberattacks and exploits, which could result in the irrevocable loss or reduction in value of your digital assets or in additional copies of your digital assets being created or bridged without your consent.
+- Base is subject to periodic upgrades by the Optimism Collective. The Optimism Collective may approve a protocol upgrade that, if implemented, may significantly impact Base, and may introduce other risks, bugs, malfunctions, cyberattack vectors, or other changes to Base that could disrupt the operation of Base, the Bridging Smart Contracts, Basenames, or the Services or otherwise cause you damage or loss.
+- If you lose your Wallet seed phrase, private keys, or password, you might permanently be unable to access your digital assets. You bear sole responsibility for safeguarding and ensuring the security of your Wallet.
+
+You further expressly waive and release Coinbase, its parents, affiliates, related companies, their officers, directors, members, employees, consultants, representatives. agents, partners, licensors, and each of their respective successors and assigns (collectively, the “Coinbase Entities”) from any and all liability, claims, causes of action, or damages arising from or in any way related to your use of the Services, and your interaction with Base, the Bridging Smart Contracts, or Basenames. Also, to the extent applicable, you shall and hereby do waive the benefits and protections of California Civil Code § 1542, which provides: “[a] general release does not extend to claims that the creditor or releasing party does not know or suspect to exist in his or her favor at the time of executing the release and that, if known by him or her, would have materially affected his or her settlement with the debtor or released party.”
+
+### 9. Interactions with Other Users
+
+You are responsible for your interactions with other users on or through the Services. While we reserve the right to monitor interactions between users, we are not obligated to do so, and we cannot be held liable for your interactions with other users, or for any user’s actions or inactions. If you have a dispute with one or more users, you release us (and our affiliates and subsidiaries, and our and their respective officers, directors, employees and agents) from claims, demands and damages (actual and consequential) of every kind and nature, known and unknown, arising out of or in any way connected with such disputes. In entering into this release you expressly waive any protections (whether statutory or otherwise) that would otherwise limit the coverage of this release to include only those claims which you may know or suspect to exist in your favor at the time of agreeing to this release.
+
+### 10. Feedback
+
+Any questions, comments, suggestions, ideas, feedback, reviews, or other information about the Services, provided by you to Coinbase, are non-confidential and Coinbase will be entitled to the unrestricted use and dissemination of these submissions for any purpose, commercial or otherwise, without acknowledgment, attribution, or compensation to you.
+
+### 11. Privacy
+
+For more information regarding our collection, use, and disclosure of personal data and certain other data, please see our [Privacy Policy](http://docs.base.org/privacy-policy). The processing of personal data by Coinbase as a processor will be subject to any data processing agreement that you enter into with Coinbase.
+
+### 12. Third-Party Services
+
+The Services may provide access to services, sites, technology, applications and resources that are provided or otherwise made available by third parties (“Third-Party Services”). Your access and use of Third-Party Services may also be subject to additional terms and conditions, privacy policies, or other agreements with such third parties. Coinbase has no control over and is not responsible for such Third-Party Services, including for the accuracy, availability, reliability, or completeness of information or content shared by or available through Third-Party Services, or on the privacy practices of Third-Party Services. We encourage you to review the privacy policies of Third-Party Services prior to using such services. You, and not Coinbase, will be responsible for any and all costs and charges associated with your use of any Third-Party Services. The integration or inclusion of such Third-Party Services does not imply an endorsement or recommendation. Any dealings you have with third parties while using the Services — including if a Third-Party Service may have infringed your intellectual property rights — are between you and the third party. Coinbase will not be responsible or liable, directly or indirectly, for any damage or loss caused or alleged to be caused by or in connection with use of or reliance on any Third-Party Services.
+
+### 13. Additional Services
+
+We or our affiliates may offer additional services that interact with Base, which may require you to agree to additional terms. If, while using an additional service, there is a conflict between these Terms and the additional terms covering that service, the additional terms will prevail.
+
+### 14. Indemnification
+
+To the fullest extent permitted by applicable laws, you will indemnify and hold the Coinbase Entities harmless from and against any claims, disputes, demands, liabilities, damages, losses, and costs and expenses, including, without limitation, reasonable legal and accounting fees arising out of or in any way connected with (a) your access to or use of the Services, (b) your violation of these Terms, or (c) your negligence or willful misconduct. If you are obligated to indemnify any Coinbase Entity hereunder, then you agree that Coinbase (or, at its discretion, the applicable Coinbase Entity) will have the right, in its sole discretion, to control any action or proceeding and to determine whether Coinbase wishes to settle, and if so, on what terms, and you agree to fully cooperate with Coinbase in the defense or settlement of such claim.
+
+### 15. Warranty Disclaimers
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, BASE, THE BRIDGING SMART CONTRACTS, BASENAMES, AND THE SERVICES ARE PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS WITHOUT ANY REPRESENTATION OR WARRANTY, WHETHER EXPRESS, IMPLIED OR STATUTORY. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, COINBASE SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND/OR NON-INFRINGEMENT. THE COINBASE ENTITIES DO NOT MAKE ANY REPRESENTATIONS OR WARRANTIES THAT (I) ACCESS TO THE SERVICES, BASE, THE BRIDGING SMART CONTRACTS, OR BASENAMES WILL BE CONTINUOUS, UNINTERRUPTED, OR TIMELY; (II) THE SERVICES, BASE, THE BRIDGING SMART CONTRACTS, OR BASENAMES WILL BE COMPATIBLE OR WORK WITH ANY SOFTWARE, SYSTEM OR OTHER SERVICES, INCLUDING ANY WALLETS; (III) THE SERVICES, BASE, THE BRIDGING SMART CONTRACTS, OR BASENAMES WILL BE SECURE, COMPLETE, FREE OF HARMFUL CODE, OR ERROR-FREE; (IV) THE SERVICES, BASE, THE BRIDGING SMART CONTRACTS, OR BASENAMES WILL PREVENT ANY UNAUTHORIZED ACCESS TO, ALTERATION OF, OR THE DELETION, DESTRUCTION, DAMAGE, LOSS OR FAILURE TO STORE ANY OF YOUR CONTENT OR OTHER DATA; OR (V) THAT THE SERVICES, BASE, THE BRIDGING SMART CONTRACTS, OR BASENAMES WILL PROTECT YOUR ASSETS FROM THEFT, HACKING, CYBER ATTACK, OR OTHER FORM OF LOSS OR DEVALUATION CAUSED BY THIRD-PARTY CONDUCT.
+
+### 16. Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, NEITHER THE COINBASE ENTITIES NOR THEIR RESPECTIVE SERVICE PROVIDERS INVOLVED IN CREATING, PRODUCING, OR DELIVERING THE SERVICES WILL BE LIABLE FOR ANY INCIDENTAL, SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES, OR DAMAGES FOR LOST PROFITS, LOST REVENUES, LOST SAVINGS, LOST BUSINESS OPPORTUNITY, LOSS OF DATA OR GOODWILL, SERVICE INTERRUPTION, COMPUTER DAMAGE OR SYSTEM FAILURE, INTELLECTUAL PROPERTY INFRINGEMENT, OR THE COST OF SUBSTITUTE SERVICES OF ANY KIND ARISING OUT OF OR IN CONNECTION WITH THESE TERMS OR FROM THE USE OF OR INABILITY TO USE THE SERVICES, BASE, THE BRIDGING SMART CONTRACTS, OR BASENAMES, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER LEGAL THEORY, AND WHETHER OR NOT THE COINBASE ENTITIES OR THEIR RESPECTIVE SERVICE PROVIDERS HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGE, EVEN IF A LIMITED REMEDY SET FORTH HEREIN IS FOUND TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT WILL THE COINBASE ENTITIES’ TOTAL LIABILITY ARISING OUT OF OR IN CONNECTION WITH THESE TERMS OR FROM THE USE OF OR INABILITY TO USE THE SERVICES, BASE, THE BRIDGING SMART CONTRACTS, OR BASENAMES EXCEED THE AMOUNTS YOU HAVE PAID OR ARE PAYABLE BY YOU TO THE COINBASE ENTITIES FOR USE OF THE SERVICES OR ONE HUNDRED DOLLARS ($100), WHICHEVER IS HIGHER.
+THE EXCLUSIONS AND LIMITATIONS OF DAMAGES SET FORTH ABOVE ARE FUNDAMENTAL ELEMENTS OF THE BASIS OF THE BARGAIN BETWEEN COINBASE AND YOU.
+
+IF ANY PORTION OF THESE SECTIONS IS HELD TO BE INVALID UNDER THE LAWS OF YOUR STATE OF RESIDENCE, THE INVALIDITY OF SUCH PORTION WILL NOT AFFECT THE VALIDITY OF THE REMAINING PORTIONS OF THE APPLICABLE SECTIONS. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL OR CERTAIN OTHER DAMAGES, SO THE ABOVE LIMITATIONS AND EXCLUSIONS MAY NOT APPLY TO YOU.
+
+### 17. Changes to Terms
+
+We reserve the right, in our sole discretion, to change these Terms at any time and your continued use of the Services after the date any such changes become effective constitutes your acceptance of the new Terms. You should periodically visit this page to review the current Terms so you are aware of any revisions. If you do not agree to abide by these or any future Terms, you are not permitted to access, browse, or use (or continue to access, browse, or use) the Services.
+
+### 18. Notice
+
+Any notices or other communications provided by us under these Terms, including those regarding modifications to these Terms, will be posted online, in the Services, or through other electronic communication. You agree and consent to receive electronically all communications, agreements, documents, notices and disclosures that we provide in connection with your use of the Services.
+
+### 19. Entire Agreement.
+
+These Terms and any other documents incorporated by reference comprise the entire understanding and agreement between you and Coinbase as to the subject matter hereof, and supersedes any and all prior discussions, agreements and understandings of any kind (including without limitation any prior versions of these Terms), between you and Coinbase. Section headings in these Terms are for convenience only and shall not govern the meaning or interpretation of any provision of these Terms.
+
+### 20. Assignment
+
+We reserve the right to assign our rights without restriction, including without limitation to any Coinbase affiliates or subsidiaries, or to any successor in interest of any business associated with the Services. In the event that Coinbase is acquired by or merged with a third party entity, we reserve the right, in any of these circumstances, to transfer or assign the information we have collected from you as part of such merger, acquisition, sale, or other change of control. You may not assign any rights and/or licenses granted under these Terms. Any attempted transfer or assignment by you in violation hereof shall be null and void. Subject to the foregoing, these Terms will bind and inure to the benefit of the parties, their successors and permitted assigns.
+
+### 21. Severability
+
+If any provision of these Terms is determined to be invalid or unenforceable under any rule, law, or regulation of any local, state, or federal government agency, such provision will be changed and interpreted to accomplish the objectives of the provision to the greatest extent possible under any applicable law and the validity or enforceability of any other provision of these Terms shall not be affected.
+
+### 22. Termination; Survival
+
+We may suspend or terminate your access to and use of the Services at our sole discretion, at any time and without notice to you. Upon any termination, discontinuation or cancellation of the Services, Sections 7 through 27 of the Terms will survive.
+
+### 23. Governing Law
+
+You agree that the laws of the State of California, without regard to principles of conflict of laws, will govern these Terms and any Dispute, except to the extent governed by federal law.
+
+### 24. Force Majeure
+
+We shall not be liable for delays, failure in performance or interruption of service which result directly or indirectly from any cause or condition beyond our reasonable control, including but not limited to, significant market volatility, act of God, act of civil or military authorities, act of terrorists, civil disturbance, war, strike or other labor dispute, fire, interruption in telecommunications or Internet services or network provider services, failure of equipment and/or software, pandemic, other catastrophe or any other occurrence which is beyond our reasonable control and shall not affect the validity and enforceability of any remaining provisions.
+
+### 25. Non-Waiver of Rights
+
+These Terms shall not be construed to waive rights that cannot be waived under applicable laws, including applicable state money transmission laws in the state where you are located. In addition, our failure to insist upon or enforce strict performance by you of any provision of these Terms or to exercise any right under these Terms will not be construed as a waiver or relinquishment to any extent of our right to assert or rely upon any such provision or right in that or any other instance.
+
+### 26. Relationship of the Parties
+
+Coinbase is an independent contractor for all purposes. Nothing in these Terms is intended to or shall operate to create a partnership or joint venture between you and Coinbase, or authorize you to act as agent of Coinbase. These Terms are not intended to, and do not, create or impose any fiduciary duties on us. To the fullest extent permitted by law, you acknowledge and agree that we owe no fiduciary duties or liabilities to you or any other party, and that to the extent any such duties or liabilities may exist at law or in equity, those duties and liabilities are hereby irrevocably disclaimed, waived, and foregone. You further agree that the only duties and obligations that we owe you are those set out expressly in these Terms.
+
+### 27. Dispute Resolution, Arbitration Agreement, Class Action Waiver, And Jury Trial Waiver
+
+If you have a dispute with us, you agree to first contact Coinbase Support via our Customer Support page (https://help.coinbase.com). If Coinbase Support is unable to resolve your dispute, you agree to follow our Formal Complaint Process. You begin this process by submitting our [complaint form](https://help.coinbase.com/en/coinbase/other-topics/other/how-to-send-a-complaint). If you would prefer to send a written complaint via mail, please include as much information as possible in describing your complaint, including your support ticket number, how you would like us to resolve the complaint, and any other relevant information to us at 82 Nassau St #61234, New York, NY 10038. The Formal Complaint Process is completed when Coinbase responds to your complaint or 45 business days after the date we receive your complaint, whichever occurs first. You agree to complete the Formal Complaint Process before filing an arbitration demand or action in small claims court.
+
+#### Disputes with Users Who Reside in the United States or Canada
+
+If you reside in the United States or Canada, and if you have a dispute with us or if we have a dispute with you, the dispute shall be resolved through binding arbitration or in small claims court pursuant to the Arbitration Agreement in Appendix 1 below.
+
+As an illustration only, the following is a summary of some of the terms of the Arbitration Agreement:
+
+- Disputes will be resolved individually (in other words, you are waiving your right to proceed against Coinbase in a class action). However, if you or we bring a coordinated group of arbitration demands with other claimants, you and we agree that the American Arbitration Association (AAA) must batch your or our arbitration demand with up to 100 other claimants to increase the efficiency and resolution of such claims.
+- Certain disputes must be decided before a court, including (1) any claim that the class action waiver is unenforceable, (2) any dispute about the payment of arbitration fees, (3) any dispute about whether you have completed the prerequisites to arbitration (such as exhausting the support and Formal Complaint processes), (4) any dispute about which version of the Arbitration Agreement applies, and (5) any dispute about whether a dispute is subject to the Arbitration Agreement in the first instance.
+- In the event that a dispute is filed with a court that does not fall into one of the above five categories, either you or Coinbase may move to compel the court to order arbitration. If the court issues an order compelling arbitration, the prevailing party on the motion to compel may recover its reasonable attorneys’ fees and costs.
+
+#### Disputes with Users Who Reside Outside the United States and Canada
+
+If you do not reside in the United States or Canada, the Arbitration Agreement in Appendix 1 does not apply to you and you may resolve any claim you have with us relating to, arising out of, or in any way in connection with our Terms, us, or our Services in a court of competent jurisdiction.


### PR DESCRIPTION
**What changed? Why?**
Added the missing TOS, Privacy Policy, and Cookie Policy docs