### PR TITLE
docs: correct LLMS link text

### DIFF
--- a/docs/mini-apps/quickstart/new-apps/install.mdx
+++ b/docs/mini-apps/quickstart/new-apps/install.mdx
@@ -10,7 +10,7 @@ A mini app is a lightweight web app that runs directly inside Farcaster clients 
 This guide gets you from zero to a running Mini App using the MiniKit template.
 
 <Tip>
-These docs are LLM‑friendly for AI development tools. **Copy individual pages** as markdown from the dropdown menu above, or **reference the complete docs** at [llms.txt](https://docs.base.org/mini-apps/llms-full.txt) for comprehensive Mini App knowledge in your AI assistant.
+These docs are LLM‑friendly for AI development tools. **Copy individual pages** as markdown from the dropdown menu above, or **reference the complete docs** at [llms-full.txt](https://docs.base.org/mini-apps/llms-full.txt) for comprehensive Mini App knowledge in your AI assistant.
 </Tip>
 
 ## Prerequisites


### PR DESCRIPTION
**What changed? Why?**
updated the link text from "llms.txt" to "llms-full.txt" to match the actual URL.
this fixes a confusing mismatch for users.

**Notes to reviewers**
just a text change for clarity; no functional code changes.

**How has it been tested?**
verified that the link now accurately reflects the target file when clicked.
