### PR TITLE
chore: add info on how to import sub accounts

### DIFF
--- a/docs/base-account/improve-ux/sub-accounts.mdx
+++ b/docs/base-account/improve-ux/sub-accounts.mdx
@@ -125,6 +125,36 @@ This is what the user will see when prompted to create a Sub Account:
   <img src="/images/base-account/SubAccountCreation.png" alt="Sub Account Creation Flow" style={{ width: '300px', height: 'auto' }} />
 </div>
 
+### Import an existing Sub Account
+
+If you already have a deployed Smart Contract Account, you can import it as a Sub Account using the provider RPC method:
+
+```tsx
+const subAccount = await provider.request({
+  method: 'wallet_addSubAccount',
+  params: [
+    {
+      account: {
+        type: 'deployed',
+        address: '0xYourSmartContractAccountAddress',
+        chainId: 8453 // the chain the account is deployed on
+      },
+    }
+  ],
+});
+
+console.log('Sub Account added:', subAccount.address);
+```
+
+<Note>
+
+After the Sub Account is imported, you will need to add the Base Account address as an owner of the Sub Account. This currently needs to be done manually
+by calling the addOwner function on the Smart Contract Account that was imported and setting the Base Account address as the owner.
+
+Additionally, only Coinbase Smart Wallet contracts are currently supported for importing as a Sub Account into your Base Account.
+</Note>
+
+
 
 ### Get Existing Sub Account
 

--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_addSubAccount.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_addSubAccount.mdx
@@ -32,6 +32,14 @@ Hex string of the public key.
 </ParamField>
 </Expandable>
 </ParamField>
+
+<ParamField body="address" type="string">
+The address of the deployed account to add as a sub account. (required for "deployed" type).
+</ParamField>
+
+<ParamField body="chainId" type="number">
+The chain ID that the account is deployed on. (required for "deployed" type).
+</ParamField>
 </Expandable>
 </ParamField>
 
@@ -56,7 +64,7 @@ Factory deployment data (optional).
 </ResponseField>
 
 <RequestExample>
-```json Request
+```json Create Request
 {
   "id": 1,
   "jsonrpc": "2.0",
@@ -68,6 +76,21 @@ Factory deployment data (optional).
         "type": "p256",
         "publicKey": "0x0123456789abcdef..."
       }]
+    }
+  }]
+}
+```
+
+```json Deployed Request
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "wallet_addSubAccount",
+  "params": [{
+    "account": {
+      "type": "deployed",
+      "address": "0x1234567890123456789012345678901234567890",
+      "chainId": 8453
     }
   }]
 }


### PR DESCRIPTION
**What changed? Why?**

Updated docs on how to import existing deployed Smart Contract wallets as sub accounts. Also updated the technical reference to include which params are required to do so.

**Notes to reviewers**

**How has it been tested?**


<img width="1560" height="936" alt="Screenshot 2025-07-22 at 10 21 15 PM" src="https://github.com/user-attachments/assets/7376e078-b85e-4acd-a483-d090e3eff5e6" />

