### PR TITLE
Fix NFT badge images in learn exercises

### DIFF
--- a/storybook/stories/components/CafeUnitTest/index.jsx
+++ b/storybook/stories/components/CafeUnitTest/index.jsx
@@ -451,7 +451,7 @@ export function CafeUnitTest({ nftNum }) {
           <div style={pinTitleStyle}>
             {nft.title} NFT Badge Earned on {chain?.name}!
           </div>
-          <img src={nft.img} style={pinStyle} alt={`${nft.title} NFT Badge`} />
+          <img src={nft.img.src} style={pinStyle} alt={`${nft.title} NFT Badge`} />
         </div>
       );
     }


### PR DESCRIPTION
**What changed? Why?**

* update image src reference from `nft.img` to `nft.img.src` in CafeUnitTest storybook component

* NFT badge images are not rendering in [learn exercise](https://docs.base.org/learn/arrays/arrays-exercise) iframes 

**How has it been tested?**

* storybook project run locally
