### PR TITLE
Fix useAuthenticate hook documentation - replace 'authenticate' with …

### DIFF
--- a/docs/mini-apps/technical-reference/minikit/hooks/useAuthenticate.mdx
+++ b/docs/mini-apps/technical-reference/minikit/hooks/useAuthenticate.mdx
@@ -39,7 +39,7 @@ import { useAuthenticate } from '@coinbase/onchainkit/minikit';
 import { useState } from 'react';
 
 export default function AuthButton() {
-  const { user, authenticate } = useAuthenticate();
+  const { user, signin } = useAuthenticate();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
 
   const handleAuth = async () => {
@@ -84,7 +84,7 @@ export default function AuthButton() {
 import { useAuthenticate } from '@coinbase/onchainkit/minikit';
 
 export default function ProtectedFeature() {
-  const { user, authenticate } = useAuthenticate();
+  const { user, signin } = useAuthenticate();
 
   if (!user) {
     return (


### PR DESCRIPTION
…'signin'

Corrected the useAuthenticate hook documentation to show the correct return value 'signin' instead of 'authenticate' in the destructuring examples on lines 42 and 87. This fixes the documentation inconsistency reported in issue #238.

The hook actually returns { user, signin } not { user, authenticate }, so the code examples were misleading developers.

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
