### PR TITLE
Fix basescan.org link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ next-env.d.ts
 *.py
 
 .mintlify-latest
+/.idea/

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -157,7 +157,7 @@
             },
             {
               "anchor": "Explorer",
-              "href": "https://basescan.com/",
+              "href": "https://basescan.org/",
               "icon": "magnifying-glass"
             },
             {


### PR DESCRIPTION
**What changed? Why?**
Was pointing to basescan.com instead of basescan.org.
