### PR TITLE
Add rundler configuration suggestions for the transaction gas limit

### DIFF
--- a/docs/base-chain/network-information/block-building.mdx
+++ b/docs/base-chain/network-information/block-building.mdx
@@ -56,6 +56,7 @@ Today, a single transaction can request any gas up to the block gas limit. With 
 #### Action items for developers
 
 * If you manually set large gas limits, update your code to stay ≤ 16,777,216.
+* If you operate a bundler, configure your maximum bundle size to stay ≤ 16,777,216. For [`rundler`](https://github.com/alchemyplatform/rundler), set `max_bundle_block_gas_limit_ratio` to 0.105 and `target_bundle_block_gas_limit_ratio` to 0.06 for Base. This will produce bundles below the limit for today's gas limit of 140M.
 * For batch jobs or complex on‑chain work, split large jobs into smaller calls.
 * If you maintain custom tooling, surface a clear message when the cap hits.
 


### PR DESCRIPTION
With the new per-transaction gas limit, bundlers are particularly affected. The suggested rundler configuration should help them continue to have their bundlers included in blocks.