### PR TITLE
update import sub account docs to note that universal must be added a…

### DIFF
--- a/docs/base-account/improve-ux/sub-accounts.mdx
+++ b/docs/base-account/improve-ux/sub-accounts.mdx
@@ -148,7 +148,7 @@ console.log('Sub Account added:', subAccount.address);
 
 <Note>
 
-After the Sub Account is imported, you will need to add the Base Account address as an owner of the Sub Account. This currently needs to be done manually
+Before the Sub Account is imported, you will need to add the Base Account address as an owner of the Sub Account. This currently needs to be done manually
 by calling the [`addOwnerAddress`](https://github.com/coinbase/smart-wallet/blob/a8c6456f3a6d5d2dea08d6336b3be13395cacd42/src/MultiOwnable.sol#L101) or [`addOwnerPublicKey`](https://github.com/coinbase/smart-wallet/blob/a8c6456f3a6d5d2dea08d6336b3be13395cacd42/src/MultiOwnable.sol#L109) functions on the Smart Contract of the Sub Account that was imported and setting the Base Account address as the owner.
 
 Additionally, only Coinbase Smart Wallet contracts are currently supported for importing as a Sub Account into your Base Account.


### PR DESCRIPTION
…s owner beforehand

**What changed? Why?**

Per the ERC spec, the sub account MUST have the universal account added as an owner before calling `wallet_addSubAccount`

**Notes to reviewers**

**How has it been tested?**
