### PR TITLE
Update unsupported-calls.mdx

### DIFF
--- a/docs/base-account/more/troubleshooting/usage-details/unsupported-calls.mdx
+++ b/docs/base-account/more/troubleshooting/usage-details/unsupported-calls.mdx
@@ -27,17 +27,3 @@ Future versions of Base Account may support it.
 You can use a factory contract or a transaction with the `CREATE2` opcode to deploy a smart contract.
 </Tip>
 
-## Solidity's Builtin `transfer` function
-
-The `transfer` function is a built-in member of the `address` type in Solidity that can be used to send ETH to an address. Base Account wallets cannot receive ETH using this function.
-This function has long been considered deprecated in favor of `call` by the Solidity community, but some older contracts still use it.
-
-The reason for this is that `transfer` only forwards 2300 gas to the `transfer` call, a protective mechanism that was designed to prevent reentrancy attacks by limiting the amount of
-gas available to a smart contract that might reenter the caller.
-In the modern world of smart contract wallets (including for Base Account), this is often not enough gas for the smart contract's `receive` or `fallback` functions to complete their work,
-causing the transaction to revert.
-
-### Known affected contracts
-
-- The [WETH9 contract](https://basescan.org/token/0x4200000000000000000000000000000000000006) uses `transfer` to send ETH to the user's wallet and therefore Base Accounts cannot directly unwrap ETH from it.
-


### PR DESCRIPTION
**What changed? Why?**

Undo: https://github.com/base/docs/pull/111#issue-3243875203

Not sure what the context of that internal discussion was, but the note in the docs is misleading as unwrapping ETH from the WETH9 contract does in fact work while consuming about 300 gas. (For both, 1.1.0 and 1.0.0 implementations)

<img width="1023" height="79" alt="sca" src="https://github.com/user-attachments/assets/240045b4-ff27-41d1-b057-4b120e8270a7" />

**Notes to reviewers**

**How has it been tested?**

https://dashboard.tenderly.co/tx/0x17c2b2554d146455db35bc26ced014809fec0efc1fb300007d1ef64a5a34e10f