### PR TITLE
fix: update node snapshots link to point to docs.base.org

### DIFF
--- a/docs/base-chain/node-operators/performance-tuning.mdx
+++ b/docs/base-chain/node-operators/performance-tuning.mdx
@@ -40,7 +40,7 @@ The following are the hardware specifications used for Base production nodes:
 
 ## Initial Sync
 
-Using a recent [snapshot](/base-chain/node-operators/snapshots.mdx) can significantly reduce the time required for the initial node synchronization process.
+Using a recent [snapshot](/chain/node-snapshots) can significantly reduce the time required for the initial node synchronization process.
 
 ## Client Software
 


### PR DESCRIPTION
**What changed? Why?**
Fix the link to the snapshots page.

**How has it been tested?**
Locally
