### PR TITLE
Avoid math mode for ETH

### DIFF
--- a/docs/base-app/agents/why-agents.mdx
+++ b/docs/base-app/agents/why-agents.mdx
@@ -12,7 +12,7 @@ Real Examples:
 
 • Smart Payment Assistant: Text "split dinner $200 4 ways" and everyone gets paid instantly with sub-cent fees, no app switching or Venmo delays.
 
-• AI Trading Companion: Message "buy $100 ETH when it hits $3,000" and your agent executes trades 24/7 while you sleep.
+• AI Trading Companion: Message "buy \$100 ETH when it hits $3,000" and your agent executes trades 24/7 while you sleep.
 
 • Travel Planning Agent: "Book flight LAX to NYC under $300" and get instant booking with crypto payments, all in your group chat
 


### PR DESCRIPTION
**What changed? Why?**

It looks like the docs are using KaTeX to render mathematical notation. Since KaTeX treats anything inside dollar signs (`$ ... $`) as inline math, the phrase `$100 ETH when it hits $3,000` ends up being displayed in italics.

**Screenshot**

<img width="824" height="220" alt="image" src="https://github.com/user-attachments/assets/158206bc-d7da-4dbe-b2a5-35407d4b1170" />

**Notes to reviewers**

I am escaping `$100 ETH` so it renders as expected.

**How has it been tested?**

I ran `mint dev` locally.