### PR TITLE
chore: document get transaction by hash

### DIFF
--- a/docs/base-chain/flashblocks/apps.mdx
+++ b/docs/base-chain/flashblocks/apps.mdx
@@ -90,6 +90,23 @@ curl https://sepolia-preconf.base.org -X POST -H "Content-Type: application/json
 }
 ```
 
+#### eth_getTransactionByHash
+
+Use the existing get transaction by hash RPC to get preconfirmed transactions:
+```
+curl https://sepolia-preconf.base.org -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x..."],"id":1}'
+```
+
+**Example Response**
+```
+{
+  "type": "0x2",
+  "chainId": "...",
+  "nonce": "...",
+  ...
+}
+```
+
 ### Libraries
 
 For popular libraries, they sometimes require additional RPC support for transaction preconfirmation to work properly.


### PR DESCRIPTION
**What changed? Why?**
Add docs for eth_getTransactionByHash flashblocks support.

