### PR TITLE
chore: update sdk version for auto spend permission

### DIFF
--- a/docs/base-account/improve-ux/sub-accounts.mdx
+++ b/docs/base-account/improve-ux/sub-accounts.mdx
@@ -266,7 +266,7 @@ Auto Spend Permissions allows Sub Accounts to access funds from their parent Bas
 
 ### Configuration
 
-Auto Spend Permissions is only available in SDK version `2.0.2-canary.20250822164845` or later. This feature is **enabled by default** when using Sub Accounts.
+Auto Spend Permissions is only available in SDK version `2.1.0` or later. This feature is **enabled by default** when using Sub Accounts.
 
 To disable Auto Spend Permissions when using Sub Accounts, set `unstable_enableAutoSpendPermissions` to `false` in your SDK configuration:
 


### PR DESCRIPTION
**What changed? Why?**
Update sdk version to use auto spend permissions to latest version
**Notes to reviewers**

**How has it been tested?**
