### PR TITLE
Docs/mini app callout

### DIFF
--- a/docs/base-app/build-with-minikit/debugging.mdx
+++ b/docs/base-app/build-with-minikit/debugging.mdx
@@ -110,12 +110,12 @@ your-domain.com/
 
 **Problem**: Your app has a manifest but still doesn't appear in catalogs.
 
-**Solution**: Your Mini App must be shared in a cast to be indexed.
+**Solution**: Your Mini App must be shared in a post to be indexed.
 
 **Steps to Index Your App**:
 
 1. Complete your manifest setup  
-2. Share your Mini App URL in a cast  
+2. Share your Mini App URL in a post 
 3. Indexing can take up to 10 minutes  
 4. Verify appearance in app catalogs
 
@@ -372,7 +372,7 @@ Before deploying your Mini App, verify these items work correctly:
 
 - [ ] Manifest file is accessible at `/.well-known/farcaster.json`  
 - [ ] App appears in embed when URL is shared  
-- [ ] App appears in search results (after casting)  
+- [ ] App appears in search results (after posting)  
 - [ ] All required manifest fields are present
 
 ## **Getting Additional Help**

--- a/docs/base-app/build-with-minikit/existing-app-integration.mdx
+++ b/docs/base-app/build-with-minikit/existing-app-integration.mdx
@@ -279,10 +279,15 @@ export async function GET() {
       ogTitle: process.env.NEXT_PUBLIC_APP_OG_TITLE,
       ogDescription: process.env.NEXT_PUBLIC_APP_OG_DESCRIPTION,
       ogImageUrl: process.env.NEXT_PUBLIC_APP_OG_IMAGE,
+  // use only while testing
+    "noindex": true
     }),
   });
 }
 ```
+<Warning>
+  While testing your Mini App please add noIndex:true to your manifest  - this is so the app is not indexed while in developement.
+</Warning>
 
 <Check>
 Test this endpoint by visiting `https://yourdomain.com/.well-known/farcaster.json` to ensure it returns valid JSON.

--- a/docs/base-app/build-with-minikit/quickstart.mdx
+++ b/docs/base-app/build-with-minikit/quickstart.mdx
@@ -210,6 +210,10 @@ Signature from manifest generation
 
 Now that the manifest is correctly set up, the Save Frame button in the template app should work. We'll explore that below.
 
+<Warning>
+  While testing your Mini App please add noIndex:true to your manifest  - this is so the app is not indexed while in developement.
+</Warning>
+
 ### useAddFrame
 
 The `useAddFrame` hook is used to add your mini app to the user's list of mini apps. It's implemented in your main page component and displays a button in the top right allowing the user to add the mini app to their list.

--- a/docs/base-app/introduction/getting-started.mdx
+++ b/docs/base-app/introduction/getting-started.mdx
@@ -136,11 +136,16 @@ Mini Apps require one configuration file located at `/.well-known/farcaster.json
       "https://yourapp.com/screenshot2.png"
     ],
     "primaryCategory": "games",
-    "tags": ["multiplayer", "strategy", "onchain"],
+    "tags": ["multiplayer", "strategy", "onchain"],,
+    // use only while testing
+    "noindex": true,
     "webhookUrl": "https://yourapp.com/api/webhook"
   }
 }
 ```
+<Warning>
+    While testing your Mini App, add "noindex": true to your manifest this prevents the app from being indexed during development.
+</Warning>
 
 ## Categories and Discovery
 

--- a/docs/base-app/introduction/mini-apps.mdx
+++ b/docs/base-app/introduction/mini-apps.mdx
@@ -250,9 +250,14 @@ Note: We **highly recommend** that you set this metadata as it will give your mi
     "ogTitle": "Example Mini App",
     "ogDescription": "Example Mini App description",
     "ogImageUrl": "https://example.com/og.png"
+    // use only while testing
+    "noindex": true
   }
 }
 ```
+<Warning>
+  While testing your Mini App, add "noindex": true to your manifest this prevents the app from being indexed during development.
+</Warning>
 
 ## Notifications
 


### PR DESCRIPTION
**What changed? Why?**
Added a warning call out for developers to please use noIndex while in development

added noIndex to manifest examples with code comment
