### PR TITLE
Update discord links

### DIFF
--- a/docs/cookbook/go-gasless.mdx
+++ b/docs/cookbook/go-gasless.mdx
@@ -394,7 +394,7 @@ This approach can greatly improve your dApp’s user experience by removing gas 
 - [simple NFT contract]
 
 [list of factory addresses]: https://docs.alchemy.com/reference/factory-addresses
-[Discord]: https://discord.com/invite/cdp
+[Discord]: https://discord.com/invite/buildonbase
 [CDP site]: https://portal.cdp.coinbase.com/
 [Coinbase Developer Platform]: https://portal.cdp.coinbase.com/
 [UI]: https://portal.cdp.coinbase.com/products/bundler-and-paymaster

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -176,7 +176,7 @@
             },
             {
               "anchor": "Support",
-              "href": "https://discord.com/invite/base",
+              "href": "https://discord.com/invite/buildonbase",
               "icon": "discord"
             }
           ]
@@ -347,7 +347,7 @@
             },
             {
               "anchor": "Support",
-              "href": "https://discord.com/invite/cdp",
+              "href": "https://discord.com/invite/buildonbase",
               "icon": "discord"
             }
           ]
@@ -626,7 +626,7 @@
             },
             {
               "anchor": "Support",
-              "href": "https://discord.com/invite/cdp",
+              "href": "https://discord.com/invite/buildonbase",
               "icon": "discord"
             }
           ]
@@ -1108,7 +1108,7 @@
       },
       {
         "label": "Support",
-        "href": "https://discord.com/invite/base"
+        "href": "https://discord.com/invite/buildonbase"
       }
     ],
     "primary": {

--- a/docs/onchainkit/guides/build-onchain-apps.mdx
+++ b/docs/onchainkit/guides/build-onchain-apps.mdx
@@ -100,6 +100,6 @@ Play with it live [here](https://onchain-app-template.vercel.app).
 
 ## Need more help?
 
-If you have any questions or need help, feel free to reach out to us on [Discord](https://discord.gg/invite/cdp)
+If you have any questions or need help, feel free to reach out to us on [Discord](https://discord.gg/invite/buildonbase)
 or open a [Github issue](https://github.com/coinbase/onchainkit/issues) or DM us
 on X at [@onchainkit](https://x.com/onchainkit), [@zizzamia](https://x.com/zizzamia), [@fkpxls](https://x.com/fkpxls).

--- a/docs/onchainkit/guides/troubleshooting.mdx
+++ b/docs/onchainkit/guides/troubleshooting.mdx
@@ -3,7 +3,7 @@ title: "Troubleshooting"
 ---
 
 
-This guide covers common issues you may encounter while using OnchainKit. If you don't find your issue here, try searching our [GitHub Issues](https://github.com/coinbase/onchainkit/issues) or joining our [Discord Community](https://discord.gg/invite/cdp).
+This guide covers common issues you may encounter while using OnchainKit. If you don't find your issue here, try searching our [GitHub Issues](https://github.com/coinbase/onchainkit/issues) or joining our [Discord Community](https://discord.gg/invite/buildonbase).
 
 ## Common Issues
 
@@ -136,6 +136,6 @@ This guide covers common issues you may encounter while using OnchainKit. If you
 
 Need more help?
 
-- [Discord Community](https://discord.gg/invite/cdp)
+- [Discord Community](https://discord.gg/invite/buildonbase)
 - [X/Twitter Support](https://x.com/onchainkit)
 - [GitHub Issues](https://github.com/coinbase/onchainkit/issues)

--- a/docs/smart-wallet/guides/sub-accounts/add-sub-accounts-to-onchainkit.mdx
+++ b/docs/smart-wallet/guides/sub-accounts/add-sub-accounts-to-onchainkit.mdx
@@ -241,4 +241,4 @@ npm run dev
 
 Congratulations! You've successfully added Sub Accounts to your OnchainKit/MiniKit project.
 
-If you have any questions, join the _#smart-wallet_ channel on [Discord](https://discord.gg/cdp).
+If you have any questions, join the _#smart-wallet_ channel on [Discord](https://discord.gg/buildonbase).

--- a/docs/smart-wallet/guides/sub-accounts/setup.mdx
+++ b/docs/smart-wallet/guides/sub-accounts/setup.mdx
@@ -222,4 +222,4 @@ In the next section, we'll cover [Using Sub Accounts](/smart-wallet/guides/sub-a
 ## Additional Resources
 
 - You can take a look at the final code in the [Sub Account Starter Template Demo](https://github.com/base/demos/tree/master/smart-wallet/sub-accounts-demo)
-- You can reach out to us on the #smart-wallet channel on [Discord](https://discord.com/invite/cdp) if you have any questions or feedback
+- You can reach out to us on the #smart-wallet channel on [Discord](https://discord.com/invite/buildonbase) if you have any questions or feedback

--- a/docs/smart-wallet/guides/sub-accounts/sub-accounts-with-privy.mdx
+++ b/docs/smart-wallet/guides/sub-accounts/sub-accounts-with-privy.mdx
@@ -150,4 +150,4 @@ npm run dev
 - [Sub Accounts Technical Reference](/smart-wallet/technical-reference/sdk/sub-account-reference)
 - [Smart Wallet Sub Accounts Feature](/smart-wallet/concepts/features/optional/sub-accounts)
 - [Privy Quickstart](https://docs.privy.io/guide/quickstart)
-- [Discord #smart-wallet](https://discord.com/invite/cdp) for questions or feedback
+- [Discord #smart-wallet](https://discord.com/invite/buildonbase) for questions or feedback

--- a/docs/smart-wallet/guides/sub-accounts/using-sub-accounts.mdx
+++ b/docs/smart-wallet/guides/sub-accounts/using-sub-accounts.mdx
@@ -276,4 +276,4 @@ All transactions will be automatically limited by the Spend Permissions configur
 ## Additional Resources
 
 - You can take a look at the final code in the [Sub Account Starter Template Demo](https://github.com/base/demos/tree/master/smart-wallet/sub-accounts-demo)
-- You can reach out to us on the #smart-wallet channel on [Discord](https://discord.com/invite/cdp) if you have any questions or feedback
+- You can reach out to us on the #smart-wallet channel on [Discord](https://discord.com/invite/buildonbase) if you have any questions or feedback

--- a/docs/smart-wallet/quickstart/react-native-project.mdx
+++ b/docs/smart-wallet/quickstart/react-native-project.mdx
@@ -203,4 +203,4 @@ return (
 
 ## Give feedback!
 
-Send us feedback on the [Coinbase Developer Platform](https://discord.com/invite/cdp/) Discord or create a new issue on the [MobileWalletProtocol/react-native-client](https://github.com/MobileWalletProtocol/react-native-client/issues) repository.
+Send us feedback on the [Base Discord](https://discord.com/invite/buildonbase/) or create a new issue on the [MobileWalletProtocol/react-native-client](https://github.com/MobileWalletProtocol/react-native-client/issues) repository.


### PR DESCRIPTION
**What changed? Why?**

Update discord link from from base to buildonbase

Update discord links from cdp to buildonbase

PSA: No change for paymaster and gasless campaign pages
