### PR TITLE
Instructions on configuring Base login with Privy

### DIFF
--- a/docs/base-account/framework-integrations/privy/setup.mdx
+++ b/docs/base-account/framework-integrations/privy/setup.mdx
@@ -75,11 +75,10 @@ const privyConfig = {
     theme: 'light' as const,
     accentColor: '#0052FF', // Base blue
     logo: 'https://your-logo-url.com/logo.png',
-  },
-  externalWallets: {
-    baseAccount: {
-      connectionOptions: 'all' as const,
-    },
+    walletList: [
+      'base_account', 
+      'coinbase_wallet', // We recommend supporting coinbase_wallet for any users still using the legacy EOA
+    ],
   },
   supportedChains: [base],
 }
@@ -108,6 +107,26 @@ export default function App({ children }: { children: React.ReactNode }) {
     </PrivyProvider>
   )
 }
+```
+
+To have Sign in with Base as a top level sign in option in the login modal, modify your `privyConfig` to include `base_account` in the `loginMethodsAndOrder` field.
+
+```tsx
+const privyConfig = {
+  embeddedWallets: {
+    createOnLogin: 'users-without-wallets' as const,
+    requireUserPasswordOnCreate: false,
+  },
+  loginMethodsAndOrder: {
+    primary: ['base_account','email', 'wallet'],
+  },
+  appearance: {
+    theme: 'light' as const,
+    accentColor: '#0052FF' as const, // Base blue
+    walletList: ['base_account', 'coinbase_wallet'],
+  },
+  supportedChains: [base],
+};
 ```
 
 ### 3. Create Authentication Hook

--- a/docs/base-account/framework-integrations/privy/setup.mdx
+++ b/docs/base-account/framework-integrations/privy/setup.mdx
@@ -77,7 +77,7 @@ const privyConfig = {
     logo: 'https://your-logo-url.com/logo.png',
     walletList: [
       'base_account', 
-      'coinbase_wallet', // We recommend supporting coinbase_wallet for any users still using the legacy EOA
+      'coinbase_wallet', // It is recommended to support coinbase_wallet for any users still using the legacy EOA
     ],
   },
   supportedChains: [base],


### PR DESCRIPTION
**What changed? Why?**

Update Privy integration guide for Base Account to show how to place Base as a top level sign in option. Also Privy now uses a walletList to manage which wallets are displayed under the wallet sign in options. This may have changed at some point, so I updated the current guide to reflect that

https://docs.privy.io/wallets/connectors/setup/configuring-external-connector-wallets

example top level
<img width="393" height="266" alt="Screenshot 2025-08-11 at 10 49 44 PM" src="https://github.com/user-attachments/assets/7ec9a3fc-da85-4877-8322-17c92f873639" />


example embedded in wallet login
<img width="382" height="494" alt="Screenshot 2025-08-11 at 10 39 53 PM" src="https://github.com/user-attachments/assets/9255414b-6f9d-4787-98fe-06c87b26c1e0" />


**Notes to reviewers**

**How has it been tested?**
Ran locally