### PR TITLE
Remove incorrect api server for onchainkit api docs

### DIFF
--- a/docs/openapi/onchainkit.yaml
+++ b/docs/openapi/onchainkit.yaml
@@ -4,9 +4,6 @@ info:
   version: '1.0.0'
   description: API reference for OnchainKit functionality
 
-servers:
-  - url: https://api.base.org/v1
-    description: Base API server
 
 components:
   parameters:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "docs",
+  "name": "base-docs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
**What changed? Why?**
Incorrect server listed in the openAPI config for the onchainkit API. Removed it so that the AI bot and users don't get confused and think that api.base.org is an endpoint

**Notes to reviewers**

**How has it been tested?**
