### PR TITLE
Updating Create React App to NextJs in Base Account Docs

### DIFF
--- a/docs/base-account/quickstart/web-react.mdx
+++ b/docs/base-account/quickstart/web-react.mdx
@@ -5,7 +5,7 @@ description: "Quickly add Sign in with Base and Base Pay to any Next.js app"
 
 import { GithubRepoCard } from "/snippets/GithubRepoCard.mdx"
 
-This quick-start shows the **minimum** code required to add Sign in with Base and Base Pay to any Next.js app using the Base Account SDK.
+This quick-start shows the **minimum** code required to add Sign in with Base (SIWB) and Base Pay to any Next.js app using the Base Account SDK.
 
 ## 1. Create a new Next.js app
 
@@ -209,6 +209,12 @@ export default function Home() {
 
 Make sure to replace `0xRecipientAddress` with your recipient address.
 </Note>
+
+<Tip>
+**Base Pay and SIWB are independent**
+
+You DO NOT need to use SIWB to use Base Pay. You can just call the `pay()` function without any additional setup.
+</Tip>
 
 ## 4. Start your app
 


### PR DESCRIPTION
**What changed? Why?**

create-react-app is deprecated. Switching the guide to nextjs
