### PR TITLE
docs: add Mint Club to token launch platforms on Base

### DIFF
--- a/docs/cookbook/launch-tokens.mdx
+++ b/docs/cookbook/launch-tokens.mdx
@@ -85,6 +85,21 @@ Flaunch leverages Uniswap V4 to enable programmable revenue splits, automated bu
 
 [Get started with Flaunch →](https://flaunch.gg)
 
+### Mint Club
+**Best for:** Token families and community-driven assets
+
+Mint Club enables anyone to launch new tokens or NFTs backed by existing ERC-20 tokens. Each trade locks the parent token in a bonding curve pool, creating onchain, auto-managed liquidity that strengthens the parent token while supporting new community assets.
+
+**Key Features:**
+- Launch tokens or NFTs from any ERC-20 token
+- Automated liquidity with customizable bonding curves
+- Integrated trading interface with cross-chain swap
+- Built-in airdrop and lock-up tools
+- Simple trading for tokens and NFTs
+- Creator revenue sharing
+
+[Get started with Mint Club →](https://mint.club)
+
 ## Technical Implementation with Foundry
 
 For developers who want full control over their token implementation, here's how to create and deploy a custom ERC-20 token on Base using Foundry.


### PR DESCRIPTION
**What changed? Why?**  
Added a new section for **Mint Club** under "Token Launch Platforms on Base". Mint Club offers bonding curve–based token and NFT launches, expanding the range of tools available to users launching assets on Base. This helps surface more community-friendly, customizable launch options.

**Notes to reviewers**  
Only added the Mint Club block directly below the Flaunch section. No other content was changed. Formatting and structure follow existing platform entries for consistency.

**How has it been tested?**  
Visually reviewed the rendered markdown in local preview to confirm correct formatting, link rendering, and structural alignment with the rest of the document.

