### PR TITLE
Update per-transaction gas maximum rollout docs

### DIFF
--- a/docs/base-chain/network-information/block-building.mdx
+++ b/docs/base-chain/network-information/block-building.mdx
@@ -78,6 +78,9 @@ priority fee, see the ([code](https://github.com/ethereum-optimism/op-geth/blob/
 
 ## Changelog
 
+* 11th Sep: Ended testing Per-Transaction Gas Maximum on Base Mainnet
+* 10th Sep: Started testing Per-Transaction Gas Maximum on Base Mainnet
+* 3rd Sep: Enabled Per-Transaction Gas Maximum on Base Sepolia
 * 7th July: Enabled Flashblocks on Base Mainnet
 * 15th May: Ended testing Flashblocks on Base Mainnet
 * 15th May: Started testing Flashblocks on Base Mainnet

--- a/docs/base-chain/network-information/block-building.mdx
+++ b/docs/base-chain/network-information/block-building.mdx
@@ -13,8 +13,8 @@ The Base networks are currently configured in the following ways:
 
 | Network      | Current Configuration       | Upcoming Deployments   |
 |--------------|-----------------------------|------------------------|
-| Base Mainnet | [Flashblocks](#flashblocks) | Sep 10: [Flashblocks](#flashblocks) + [Per-Transaction Gas Max](#per-transaction-gas-maximum) |
-| Base Sepolia | [Flashblocks](#flashblocks) | Sep 3: [Flashblocks](#flashblocks) + [Per-Transaction Gas Max](#per-transaction-gas-maximum) |
+| Base Mainnet | [Flashblocks](#flashblocks) | Sep 17: [Flashblocks](#flashblocks) + [Per-Transaction Gas Max](#per-transaction-gas-maximum) |
+| Base Sepolia | [Flashblocks](#flashblocks) + [Per-Transaction Gas Max](#per-transaction-gas-maximum) | |
 
 ## Configurations
 
@@ -41,22 +41,22 @@ Consequently, transactions with large gas requirements must wait for later Flash
 ### Per-Transaction Gas Maximum
 
 <Warning>
-On **September 10**, we’ll begin enforcing a per‑transaction gas cap of 16,777,216 gas (2^24) on Base. This aligns Base with the [in‑flight L1 proposal](https://eips.ethereum.org/EIPS/eip-7825), improves network predictability, and has no effect on fees for typical users. We’ll activate it first on Base Sepolia on **September 3**, then activate it on Base mainnet temporarily for one day on **September 10** as a warning. This will be activated permanently on Base mainnet on **September 17**.
+On **September 17**, we’ll begin enforcing a per‑transaction gas cap of 25,000,000 on Base. This aligns Base with the [in‑flight L1 proposal](https://eips.ethereum.org/EIPS/eip-7825), improves network predictability, and has no effect on fees for typical users.
 
 #### What’s changing
 
-Today, a single transaction can request any gas up to the block gas limit. With this change, transactions that specify gas > 16,777,216 will be rejected by the mempool before inclusion.
+Today, a single transaction can request any gas up to the block gas limit. With this change, transactions that specify gas > 25,000,000 will be rejected by the mempool before inclusion.
 
 #### Why we’re doing this
 
 * Predictability & resilience. Bounding single‑tx execution reduces extreme outliers and makes block building more stable.
-* Consistency with Ethereum. The L1 community is converging on a 2^24 per‑tx cap; we’re aligning early so builders don’t have to juggle different rules across layers.
+* Consistency with Ethereum. The L1 community is converging on an in-protocol per‑tx cap; we’re aligning early so builders don’t have to juggle different rules across layers.
 * No practical impact for most builders. The overwhelming majority of Base transactions are far below this cap.
 
 #### Action items for developers
 
-* If you manually set large gas limits, update your code to stay ≤ 16,777,216.
-* If you operate a bundler, configure your maximum bundle size to stay ≤ 16,777,216. For [`rundler`](https://github.com/alchemyplatform/rundler), set `max_bundle_block_gas_limit_ratio` to 0.105 and `target_bundle_block_gas_limit_ratio` to 0.06 for Base. This will produce bundles below the limit for today's gas limit of 140M.
+* If you manually set large gas limits, update your code to stay ≤ 25,000,000.
+* If you operate a bundler, configure your maximum bundle size to stay ≤ 25,000,000. For [`rundler`](https://github.com/alchemyplatform/rundler), set `max_bundle_block_gas_limit_ratio` to 0.166 and `target_bundle_block_gas_limit_ratio` to 0.1 for Base. This will produce bundles below the limit for today's gas limit of 150M.
 * For batch jobs or complex on‑chain work, split large jobs into smaller calls.
 * If you maintain custom tooling, surface a clear message when the cap hits.
 
@@ -67,7 +67,9 @@ Today, a single transaction can request any gas up to the block gas limit. With 
 * **Will contract deployments break?** Typical deployments are well below the cap. If yours isn’t, consider slimming bytecode or chunking initialization.
 </Warning>
 
-Base enforces a per-transaction gas maximum of **16,777,216 gas (2^24)**. Transactions that specify a gas limit above this value are **rejected by the mempool before inclusion**. `eth_sendTransaction` or `eth_sendRawTransaction` will return a JSON-RPC error (for example: `exceeds maximum per-transaction gas limit`). This cap does **not** change the block gas limit or the block validity conditions (that will come later with [EIP 7825](https://eips.ethereum.org/EIPS/eip-7825)).
+Base enforces a per-transaction gas maximum of **25,000,000 gas**. Transactions that specify a gas limit above this value are **rejected by the mempool before inclusion**. `eth_sendTransaction` or `eth_sendRawTransaction` will return a JSON-RPC error (for example: `exceeds maximum per-transaction gas limit`). This cap does **not** change the block gas limit or the block validity conditions.
+
+Fusaka's [EIP 7825](https://eips.ethereum.org/EIPS/eip-7825) **will** change the block validity conditions and enforce a lower per-transaction gas maximum of 16,777,216 gas (2^24). We expect this protocol change to be adopted in all OP Stack chains around January 2026.
 
 ### Vanilla
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -20,7 +20,7 @@
     }
   },
   "banner":{
-    "content": "[On September 10th, Base Chain will begin enforcing a per-transaction gas cap. Read more here](/base-chain/network-information/block-building#per-transaction-gas-maximum)."
+    "content": "[On September 17th, Base Chain will begin enforcing a per-transaction gas cap. Read more here](/base-chain/network-information/block-building#per-transaction-gas-maximum)."
   },
   "navigation": {
     "tabs": [


### PR DESCRIPTION
The per-transaction gas maximum will now be 25,000,000 gas. Updated dates and the changelog based on the rollout so far.