### PR TITLE
Update spend permissions docs

### DIFF
--- a/docs/base-account/improve-ux/spend-permissions.mdx
+++ b/docs/base-account/improve-ux/spend-permissions.mdx
@@ -48,15 +48,13 @@ console.log("Spend Permission:", permission);
 
 Using a permission is 2 steps:
 
-1. **Prepare the calls** — Call `prepareSpendCallData` with the permission and an `amount`.
+1. **Prepare the calls** — Call `prepareSpendCallData` with the permission and the requested `amount`.
 2. **Submit the calls** — Submit the calls using your app's spender account.
 
 `prepareSpendCallData` returns an array of calls needed to spend the tokens:
 
 - `approveWithSignature` — When the permission is not yet registered onchain, this call would be prepended to the `spend` call.
-- `spend` — The call to spend the tokens.
-
-This array should have 1 or 2 calls, submit them in order using your app's spender account.
+- `spend` — The call to spend the tokens from the user's Base Account.
 
 ```tsx
 import { prepareSpendCallData } from "@base-org/account/spend-permission";
@@ -97,6 +95,15 @@ await Promise.all(
   )
 );
 ```
+
+<Note>
+**About the `spendCalls` array**
+
+This array has 2 calls when submitting the permission onchain for *the first time*.
+When the permission is already registered onchain, this array has only 1 call (the `spend` call).
+
+For most use cases, you don't need to worry about this.
+</Note>
 
 ### Revoke a Spend Permission
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -229,6 +229,12 @@
                   "base-account/reference/base-pay/pay",
                   "base-account/reference/base-pay/getPaymentStatus",
                   "base-account/reference/core/getProvider",
+                  "base-account/reference/spend-permission-utilities/requestSpendPermission",
+                  "base-account/reference/spend-permission-utilities/prepareSpendCallData",
+                  "base-account/reference/spend-permission-utilities/fetchPermissions",
+                  "base-account/reference/spend-permission-utilities/getPermissionStatus",
+                  "base-account/reference/spend-permission-utilities/requestRevoke",
+                  "base-account/reference/spend-permission-utilities/prepareRevokeCallData",
                   "base-account/reference/core/generateKeyPair",
                   "base-account/reference/core/getKeypair",
                   "base-account/reference/core/getCryptoKeyAccount"
@@ -294,17 +300,6 @@
                       "base-account/reference/core/capabilities/auxiliaryFunds"
                     ]
                   }
-                ]
-              },
-              {
-                "group": "Spend Permission Utilities",
-                "pages": [
-                  "base-account/reference/spend-permission-utilities/requestSpendPermission",
-                  "base-account/reference/spend-permission-utilities/prepareSpendCallData",
-                  "base-account/reference/spend-permission-utilities/fetchPermissions",
-                  "base-account/reference/spend-permission-utilities/getPermissionStatus",
-                  "base-account/reference/spend-permission-utilities/requestRevoke",
-                  "base-account/reference/spend-permission-utilities/prepareRevokeCallData"
                 ]
               },
               {


### PR DESCRIPTION
**What changed? Why?**

- Adding callouts to explain details about `prepareSpendCalls`
- Restructuring the reference section