### PR TITLE
chore: fixes for banner on dark mode

### DIFF
--- a/docs/snippets/Button/index.mdx
+++ b/docs/snippets/Button/index.mdx
@@ -16,7 +16,7 @@ export const Button = ({
 
   const variantStyles = {
   primary:
-    'bg-blue text-white border border-blue hover:bg-blue-80 active:bg-[#06318E]',
+    'bg-blue text-black border border-blue hover:bg-blue-80 active:bg-[#06318E] dark:text-white',
   secondary:
     'bg-white border border-white text-palette-foreground hover:bg-zinc-15 active:bg-zinc-30',
   outlined:

--- a/docs/snippets/banner/BaseBanner.mdx
+++ b/docs/snippets/banner/BaseBanner.mdx
@@ -21,7 +21,7 @@ export const BaseBanner = ({
   }
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-white py-8 px-4 lg:px-12 z-50 text-black dark:bg-black dark:text-white">
+    <div className="fixed bottom-0 left-0 right-0 bg-white py-8 px-4 lg:px-12 z-50 text-black dark:bg-black dark:text-white border-t dark:border-gray-95">
       <div className="flex items-center max-w-8xl mx-auto">
         {typeof content === 'function' ? content({ onDismiss }) : content}
         {dismissable && <button


### PR DESCRIPTION
**What changed? Why?**

Light mode was broken.

Fixed: 

![image](https://github.com/user-attachments/assets/3de5ab4e-d15b-4964-8be5-d784d14b0dfc)


**Notes to reviewers**

**How has it been tested?**
