### PR TITLE
Update prompt-library.mdx

### DIFF
--- a/docs/snippets/prompt-library.mdx
+++ b/docs/snippets/prompt-library.mdx
@@ -79,7 +79,7 @@ I'm working on a onchainkit project using [frameworks/libraries]. I need your he
 3. Constraints: [mention any technical limitations]
 4. Expected outcome: [describe what success looks like]
 
-Here's the relevant documentation @https://docs.base.org/onchainkit/llms.txt
+Here's the relevant documentation @https://docs.base.org/onchainkit/getting-started
 ```
 
 **Ask for Iterations**
@@ -109,7 +109,7 @@ Example LLMs.txt Usage:
 ```
 I'm implementing a swap component with OnchainKit. Here's the relevant LLMs.txt:
 
-@https://docs.base.org/onchainkit/llms.txt
+@https://docs.base.org/onchainkit/getting-started
 
 Based on this documentation, please show me how to implement a wallet connector that:
 1. Swap from base usdc to base th


### PR DESCRIPTION
Fix broken links

**What changed? Why?**

Fixed broken links

**Notes to reviewers**

@https://docs.base.org/onchainkit/llms.txt does not lead anywhere

**How has it been tested?**

https://docs.base.org/onchainkit/getting-started link is working
