### PR TITLE
fix: Update broken miniapps links and add redirect rules

### DIFF
--- a/docs/base-account/guides/sub-accounts/add-sub-accounts-to-onchainkit.mdx
+++ b/docs/base-account/guides/sub-accounts/add-sub-accounts-to-onchainkit.mdx
@@ -6,7 +6,7 @@ import { GithubRepoCard } from "/snippets/GithubRepoCard.mdx"
 
 
 
-This guide will show you how to add Sub Accounts to your existing [OnchainKit](/onchainkit/getting-started) or [MiniKit](/base-app/build-with-minikit/quickstart) project.
+This guide will show you how to add Sub Accounts to your existing [OnchainKit](/onchainkit/getting-started) or [MiniKit](/base-app/miniapps/quickstart) project.
 
 Sub Accounts allow you to create a seamless user experience by skipping transaction confirmations,
 you can read more about it in the [Sub Accounts Intro Page](/smart-wallet/guides/sub-accounts).
@@ -14,7 +14,7 @@ you can read more about it in the [Sub Accounts Intro Page](/smart-wallet/guides
 Before you start, make sure you have checked the following guides:
 
 - [OnchainKit Quickstart](/onchainkit/getting-started)
-- [MiniKit Quickstart](/base-app/build-with-minikit/quickstart)
+- [MiniKit Quickstart](/base-app/miniapps/quickstart)
 - [OnchainKit Custom Providers](/onchainkit/config/supplemental-providers)
 - [Sub Accounts Intro Page](/smart-wallet/guides/sub-accounts)
 
@@ -248,7 +248,7 @@ For OnchainKit, use `OnchainKitProvider` instead of `MiniKitProvider` as it's de
 After installing the dependencies as described [above](#override-the-default-coinbase-wallet-sdk-version),
 make sure your environment variables are up to date as per
 the [OnchainKit Quickstart](/onchainkit/getting-started)or
-[MiniKit Quickstart](/base-app/build-with-minikit/quickstart).
+[MiniKit Quickstart](/base-app/miniapps/quickstart).
 
 Then, you can run the app with the following command:
 

--- a/docs/base-app/guides/search-and-discovery.mdx
+++ b/docs/base-app/guides/search-and-discovery.mdx
@@ -80,7 +80,7 @@ To remove your Mini App from search results:
 - **Invalidate manifest:** Update your manifest to make it invalid (removes from all discovery).
 
 <Warning>
-If your Mini App does not show in search please follow the debugging guide [here](/base-app/build-with-minikit/debugging#1-app-discovery--indexing-issues)
+If your Mini App does not show in search please follow the debugging guide [here](/base-app/miniapps/debugging#1-app-discovery--indexing-issues)
 </Warning>
 
 ## Discovery
@@ -115,7 +115,7 @@ This surface functions like the iPhone homescreen for onchain applications. User
 - Access through recent usage if they've interacted with it recently
 
 <Tip>
-You can prompt users to save your Mini App using the [useAddFrame hook](/base-app/build-with-minikit/overview#useaddframe). Consider waiting until users experience value - after completing their first action or reaching a milestone - for better conversion rates.
+You can prompt users to save your Mini App using the [useAddFrame hook](/base-app/miniapps/overview#useaddframe). Consider waiting until users experience value - after completing their first action or reaching a milestone - for better conversion rates.
 </Tip>
 
 **App Categories** - Browsable directory organized by interest
@@ -148,7 +148,7 @@ Choose your primaryCategory carefully as it determines where your app appears in
 - Use dynamic embed generation for personalized content
 
 <Warning>
-If your Mini App does not show as an embed please follow the debugging guide [here](/base-app/build-with-minikit/debugging#3-embed-rendering-issues)
+If your Mini App does not show as an embed please follow the debugging guide [here](/base-app/miniapps/debugging#3-embed-rendering-issues)
 </Warning>
 
 **Build for Discovery:**
@@ -167,7 +167,7 @@ If your Mini App does not show as an embed please follow the debugging guide [he
 
 Continue building your Mini App with these resources:
 
-- [MiniKit Documentation](/base-app/build-with-minikit/overview): Complete MiniKit integration guide
+- [MiniKit Documentation](/base-app/miniapps/overview): Complete MiniKit integration guide
 - [Thinking Social](/base-app/guides/thinking-social): Social mechanics and sharing best practices
 
 

--- a/docs/base-app/introduction/getting-started.mdx
+++ b/docs/base-app/introduction/getting-started.mdx
@@ -287,7 +287,7 @@ View working implementation examples
 <Card
   title='MiniKit'
   icon='book'
-  href='https://docs.base.org/base-app/build-with-minikit/overview'
+  href='https://docs.base.org/base-app/miniapps/overview'
 >
   MiniKit documentation and overview
 </Card>
@@ -303,7 +303,7 @@ View working implementation examples
 <Card
   title='Debug Guide'
   icon='alert-triangle'
-  href='https://docs.base.org/base-app/build-with-minikit/debugging'
+  href='https://docs.base.org/base-app/miniapps/debugging'
 >
   Debugging MiniKit and Mini Apps
 </Card>

--- a/docs/base-app/introduction/mini-apps.mdx
+++ b/docs/base-app/introduction/mini-apps.mdx
@@ -10,11 +10,11 @@ We're so excited that mini apps are supported in Base App! The purpose of this g
 
 For reference, MiniKit is easiest way to build mini apps on Base, allowing developers to easily build mini apps without needing to know the details of the SDK implementation. It integrates seamlessly with OnchainKit components and provides Base App-specific hooks.
 
-<Card title="Quick Start with MiniKit" icon="rocket" href="/base-app/build-with-minikit/quickstart">
+<Card title="Quick Start with MiniKit" icon="rocket" href="/base-app/miniapps/quickstart">
 If you use MiniKit and/or follow the MiniKit quickstart guide, your mini app will work out of the box in Base App!
 </Card>
 
-<Card title="Debugging Guide" icon="bug" href="/base-app/build-with-minikit/debugging">
+<Card title="Debugging Guide" icon="bug" href="/base-app/miniapps/debugging">
 If you're already using MiniKit and experiencing issues, you can refer to our debugging guide
 </Card>
 

--- a/docs/base-app/introduction/why-mini-apps.mdx
+++ b/docs/base-app/introduction/why-mini-apps.mdx
@@ -8,7 +8,7 @@ description: "Discover how Mini Apps eliminate  friction and leverage social dis
 The next evolution of digital experiences extends beyond app stores into social feeds and direct messages. Mini Apps are lightweight, social-native apps that launch instantly when you tap them: no downloads, no friction, just immediate engagement. While the Base App provides the discoverability through social distribution and featured listings, Mini Apps deliver the frictionless experience that makes instant trial and viral sharing possible.
 
 <Note>
-Existing web applications can be converted into Mini Apps. Learn how to [integrate your existing app](/base-app/build-with-minikit/existing-app-integration) with our helpful guide.
+Existing web applications can be converted into Mini Apps. Learn how to [integrate your existing app](/base-app/miniapps/existing-app-integration) with our helpful guide.
 </Note>
 
 ## Beyond the App Store Model
@@ -146,7 +146,7 @@ The development path is streamlined and permissionless:
 
 <Steps>
 <Step title="Build your Mini App">
-  Use [MiniKit](/base-app/build-with-minikit/quickstart) or the [Farcaster SDK](https://miniapps.farcaster.xyz/docs/getting-started) to create your application.
+  Use [MiniKit](/base-app/miniapps/quickstart) or the [Farcaster SDK](https://miniapps.farcaster.xyz/docs/getting-started) to create your application.
 </Step>
 
 <Step title="Deploy directly">
@@ -173,11 +173,11 @@ The development path is streamlined and permissionless:
 Mini Apps represent a fundamental shift toward social-native digital experiences. The advantage goes to builders who understand that in a social-first world, distribution and engagement are built into the platform itself.
 
 <CardGroup cols={2}>
-<Card title="Quick Start Guide" icon="rocket" href="/base-app/build-with-minikit/quickstart">
+<Card title="Quick Start Guide" icon="rocket" href="/base-app/miniapps/quickstart">
   Get started with MiniKit and build your first Mini App in minutes.
 </Card>
 
-<Card title="Existing App Integration" icon="code" href="/base-app/build-with-minikit/existing-app-integration">
+<Card title="Existing App Integration" icon="code" href="/base-app/miniapps/existing-app-integration">
   Already have a web app? Turn it into a Mini App with our integration guide.
 </Card>
 </CardGroup>

--- a/docs/base-app/miniapps/existing-app-integration.mdx
+++ b/docs/base-app/miniapps/existing-app-integration.mdx
@@ -7,7 +7,7 @@ This guide helps developers integrate MiniKit into an existing Next.js project. 
 
 <Warning>
   This guide assumes you want to add MiniKit to an existing application. For new
-  projects, use the [MiniKit CLI](/base-app/build-with-minikit/quickstart) for
+  projects, use the [MiniKit CLI](/base-app/miniapps/quickstart) for
   automatic setup.
 </Warning>
 
@@ -399,7 +399,7 @@ Once validation passes:
 </Tab>
 </Tabs>
 
-<Card title="Need Help Debugging?" icon="bug" href="/base-app/build-with-minikit/debugging">
+<Card title="Need Help Debugging?" icon="bug" href="/base-app/miniapps/debugging">
 If you encounter issues, check our comprehensive debugging guide for common problems and solutions.
 </Card>
 </Step>
@@ -470,7 +470,7 @@ Handle Farcaster authentication and sign-in flows
 <Card
   title='Explore All Hooks'
   icon='code'
-  href='/base-app/build-with-minikit/overview#hooks'
+  href='/base-app/miniapps/overview#hooks'
 >
   Learn about all available MiniKit hooks, their parameters, and usage examples
 </Card>

--- a/docs/base-app/miniapps/overview.mdx
+++ b/docs/base-app/miniapps/overview.mdx
@@ -53,7 +53,7 @@ npx create-onchain --mini
 <Card
   title='Quick Start Guide'
   icon='play'
-  href='/base-app/build-with-minikit/quickstart'
+  href='/base-app/miniapps/quickstart'
 >
   You can also follow our comprehensive Quick Start guide for detailed setup
   instructions

--- a/docs/base-app/miniapps/quickstart.mdx
+++ b/docs/base-app/miniapps/quickstart.mdx
@@ -46,7 +46,7 @@ npm run dev
 ```
 
 <Tip>
-These docs are LLM-friendly—reference [llms.txt](https://docs.base.org/base-app/build-with-minikit/llms.txt) in your code editor to streamline builds and prompt smarter.
+These docs are LLM-friendly—reference [llms.txt](https://docs.base.org/base-app/miniapps/llms.txt) in your code editor to streamline builds and prompt smarter.
 </Tip>
 </Step>
 </Steps>
@@ -405,11 +405,11 @@ const handleSendNotification = async () => {
 Congratulations, you've created your first mini app, set up the manifest, added key MiniKit hooks, and sent your users a notification! We're excited to see what you build with MiniKit!
 
 <CardGroup cols={2}>
-<Card title="Explore MiniKit Overview" icon="book-open" href="/base-app/build-with-minikit/overview">
+<Card title="Explore MiniKit Overview" icon="book-open" href="/base-app/miniapps/overview">
 Learn more about MiniKit features and capabilities
 </Card>
 
-<Card title="Social Patterns Guide" icon="users" href="/base-app/build-with-minikit/thinking-social">
+<Card title="Social Patterns Guide" icon="users" href="/base-app/miniapps/thinking-social">
 Design patterns for social mini apps
 </Card>
 </CardGroup>

--- a/docs/base-chain/tools/base-products.mdx
+++ b/docs/base-chain/tools/base-products.mdx
@@ -7,7 +7,7 @@ title: "Base Products"
     Ready-to-use, full-stack components to make building onchain faster and
     easier.
   </Card>
-  <Card title="MiniKit" icon="square-2" href="https://docs.base.org/base-app/build-with-minikit/overview">
+  <Card title="MiniKit" icon="square-2" href="https://docs.base.org/base-app/miniapps/overview">
     Build mini apps to increase your distribution and find traction.
   </Card>
   <Card title="AgentKit" icon="square-3" href="https://docs.cdp.coinbase.com/agent-kit/welcome">

--- a/docs/cookbook/onchain-social.mdx
+++ b/docs/cookbook/onchain-social.mdx
@@ -302,7 +302,7 @@ Mini Apps offer developers direct access to social distribution - you're buildin
 
 Transform your existing Next.js application into a Mini App without major restructuring. The process is straightforward and doesn't require rebuilding your entire application.
 
-<Card title="Complete Integration Guide" icon="book" href="/base-app/build-with-minikit/existing-app-integration">
+<Card title="Complete Integration Guide" icon="book" href="/base-app/miniapps/existing-app-integration">
 Follow our comprehensive guide for integrating MiniKit into existing applications with step-by-step instructions, environment setup, and testing procedures.
 </Card>
 
@@ -313,7 +313,7 @@ Follow our comprehensive guide for integrating MiniKit into existing application
 - Configure environment variables and deployment
 
 <Note>
-For new projects, use the [MiniKit CLI](/base-app/build-with-minikit/quickstart) for automatic setup with all features pre-configured.
+For new projects, use the [MiniKit CLI](/base-app/miniapps/quickstart) for automatic setup with all features pre-configured.
 </Note>
 
 ## Advanced MiniKit Features
@@ -321,16 +321,16 @@ For new projects, use the [MiniKit CLI](/base-app/build-with-minikit/quickstart)
 Once you have your basic Mini App running, explore advanced capabilities:
 
 <CardGroup cols={2}>
-  <Card title="Notifications & Engagement" icon="bell" href="/base-app/build-with-minikit/overview#usenotification">
+  <Card title="Notifications & Engagement" icon="bell" href="/base-app/miniapps/overview#usenotification">
     Send push notifications to users who have added your Mini App
   </Card>
-  <Card title="Authentication Patterns" icon="key" href="/base-app/build-with-minikit/overview#useauthenticate">
+  <Card title="Authentication Patterns" icon="key" href="/base-app/miniapps/overview#useauthenticate">
     Implement Farcaster authentication for secure, persistent sessions
   </Card>
-  <Card title="Profile Integration" icon="user" href="/base-app/build-with-minikit/overview#useviewprofile">
+  <Card title="Profile Integration" icon="user" href="/base-app/miniapps/overview#useviewprofile">
     Navigate users to Farcaster profiles and build social connections
   </Card>
-  <Card title="Frame Management" icon="plus" href="/base-app/build-with-minikit/overview#useaddframe">
+  <Card title="Frame Management" icon="plus" href="/base-app/miniapps/overview#useaddframe">
     Allow users to save your Mini App for easy access
   </Card>
 </CardGroup>
@@ -343,10 +343,10 @@ Building successful Mini Apps requires understanding social-specific patterns an
   <Card title="Social Design Patterns" icon="users" href="/base-app/guides/thinking-social">
     Design patterns and best practices for building social Mini Apps
   </Card>
-  <Card title="Debugging Guide" icon="bug" href="/base-app/build-with-minikit/debugging">
+  <Card title="Debugging Guide" icon="bug" href="/base-app/miniapps/debugging">
     Common issues and solutions when developing Mini Apps
   </Card>
-  <Card title="Performance Optimization" icon="bolt" href="/base-app/build-with-minikit/overview#performance">
+  <Card title="Performance Optimization" icon="bolt" href="/base-app/miniapps/overview#performance">
     Optimize loading times and user experience for mobile social environments
   </Card>
   <Card title="Coinbase Wallet Integration" icon="wallet" href="/base-app/introduction/mini-apps">
@@ -357,10 +357,10 @@ Building successful Mini Apps requires understanding social-specific patterns an
 ## Resources and Community
 
 <CardGroup cols={2}>
-  <Card title="MiniKit Documentation" icon="book" href="/base-app/build-with-minikit/overview">
+  <Card title="MiniKit Documentation" icon="book" href="/base-app/miniapps/overview">
     Complete documentation for building Mini Apps with MiniKit
   </Card>
-  <Card title="MiniKit Quickstart" icon="rocket" href="/base-app/build-with-minikit/quickstart">
+  <Card title="MiniKit Quickstart" icon="rocket" href="/base-app/miniapps/quickstart">
     Get started with MiniKit in under 10 minutes
   </Card>
   <Card title="Farcaster Protocol" icon="network" href="https://docs.farcaster.xyz/">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1150,6 +1150,10 @@
   },
   "redirects": [
     {
+      "source": "/test-redirect",
+      "destination": "/base-app/miniapps/quickstart"
+    },
+    {
       "source": "/privacy-policy-2025",
       "destination": "/privacy-policy"
     },
@@ -1171,19 +1175,19 @@
     },
     {
       "source": "/builderkits/minikit/debugging",
-      "destination": "/base-app/build-with-minikit/debugging"
+      "destination": "/base-app/miniapps/debugging"
     },
     {
       "source": "/builderkits/minikit/existing-app-integration",
-      "destination": "/base-app/build-with-minikit/existing-app-integration"
+      "destination": "/base-app/miniapps/existing-app-integration"
     },
     {
       "source": "/builderkits/minikit/overview",
-      "destination": "/base-app/build-with-minikit/overview"
+      "destination": "/base-app/miniapps/overview"
     },
     {
       "source": "/builderkits/minikit/quickstart",
-      "destination": "/base-app/build-with-minikit/quickstart"
+      "destination": "/base-app/miniapps/quickstart"
     },
     {
       "source": "/builderkits/minikit/thinking-social",
@@ -1511,7 +1515,7 @@
     },
     {
       "source": "/cookbook/growth/deploy-to-vercel",
-      "destination": "/base-app/build-with-minikit/quickstart#deploying-to-vercel"
+      "destination": "/base-app/miniapps/quickstart#deploying-to-vercel"
     },
     {
       "source": "/cookbook/growth/email-campaigns",
@@ -1623,7 +1627,7 @@
     },
     {
       "source": "/cookbook/use-case-guides/deploy-to-vercel",
-      "destination": "/base-app/build-with-minikit/quickstart#deploying-to-vercel"
+      "destination": "/base-app/miniapps/quickstart#deploying-to-vercel"
     },
     {
       "source": "/cookbook/use-case-guides/finance/access-real-time-asset-data-pyth-price-feeds",
@@ -2240,6 +2244,26 @@
     {
       "source": "/wallet-app/:slug*",
       "destination": "/base-app/:slug*"
+    },
+    {
+      "source": "/base-app/build-with-minikit/overview",
+      "destination": "/base-app/miniapps/overview"
+    },
+    {
+      "source": "/base-app/build-with-minikit/quickstart",
+      "destination": "/base-app/miniapps/quickstart"
+    },
+    {
+      "source": "/base-app/build-with-minikit/existing-app-integration",
+      "destination": "/base-app/miniapps/existing-app-integration"
+    },
+    {
+      "source": "/base-app/build-with-minikit/thinking-social",
+      "destination": "/base-app/miniapps/thinking-social"
+    },
+    {
+      "source": "/base-app/build-with-minikit/debugging",
+      "destination": "/base-app/miniapps/debugging"
     }
   ],
   "integrations": {

--- a/docs/get-started/base.mdx
+++ b/docs/get-started/base.mdx
@@ -81,7 +81,7 @@ Explore [all products](/get-started/products) and [use cases](/get-started/use-c
   <Card
     title="Build a Mini App"
     icon="bullhorn"
-    href="/base-app/build-with-minikit/quickstart"
+    href="/base-app/miniapps/quickstart"
   >
     Mini Apps run directly inside the social feed: Make your existing app a Mini
     App or build a new one.

--- a/docs/get-started/products.mdx
+++ b/docs/get-started/products.mdx
@@ -7,7 +7,7 @@ keywords: ['onchainkit', 'minikit', 'agentkit', 'base account', 'appchains', 'pa
   <Card title="OnchainKit" icon="puzzle-piece" href="/onchainkit/getting-started">
     All-in-one toolkit and ready-to-use, full-stack components.
   </Card>
-  <Card title="MiniKit" icon="bullhorn" href="/base-app/build-with-minikit/quickstart">
+  <Card title="MiniKit" icon="bullhorn" href="/base-app/miniapps/quickstart">
     Feature your mini app on decentralized social platforms with a few lines of code.
   </Card>
   <Card title="Smart Wallet" icon="fingerprint" href="/smart-wallet/quickstart">


### PR DESCRIPTION
## Summary
- Fixed 35 broken internal links across 11 documentation files caused by path reorganization from `/base-app/build-with-minikit/` to `/base-app/miniapps/`
- Added redirect rules to preserve SEO and handle legacy URLs

## Changes Made
- Updated internal links in documentation files to use new miniapps paths
- Added redirect configuration in docs.json for legacy URL handling

## Impact
- Fixes broken user experience from commit 7abc5c5
- Preserves SEO value of existing links
- Maintains backward compatibility for bookmarked URLs

## Known Issue
Redirect rules don't work in local development (Mintlify configuration issue). New URLs work correctly, but legacy URL testing requires production environment.