### PR TITLE
Update xmtp agent guide

### DIFF
--- a/docs/wallet-app/guides/chat-agents.mdx
+++ b/docs/wallet-app/guides/chat-agents.mdx
@@ -55,7 +55,7 @@ cd xmtp-agent-examples
 Install all required packages:
 
 ```bash
-yarn
+npm
 ```
 
 **STEP 3: GENERATE KEYS FOR YOUR AGENT**
@@ -63,7 +63,7 @@ yarn
 Run the key generation script to create your agent's wallet:
 
 ```bash
-yarn gen:keys
+npm gen:keys
 ```
 
 This creates a .env file with:
@@ -107,7 +107,7 @@ for await (const message of  stream) {
 Then run your agent:
 
 ```bash
-yarn dev
+npm dev
 ```
 
 ### Getting the address of a user
@@ -138,7 +138,7 @@ You can also explore example implementations in the `/examples` folder, includin
 1\. Start your agent:
 
 ```javascript
-yarn dev
+npm dev
 ```
 
 2\. Test on [xmtp.chat:](https://xmtp.chat/conversations)  
@@ -216,14 +216,13 @@ const address = inboxState.identifiers[0].identifier;
 const inboxId = client.inboxId;
 const installationId = client.installationId;
 const conversations = await client.conversations.list();
-const installations = await client.preferences.inboxState();
 
 console.log(`
 ✓ XMTP Client:
 • InboxId: ${inboxId}
 • Address: ${address}
 • Conversations: ${conversations.length}
-• Installations: ${installations.installations.length}
+• Installations: ${inboxState.installations.length}
 • InstallationId: ${installationId}
 • Network: ${process.env.XMTP_ENV}`);
 ```


### PR DESCRIPTION
## What changed? Why?

Updated Chat Agents documentation to use the correct XMTP repository and current SDK. Original docs pointed to deprecated `xmtp/bot-starter` repo and outdated `@xmtp/xmtp-js` SDK.

**Key Changes:**
- Repository: `xmtp/bot-starter` → `ephemeraHQ/xmtp-agent-examples`
- SDK: `@xmtp/xmtp-js` → `@xmtp/node-sdk`
- Node.js: v16+ → v20+
- Environment variables: `PRIVATE_KEY` → `WALLET_KEY`, added `ENCRYPTION_KEY`
- Fixed all GitHub example links
- Consistent "agent" terminology throughout
