### PR TITLE
chore: change all .tar.gz to .tar.zst, chage tar command to use zstd flag

### DIFF
--- a/docs/base-chain/node-operators/snapshots.mdx
+++ b/docs/base-chain/node-operators/snapshots.mdx
@@ -37,13 +37,13 @@ These steps assume you are in the cloned `node` directory (the one containing `d
     | Mainnet  | Reth   | Archive       | `wget https://mainnet-reth-archive-snapshots.base.org/$(curl https://mainnet-reth-archive-snapshots.base.org/latest)` |
 
     <Note>
-    Ensure you have enough free disk space to download the snapshot archive (`.tar.gz` file) _and_ extract its contents. The extracted data will be significantly larger than the archive.
+    Ensure you have enough free disk space to download the snapshot archive (`.tar.zst` file) _and_ extract its contents. The extracted data will be significantly larger than the archive.
     </Note>
 
-3. **Extract Snapshot**: Untar the downloaded snapshot archive. Replace `<snapshot-filename.tar.gz>` with the actual downloaded filename:
+3. **Extract Snapshot**: Untar the downloaded snapshot archive. Replace `<snapshot-filename.tar.zst>` with the actual downloaded filename:
 
     ```bash
-    tar -xzvf <snapshot-filename.tar.gz>
+    tar --zstd -xvf <snapshot-filename.tar.zst>
     ```
 
 4. **Move Data**: The extraction process will likely create a directory (e.g., `geth` or `reth`). 
@@ -75,5 +75,5 @@ These steps assume you are in the cloned `node` directory (the one containing `d
     docker compose up --build -d
     ```
 
-6. **Verify and Clean Up**: Monitor the node logs (`docker compose logs -f <service_name>`) or use the [sync monitoring](/base-chain/node-operators/run-a-base-node#monitoring-sync-progress) command to ensure the node starts syncing from the snapshot's block height. Once confirmed, you can safely delete the downloaded snapshot archive (`.tar.gz` file) to free up disk space.
+6. **Verify and Clean Up**: Monitor the node logs (`docker compose logs -f <service_name>`) or use the [sync monitoring](/base-chain/node-operators/run-a-base-node#monitoring-sync-progress) command to ensure the node starts syncing from the snapshot's block height. Once confirmed, you can safely delete the downloaded snapshot archive (`.tar.zst` file) to free up disk space.
 


### PR DESCRIPTION
**What changed? Why?**
You have an old format for snapshots in the documentation only.
**Notes to reviewers**

**How has it been tested?**
I'm unzipping your snapshot rn via:
```bash
tar --zstd -xvf base-mainnet-reth-1753251908.tar.zst
```