### PR TITLE
Update header order to swap Base App with Onchainkit

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -328,6 +328,35 @@
         }
       },
       {
+        "tab": "Base App",
+        "groups": [
+          {
+            "group": "Introduction",
+            "pages": [
+              "base-app/introduction/getting-started",
+              "base-app/introduction/mini-apps",
+              "base-app/introduction/beta-faq"
+            ]
+          },
+          {
+            "group": "Build with MiniKit",
+            "pages": [
+              "base-app/build-with-minikit/overview",
+              "base-app/build-with-minikit/quickstart",
+              "base-app/build-with-minikit/existing-app-integration",
+              "base-app/build-with-minikit/debugging"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "base-app/guides/thinking-social",
+              "base-app/guides/chat-agents"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "OnchainKit",
         "groups": [
           {
@@ -605,35 +634,6 @@
             }
           ]
         }
-      },
-      {
-        "tab": "Base App",
-        "groups": [
-          {
-            "group": "Introduction",
-            "pages": [
-              "base-app/introduction/getting-started",
-              "base-app/introduction/mini-apps",
-              "base-app/introduction/beta-faq"
-            ]
-          },
-          {
-            "group": "Build with MiniKit",
-            "pages": [
-              "base-app/build-with-minikit/overview",
-              "base-app/build-with-minikit/quickstart",
-              "base-app/build-with-minikit/existing-app-integration",
-              "base-app/build-with-minikit/debugging"
-            ]
-          },
-          {
-            "group": "Guides",
-            "pages": [
-              "base-app/guides/thinking-social",
-              "base-app/guides/chat-agents"
-            ]
-          }
-        ]
       },
       {
         "tab": "Cookbook",


### PR DESCRIPTION
**What changed? Why?**

Swapping the OnchainKit header with the Base App header so the header order is cleaner. 

Base Chain -> Base Account -> Base App -> OnchainKit...

so that OnchainKit isn't between the headers with the "Base" prefix 