### PR TITLE
Add Content Types section to Chat Agents doc

### DIFF
--- a/docs/wallet-app/guides/chat-agents.mdx
+++ b/docs/wallet-app/guides/chat-agents.mdx
@@ -135,13 +135,13 @@ You can also explore example implementations in the `/examples` folder, includin
 
 **Development Testing**
 
-1\. Start your agent:
+1. Start your agent:
 
 ```javascript
 npm dev
 ```
 
-2\. Test on [xmtp.chat:](https://xmtp.chat/conversations)  
+2. Test on [xmtp.chat:](https://xmtp.chat/conversations)  
 • Go to https://xmtp.chat  
 • Connect your personal wallet  
 • Switch to Dev environment in settings  
@@ -150,13 +150,13 @@ npm dev
 
 **Production Testing**
 
-1\. Update environment:
+1. Update environment:
 
 ```javascript
 XMTP_ENV=production
 ```
 
-2\. Test on Coinbase Wallet:  
+2. Test on Coinbase Wallet:  
 • Open Coinbase Wallet mobile app  
 • Go to messaging  
 • Start conversation with your agent's address  
@@ -166,17 +166,17 @@ XMTP_ENV=production
 
 Give your agent a human-readable name:
 
-**1\. Import agent wallet to Coinbase Wallet extension:**  
+**1. Import agent wallet to Coinbase Wallet extension:**  
 • Install Coinbase Wallet browser extension  
 • Import using your agent's private key
 
-**2\. Purchase a basename:**  
+**2. Purchase a basename:**  
 • Visit https://base.org/names  
 • Connect your agent's wallet  
 • Search and purchase your desired basename (e.g., myagent.base.eth)  
 • Set as primary name
 
-**3\. Verify setup:**  
+**3. Verify setup:**  
 • Your agent can now be reached via the basename instead of the long address  
 • Users can message myagent.base.eth instead of 0x123...
 
@@ -201,10 +201,10 @@ Heroku, Vercel, or any Node.js hosting platform:
 **STEP 8: MONITOR AND MAINTAIN**
 
 **Best Practices**  
-1\. Logging: Add comprehensive logging to track agent activity  
-2\. Error Handling: Implement try-catch blocks for network issues  
-3\. Rate Limiting: Respect XMTP rate limits in your agent logic  
-4\. Security: Never expose private keys; use environment variables
+1. Logging: Add comprehensive logging to track agent activity  
+2. Error Handling: Implement try-catch blocks for network issues  
+3. Rate Limiting: Respect XMTP rate limits in your agent logic  
+4. Security: Never expose private keys; use environment variables
 
 **Monitoring**  
 
@@ -226,6 +226,168 @@ console.log(`
 • InstallationId: ${installationId}
 • Network: ${process.env.XMTP_ENV}`);
 ```
+
+## Content types
+
+Coinbase Wallet supports various XMTP content types for rich messaging capabilities. This document outlines all supported content types, including custom types for Quick Actions and Intent.
+
+XMTP uses content types to define the structure and meaning of message types.
+
+We'll outline the standard and custom XMTP content types you can utilize in your agent.
+
+### XMTP Content Types
+
+**Text Messages**
+- Content Type: `xmtp.org/text:1.0`
+- Purpose: Basic text messaging
+- Usage: Default for plain text
+
+**Attachments**
+- Content Type: `xmtp.org/attachment:1.0`
+- Purpose: File attachments (inline)
+- Usage: Send files directly in messages
+
+**Remote Static Attachments**
+- Content Type: `xmtp.org/remoteStaticAttachment:1.0`
+- Purpose: Remote file attachments via URLs
+- Usage: Reduce message size
+
+**Reactions**
+- Content Type: `xmtp.org/reaction:1.0`
+- Purpose: Emoji reactions
+- Usage: React to messages with emojis
+- Note: Does not trigger read receipts
+
+**Replies**
+- Content Type: `xmtp.org/reply:1.0`
+- Purpose: Threaded conversations
+- Usage: Reply to specific messages
+
+**Group Management**
+- Content Types:
+  - `xmtp.org/group_membership_change:1.0`
+  - `xmtp.org/group_updated:1.0`
+- Purpose: Membership & group metadata updates
+- Usage: Automatic system messages
+
+**Read Receipts**
+- Content Type: `xmtp.org/readReceipt:1.0`
+- Purpose: Read confirmations
+- Usage: Sent automatically
+
+**Transactions (Wallet Send Calls)**
+- Content Type: `xmtp.org/walletSendCalls:1.0`
+- Purpose: Request wallet actions from users
+
+**Transaction Receipts**
+- Content Type: `xmtp.org/transactionReference:1.0`
+- Purpose: Share blockchain transaction info
+
+### Coinbase Wallet Content Types
+
+There are content types developed by the Coinbase Wallet team for agents in Coinbase Wallet. Other XMTP clients may not support these content types.
+
+**Quick Actions (coinbase.com/actions:1.0)**
+
+Purpose: Present interactive buttons in a message
+
+Structure:
+```typescript
+type ActionsContent = {
+  id: string;
+  description: string;
+  actions: Action[];
+  expiresAt?: string;
+};
+
+type Action = {
+  id: string;
+  label: string;
+  imageUrl?: string;
+  style?: 'primary' | 'secondary' | 'danger';
+  expiresAt?: string;
+};
+```
+
+Validation Rules:
+- `id`, `description` are required
+- `actions` must be 1–10 items with unique IDs
+- Style must be one of: `primary`, `secondary`, `danger`
+
+Fallback:
+```
+[Description]
+
+[1] [Action Label 1]
+[2] [Action Label 2]
+...
+Reply with the number to select
+```
+
+Example: Payment Options
+```json
+{
+  id: 'payment_alice_123',
+  description: 'Choose amount to send to Alice',
+  actions: [
+    { id: 'send_10', label: 'Send $10', style: 'primary' },
+    { id: 'send_20', label: 'Send $20', style: 'primary' },
+    { id: 'custom_amount', label: 'Custom Amount', style: 'secondary' },
+  ],
+  expiresAt: '2024-12-31T23:59:59Z'
+}
+```
+
+**Intent (coinbase.com/intent:1.0)**
+
+Purpose: User expresses choice from Quick Actions
+
+Structure:
+```typescript
+type IntentContent = {
+  id: string;
+  actionId: string;
+  metadata?: Record<string, string | number | boolean | null>;
+};
+```
+
+Validation Rules:
+- `id`, `actionId` required
+- Must match corresponding Actions
+- `metadata` is optional, `<10KB`
+
+Fallback:
+```
+User selected action: [actionId]
+```
+
+Example: Intent Message
+```json
+{
+  id: 'payment_alice_123',
+  actionId: 'send_10',
+  metadata: {
+    timestamp: Date.now(),
+    actionLabel: 'Send $10'
+  }
+}
+```
+
+### Best practices
+
+- Always validate content structures
+- Provide fallbacks for unsupported clients
+- Test across client versions
+- Limit message and metadata size
+- Follow XIP-67
+
+Your agent should respond to both direct messages and group chat messages (if applicable).
+
+For direct messages, it should automatically respond.
+
+We recommend reacting to messages with an emoji (like 👀 or ⌛) to indicate the message was received, while the response is processing.
+
+For group chat messages, agents should only respond if they are mentioned with the "@" symbol and the agent's name. (example "@bankr"), OR if the user replies directly to a message from the agent (using the reply content type).
 
 ## Getting featured
 


### PR DESCRIPTION
**What changed? Why?**
Adds a Content Types section to the [Chat Agents in Coinbase Wallet](https://docs.base.org/wallet-app/guides/chat-agents) doc

**Notes to reviewers**

**How has it been tested?**
Tested both locally and on the preview Mintlify build
