### PR TITLE
Update Base Pay error handling and examples

### DIFF
--- a/docs/base-account/guides/accept-payments.mdx
+++ b/docs/base-account/guides/accept-payments.mdx
@@ -29,18 +29,23 @@ If you intend on using the BasePayButton, please follow the [Brand Guidelines](/
 import { pay, getPaymentStatus } from '@base-org/account';
 
 // Trigger a payment – user will see a popup from their wallet service
-const { id } = await pay({
-  amount: '1.00',           // USD amount (we quote USDC internally)
-  to:    '0xRecipient',     // your address
-  testnet: true            // set false for Mainnet
-});
-
-// Option 1: Poll until mined
-const { status } = await getPaymentStatus({ 
-  id,
-  testnet: true            // MUST match the testnet setting used in pay()
-});
-if (status === 'completed') console.log('🎉 payment settled');
+try {
+  const payment = await pay({
+    amount: '1.00',           // USD amount (USDC used internally)
+    to:    '0xRecipient',     // your address
+    testnet: true            // set false for Mainnet
+  });
+  
+  // Option 1: Poll until mined
+  const { status } = await getPaymentStatus({ 
+    id: payment.id,
+    testnet: true            // MUST match the testnet setting used in pay()
+  });
+  if (status === 'completed') console.log('🎉 payment settled');
+  
+} catch (error) {
+  console.error(`Payment failed: ${error.message}`);
+}
 ```
 
 <Note>
@@ -58,17 +63,39 @@ This is what the user will see when prompted to pay:
 Need an email, phone, or shipping address at checkout?  Pass a <code>payerInfo</code> object:
 
 ```ts
-await pay({
-  amount: '25.00',
-  to: '0xRecipient',
-  payerInfo: {
-    requests: [
-      { type: 'email' },
-      { type: 'phoneNumber', optional: true }
-    ],
-    callbackURL: 'https://your-api.com/validate' // Optional - for server-side validation
+try {
+  const payment = await pay({
+    amount: '25.00',
+    to: '0xRecipient',
+    payerInfo: {
+      requests: [
+        { type: 'email' },
+        { type: 'phoneNumber', optional: true },
+        { type: 'physicalAddress', optional: true }
+      ],
+      callbackURL: 'https://your-api.com/validate' // Optional - for server-side validation
+    }
+  });
+  
+  console.log(`Payment sent! Transaction ID: ${payment.id}`);
+  
+  // Log the collected user information
+  if (payment.payerInfoResponses) {
+    if (payment.payerInfoResponses.email) {
+      console.log(`Email: ${payment.payerInfoResponses.email}`);
+    }
+    if (payment.payerInfoResponses.phoneNumber) {
+      console.log(`Phone: ${payment.payerInfoResponses.phoneNumber.number}`);
+      console.log(`Country: ${payment.payerInfoResponses.phoneNumber.country}`);
+    }
+    if (payment.payerInfoResponses.physicalAddress) {
+      const address = payment.payerInfoResponses.physicalAddress;
+      console.log(`Shipping Address: ${address.name.firstName} ${address.name.familyName}, ${address.address1}, ${address.city}, ${address.state} ${address.postalCode}`);
+    }
   }
-});
+} catch (error) {
+  console.error(`Payment failed: ${error.message}`);
+}
 ```
 
 Supported request types:
@@ -78,7 +105,7 @@ Supported request types:
 | <code>email</code> | string |
 | <code>name</code> | &#123; firstName, familyName &#125; |
 | <code>phoneNumber</code> | &#123; number, country &#125; |
-| <code>physicalAddress</code> | full address object |
+| <code>physicalAddress</code> | [full address object](/base-account/reference/core/capabilities/datacallback#physical-address-object) |
 | <code>onchainAddress</code> | string |
 
 <Warning>Required by default — set <code>optional: true</code> to avoid aborting the payment if the user declines.</Warning>
@@ -116,10 +143,19 @@ import { BasePayButton } from '@base-org/account-ui/react';
 import { pay } from '@base-org/account';
 
 export function Checkout() {
+  const handlePayment = async () => {
+    try {
+      const payment = await pay({ amount: '5.00', to: '0xRecipient' });
+      console.log(`Payment sent! Transaction ID: ${payment.id}`);
+    } catch (error) {
+      console.error(`Payment failed: ${error.message}`);
+    }
+  };
+
   return (
     <BasePayButton
       colorScheme="light"
-      onClick={() => pay({ amount: '5.00', to: '0xRecipient' })}
+      onClick={handlePayment}
     />
   );
 }

--- a/docs/base-account/llms.txt
+++ b/docs/base-account/llms.txt
@@ -141,7 +141,7 @@ const provider = createBaseAccountSDK().getProvider();
 
 // Trigger a payment
 const { id } = await pay({
-  amount: '5.00',           // USD amount (we quote USDC internally)
+  amount: '5.00',           // USD amount (USDC used internally)
   to:    '0xRecipient',     // your address
   testnet: true            // set false for Mainnet
 });

--- a/docs/base-account/reference/base-pay/getPaymentStatus.mdx
+++ b/docs/base-account/reference/base-pay/getPaymentStatus.mdx
@@ -79,20 +79,26 @@ console.log("Payment status:", status.status);
 ```typescript Complete Payment Flow
 import { pay, getPaymentStatus } from '@base-org/account';
 
-// Send payment
-const payResult = await pay({
-  amount: "10.50",
-  to: "0x1234567890123456789012345678901234567890"
-});
+try {
+  // Send payment
+  const payment = await pay({
+    amount: "10.50",
+    to: "0x1234567890123456789012345678901234567890"
+  });
+} catch (error) {
+  console.error(`Payment failed: ${error.message}`);
+}
 
-if (payResult.success) {
+try {
   // Check status
   const status = await getPaymentStatus({
-    id: payResult.id,
+    id: payment.id,
     testnet: false
   });
   
   console.log("Status:", status.status);
+  catch (error) {
+  console.error(`Get status Failed: ${error.message}`);
 }
 ```
 </RequestExample>

--- a/docs/base-account/reference/base-pay/pay.mdx
+++ b/docs/base-account/reference/base-pay/pay.mdx
@@ -54,13 +54,9 @@ Optional callback URL for server-side validation.
 ## Returns
 
 <ResponseField name="result" type="PayResult">
-Payment result indicating success or failure.
+Payment result on success. The function throws an error on failure.
 
 <Expandable title="Payment Success properties">
-<ResponseField name="success" type="boolean">
-Always true for successful payments.
-</ResponseField>
-
 <ResponseField name="id" type="string">
 Transaction hash - use this to check payment status.
 </ResponseField>
@@ -77,79 +73,131 @@ Address that received the payment.
 Optional responses from information requests.
 </ResponseField>
 </Expandable>
-
-<Expandable title="Payment Error properties">
-<ResponseField name="success" type="boolean">
-Always false for failed payments.
 </ResponseField>
 
-<ResponseField name="error" type="string">
-Error message explaining what went wrong.
-</ResponseField>
+## Errors
 
-<ResponseField name="amount" type="string">
-Amount that was attempted.
-</ResponseField>
-
-<ResponseField name="to" type="string">
-Address that would have received the payment.
-</ResponseField>
-</Expandable>
-</ResponseField>
+The `pay` function throws an error when the payment fails. The error object contains a message explaining what went wrong.
 
 
 <RequestExample>
 ```typescript Basic Payment
 import { pay } from '@base-org/account';
 
-const result = await pay({
-  amount: "10.50",
-  to: "0x1234567890123456789012345678901234567890",
-  testnet: false
-});
+try {
+  const payment = await pay({
+    amount: "10.50",
+    to: "0x1234567890123456789012345678901234567890",
+    testnet: false
+  });
+  console.log(`Payment sent! Transaction ID: ${payment.id}`);
+} catch (error) {
+  console.error(`Payment failed: ${error.message}`);
+}
 ```
 
 ```typescript Payment with Data Collection
-const result = await pay({
-  amount: "25.00",
-  to: "0x1234567890123456789012345678901234567890",
-  payerInfo: {
-    requests: [
-      { type: 'email', optional: false },
-      { type: 'physicalAddress', optional: true }
-    ],
-    callbackURL: "https://your-api.com/validate"
+try {
+  const payment = await pay({
+    amount: "25.00",
+    to: "0x1234567890123456789012345678901234567890",
+    payerInfo: {
+      requests: [
+        { type: 'email', optional: false },
+        { type: 'phoneNumber', optional: true },
+        { type: 'physicalAddress', optional: true }
+      ],
+      callbackURL: "https://your-api.com/validate"
+    }
+  });
+  
+  console.log(`Payment sent! Transaction ID: ${payment.id}`);
+  
+  // Access collected user information
+  if (payment.payerInfoResponses) {
+    console.log('Email:', payment.payerInfoResponses.email);
+    
+    if (payment.payerInfoResponses.phoneNumber) {
+      console.log('Phone:', payment.payerInfoResponses.phoneNumber.number);
+      console.log('Country:', payment.payerInfoResponses.phoneNumber.country);
+    }
+    
+    if (payment.payerInfoResponses.physicalAddress) {
+      const address = payment.payerInfoResponses.physicalAddress;
+      console.log('Address:', address.address1);
+      console.log('City:', address.city);
+      console.log('State:', address.state);
+      console.log('Postal Code:', address.postalCode);
+      console.log('Recipient Name:', `${address.name.firstName} ${address.name.familyName}`);
+    }
   }
-});
+} catch (error) {
+  console.error(`Payment failed: ${error.message}`);
+}
 ```
 </RequestExample>
 
 <ResponseExample>
-```typescript Success Response
+```typescript Basic Success Response
 {
-  success: true,
   id: "0xabcd1234...",
   amount: "10.50",
+  to: "0x1234567890123456789012345678901234567890"
+}
+```
+
+```typescript Success Response with Data Collection
+{
+  id: "0xabcd1234...",
+  amount: "25.00",
   to: "0x1234567890123456789012345678901234567890",
   payerInfoResponses: {
-    email: "user@example.com"
+    email: "user@example.com",
+    phoneNumber: {
+      number: "+1234567890",
+      country: "US"
+    },
+    physicalAddress: {
+      address1: "123 Main St",
+      city: "San Francisco",
+      state: "CA",
+      postalCode: "94105",
+      country: "US",
+      name: {
+        firstName: "John",
+        familyName: "Doe"
+      }
+    }
   }
 }
 ```
 
-```typescript Error Response
+```typescript Error (thrown)
 {
-  success: false,
-  error: "Insufficient balance",
-  amount: "10.50",
-  to: "0x1234567890123456789012345678901234567890"
+  "code": 4001,
+  "message": "Request rejected",
+  "stack": "Error: Request rejected\n    at getEthProviderError..."
 }
 ```
 </ResponseExample>
 
 ## Error Handling
 
-Always wrap calls to `pay` in a try-catch block to handle these errors gracefully.
+The `pay` function throws errors instead of returning a result. Always wrap calls to `pay` in a try-catch block to handle errors gracefully:
+
+```typescript
+try {
+  const payment = await pay({
+    amount: "10.00",
+    to: "0xRecipient"
+  });
+  // Payment succeeded, use payment.id for tracking
+  console.log(`Payment sent! Transaction ID: ${payment.id}`);
+} catch (error) {
+  // Payment failed
+  console.error(`Payment failed: ${error.message}`);
+}
+```
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 

--- a/docs/base-account/reference/core/capabilities/datacallback.mdx
+++ b/docs/base-account/reference/core/capabilities/datacallback.mdx
@@ -51,6 +51,10 @@ type DataCallbackCapability = {
   state: string;
   postalCode: string;
   country: string;
+  name: {
+    firstName: string;
+    familyName: string;
+  };
 }
 ```
 
@@ -124,7 +128,7 @@ Your callback API will receive a POST request with the following structure:
             state: string;
             postalCode: string;
             countryCode: string;
-            name?: {
+            name: {
               firstName: string;
               familyName: string;
           };
@@ -185,6 +189,10 @@ Return validation errors to prompt the user to correct their information:
       state?: string;
       postalCode?: string;
       countryCode?: string;
+      name?: {
+        firstName?: string;
+        familyName?: string;
+      };
     };
     name?: {
       firstName?: string;


### PR DESCRIPTION
**What changed? Why?**

Updated Base Pay documentation to improve error handling and provide clearer examples:

- Modified pay() function documentation to reflect that it now throws errors instead of returning a success/error object
- Added try-catch blocks to all code examples
- Added more detail to examples showing how to access collected user information (email, phone, address)
- Updated getPaymentStatus() examples to match the updated error handling pattern


Also updated dataCallbacks that looked off to me
**Notes to reviewers**

These changes align the documentation with the current Base Pay API behavior where the pay() function throws errors on failure rather than returning an object with a success property. All examples now demonstrate proper error handling with try-catch blocks.
