### PR TITLE
Update SDK initialization to use appLogoUrl instead of deprecated appLogo

### DIFF
--- a/docs/base-account/quickstart/web-react.mdx
+++ b/docs/base-account/quickstart/web-react.mdx
@@ -66,7 +66,7 @@ function App() {
   const sdk = createBaseAccountSDK(
     {
       appName: 'Base Account Quick-start',
-      appLogo: 'https://base.org/logo.png',
+      appLogoUrl: 'https://base.org/logo.png',
     }
   );
 


### PR DESCRIPTION
**What changed? Why?**
Updated the Base Account SDK initialization code in the documentation to use the correct property name appLogoUrl instead of the deprecated appLogo.

**Notes to reviewers**
This is a documentation-only change to align with the current SDK API
The old property name appLogo appears to be deprecated in favor of the more descriptive appLogoUrl
No functional changes to the codebase, only documentation updates

**How has it been tested?**
Verified against the latest SDK documentation that appLogoUrl is the correct property name
https://docs.base.org/base-account/reference/core/createBaseAccount

Confirmed that the example code compiles and runs correctly with the updated property name