### PR TITLE
fix: update outdated GitHub link in cookbook/launch-tokens page

### DIFF
--- a/docs/cookbook/launch-tokens.mdx
+++ b/docs/cookbook/launch-tokens.mdx
@@ -413,7 +413,7 @@ Remember to always prioritize security, transparency, and community value when d
   <Card title="Base Twitter" icon="twitter" href="https://twitter.com/base">
     Follow Base updates
   </Card>
-  <Card title="Base GitHub" icon="github" href="https://github.com/base-org">
+  <Card title="Base GitHub" icon="github" href="https://github.com/base">
     Contribute to Base development
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Description
Fixed outdated GitHub link in the cookbook/launch-tokens page that was pointing to Base's old Github repo

**What changed? Why?**
- Changed href from https://github.com/base-org to https://github.com/base

**Notes to reviewers**

**How has it been tested?**
- [x] Tested locally
- [x] Verified link works in browser