### PR TITLE
Update wallet_addSubAccount params: rename keys.key to keys…

### DIFF
--- a/docs/smart-wallet/llms.txt
+++ b/docs/smart-wallet/llms.txt
@@ -2358,7 +2358,7 @@ type AccountCreate = {
   type: 'create';
   keys: {
     type: 'address' | 'p256' | 'webcrypto-p256' | 'webauthn-p256';
-    key: `0x${string}`;
+    publicKey: `0x${string}`;
   }[];
 };
 

--- a/docs/smart-wallet/technical-reference/sdk/CoinbaseWalletProvider/wallet_addSubAccount.mdx
+++ b/docs/smart-wallet/technical-reference/sdk/CoinbaseWalletProvider/wallet_addSubAccount.mdx
@@ -27,7 +27,7 @@ Array of key objects for the sub account (required for "create" type).
 Type of key: "address", "p256", "webcrypto-p256", or "webauthn-p256".
 </ParamField>
 
-<ParamField body="key" type="string" required>
+<ParamField body="publicKey" type="string" required>
 Hex string of the public key.
 </ParamField>
 </Expandable>
@@ -70,7 +70,7 @@ Factory deployment data (optional).
       "type": "create",
       "keys": [{
         "type": "p256",
-        "key": "0x0123456789abcdef..."
+        "publicKey": "0x0123456789abcdef..."
       }]
     }
   }]


### PR DESCRIPTION
….publicKey

**What changed? Why?**
Update the wallet_addSubAccount spec to reflect the new naming changes

**Notes to reviewers**

**How has it been tested?**
