### PR TITLE
correction of wrong link on the documentation

### DIFF
--- a/docs/onchainkit/guides/build-onchain-apps.mdx
+++ b/docs/onchainkit/guides/build-onchain-apps.mdx
@@ -14,7 +14,7 @@ Whether you're a hackathon participant or an ambitious entrepreneur aiming to bu
 <Frame>
 <img
   alt="Build Onchain Apps with OnchainKit"
-  src="/images/onchainkit/onchain-app-template-1.png"
+  src="/docs/images/onchainkit/onchain-app-template-1.png"
   width="702"
 />
 </Frame>


### PR DESCRIPTION
updating the outdated png on the base documentation

**What changed? Why?**

The link to the PNG display of the ochainkit file was updated

**Notes to reviewers**

**How has it been tested?**
yes and works perfectly