### PR TITLE
Update datacallback response structure

### DIFF
--- a/docs/base-account/examples/onchain-vibes-store-with-profiles.mdx
+++ b/docs/base-account/examples/onchain-vibes-store-with-profiles.mdx
@@ -121,11 +121,8 @@ export async function POST(request: NextRequest) {
     if (Object.keys(errors).length > 0) {
       return NextResponse.json({ errors });
     }
-    return NextResponse.json({
-      calls: requestData.calls,
-      chainId: requestData.chainId,
-      capabilities: requestData.capabilities
-    });
+    // Return requestData wrapped in request object
+    return NextResponse.json({ request: requestData });
   } catch (error) {
     return NextResponse.json({ errors: { server: "Server error validating data" } });
   }
@@ -133,7 +130,7 @@ export async function POST(request: NextRequest) {
 ```
 
 - The API receives the user's data, validates it, and returns errors if needed.
-- If validation passes, it must return the original `calls`, `chainId`, and `capabilities`.
+- If validation passes, it must return the request data wrapped in a `request` object.
 - If errors are returned, the wallet prompts the user to correct their info.
 
 ---

--- a/docs/base-account/reference/core/capabilities/datacallback.mdx
+++ b/docs/base-account/reference/core/capabilities/datacallback.mdx
@@ -111,7 +111,6 @@ Your callback API will receive a POST request with the following structure:
     data: string;
   }[];
   chainId: string;
-  version: string;
   capabilities: {
     dataCallback: {
       requestedInfo: {
@@ -151,22 +150,23 @@ Your callback API must respond with one of two formats:
 
 ### 1. Success Response
 
-Return the calls the user will end up submitting. They can be the same calls or new ones, but they must be present. You can change all capabilities (e.g. switching Paymaster if calls happen on a different chain) except the data callback capability, which must remain present.
+Return the calls the user will end up submitting wrapped in a `request` object. They can be the same calls or new ones, but they must be present. You can change all capabilities (e.g. switching Paymaster if calls happen on a different chain) except the data callback capability, which must remain present.
 
 ```typescript
 {
-  calls: {
-    to: string;
-    data: string;
-  }[];
-  chainId: string;
-  version: string;
-  capabilities: {
-    dataCallback: {
-      // Original or updated dataCallback capability
+  request: {
+    calls: {
+      to: string;
+      data: string;
+    }[];
+    chainId: string;
+    capabilities: {
+      dataCallback: {
+        // Original or updated dataCallback capability
+      };
+      // Other capabilities can be changed as needed
     };
-    // Other capabilities can be changed as needed
-  };
+  }
 }
 ```
 
@@ -234,13 +234,20 @@ export async function POST(request: Request) {
       return Response.json({ errors });
     }
 
-    // Success - return original calls
-    return Response.json({
-      calls: requestData.calls,
-      chainId: requestData.chainId,
-      version: requestData.version,
-      capabilities: requestData.capabilities
+    // Success - return the request data wrapped in a request object
+    // The wallet expects the response to contain the original or modified calls
+    return Response.json({ 
+      request: requestData 
     });
+    
+    // Alternative: Explicitly enumerate fields if needed
+    // return Response.json({ 
+    //   request: { 
+    //     calls: requestData.calls, 
+    //     chainId: requestData.chainId, 
+    //     capabilities: requestData.capabilities 
+    //   } 
+    // });
 
   } catch (error) {
     return Response.json({


### PR DESCRIPTION
## What changed? Why?

Updated the datacallback API response structure in Base Account documentation to wrap the response data in a `request` object. This change aligns the documentation with the actual wallet implementation requirements.

The changes affect:
- Example implementation in the Onchain Vibes Store tutorial
- Reference documentation for the datacallback capability

Previously, the callback API was documented to return the calls, chainId, and capabilities directly. Now it correctly shows they should be wrapped in a `request` object.

## How was this tested?

Documentation changes only - no code tests required. Verified markdown syntax and code examples render correctly.

## How can reviewers manually test these changes?

1. Review the updated documentation in `docs/base-account/examples/onchain-vibes-store-with-profiles.mdx`
2. Review the updated reference documentation in `docs/base-account/reference/core/capabilities/datacallback.mdx`
3. Verify that the response structure matches the actual wallet implementation

## Demo/screenshots


