### PR TITLE
Remove SDK instantiation from pay method examples

### DIFF
--- a/docs/base-account/guides/accept-payments.mdx
+++ b/docs/base-account/guides/accept-payments.mdx
@@ -19,10 +19,7 @@ USDC on Base is a fully-backed digital dollar that settles in seconds and costs 
 ## Client-side (Browser SDK)
 
 ```ts Browser (SDK)
-import { createBaseAccountSDK, pay, getPaymentStatus } from '@base-org/account';
-
-// Initialise SDK (defaults are fine for most apps)
-const provider = createBaseAccountSDK().getProvider();
+import { pay, getPaymentStatus } from '@base-org/account';
 
 // Trigger a payment – user will see a popup from their wallet service
 const { id } = await pay({


### PR DESCRIPTION
**What changed? Why?**

Removed unnecessary SDK instantiation and provider references from the accept payments guide. The pay() and getPaymentStatus() methods can be imported and used directly without creating an SDK instance or provider.
