### PR TITLE
Fix clientFid for TBA

### DIFF
--- a/docs/wallet-app/introduction/mini-apps.mdx
+++ b/docs/wallet-app/introduction/mini-apps.mdx
@@ -258,7 +258,7 @@ The following Mini App SDK features are **not currently supported** in Coinbase 
 * Use `sdk.actions.composeCast()` instead of Warpcast composer URLs  
 * Implement visual feedback alternatives for haptic feedback  
 * Avoid relying on location context for core functionality
-* To conditionally render functionality based on the user's client, check context.client.clientFid (Coinbase Wallet returns 399519)
+* To conditionally render functionality based on the user's client, check context.client.clientFid (Coinbase Wallet returns 309857)
 
 We are actively working to expand compatibility and expect to support additional features in future releases.
 


### PR DESCRIPTION
- Opening my mini app Kiwi News in the TBA app, my clientFid is 309857, not the number mentioned in the docs.
- I then went to Neynar to call https://hub-api.neynar.com/v1/userDataByFid with the 309857 fid and the 399519
- To me only 309857 returns a valid profile, so I assume that this is the correct clientFid