### PR TITLE
Base Account Telemetry page: update makeProvider to getProvider

### DIFF
--- a/docs/base-account/more/telemetry.mdx
+++ b/docs/base-account/more/telemetry.mdx
@@ -59,7 +59,7 @@ const sdk = createCoinbaseWalletSDK({
   telemetry: false, // [!code focus]
 });
 
-const provider = sdk.makeProvider();
+const provider = sdk.getProvider();
 ```
 
 For legacy Coinbase Wallet SDK class based components:
@@ -72,7 +72,7 @@ const sdk = new CoinbaseWalletSDK({
   appLogoUrl: "https://example.com/logo.png",
 });
 
-const provider = sdk.makeProvider({
+const provider = sdk.getProvider({
   telemetry: false, // [!code focus]
 });
 ```


### PR DESCRIPTION
**What changed? Why?**

Telemetry page in Base Account docs should use `getProvider` instead of `makeProvider`
This PR is to fix the mistake
