### PR TITLE
Docs/mini app auth

### DIFF
--- a/docs/mini-apps/features/Authentication.mdx
+++ b/docs/mini-apps/features/Authentication.mdx
@@ -29,6 +29,7 @@ All hosts return context data (including user). Use it for analytics or lightwei
 </Tab>
 </Tabs>
 
+
 ## Implementation Example
 
 ```tsx App.tsx
@@ -54,6 +55,10 @@ function MyComponent() {
   );
 }
 ```
+
+<Info>
+For a complete example of using Quick Auth with MiniKit, see [here](https://github.com/coinbase/onchainkit/blob/main/examples/minikit-example/app/components/UserInfo.tsx).
+</Info>
 
 ## Best practices
 

--- a/docs/mini-apps/troubleshooting/common-issues.mdx
+++ b/docs/mini-apps/troubleshooting/common-issues.mdx
@@ -84,7 +84,30 @@ Solution: Use `name="fc:frame"` meta tag in `<head>` and validate using the Embe
 
 ### 4. Wallet Connection Problems
 
-Prefer MiniKit with OnchainKit Wallet or Wagmi hooks. MiniKit includes wagmi providers; avoid double configuration.
+Always use the user's connected wallet for optimal experience. You can do this either by using [OnchainKit's Wallet component](/onchainkit/wallet/wallet) or Wagmi hooks. Below is a Wagmi hook example:
+
+```tsx App.tsx
+import { useAccount } from 'wagmi';
+
+function MyComponent() {
+  const { address, isConnected } = useAccount();
+  
+  const walletConnected = isConnected;
+  
+  const userAddress = address; // Cryptographically verified
+  
+  return (
+    <div>
+      {walletConnected && (
+        <p>Wallet: {userAddress}</p>
+      )}
+      {/* Use wallet data for secure operations */}
+    </div>
+  );
+}
+```
+
+
 
 ### 5. Gesture Conflicts and App Dismissal Issues
 


### PR DESCRIPTION
**What changed? Why?**
-- Added wagmi hooks for developers to have an example of using connected wallet
-- added link to minikit quick auth example
