### PR TITLE
Add Tip on how to override pinned base account sdk version in Wagmi

### DIFF
--- a/docs/base-account/framework-integrations/wagmi/setup.mdx
+++ b/docs/base-account/framework-integrations/wagmi/setup.mdx
@@ -9,6 +9,10 @@ Learn how to set up Wagmi with Base Account to enable Base Account SDK functiona
 
 [Wagmi](https://wagmi.sh/) is a collection of React hooks for Ethereum Virtual Machine (EVM) compatible networks that makes it easy to work with wallets, contracts, transactions, and signing. Base Account integrates perfectly with Wagmi, allowing you to use all your familiar hooks.
 
+<Tip>
+To create a new wagmi project, you can use the command line `npm create wagmi@latest`.
+</Tip>
+
 ## Installation
 
 If you start [a new wagmi project](https://wagmi.sh/react/getting-started), you can skip the installation step.
@@ -34,7 +38,17 @@ bun add wagmi viem @base-org/account
 </CodeGroup>
 
 <Tip>
-To create a new wagmi project, you can use the command line `npm create wagmi@latest`.
+To get access to the latest version of the Base Account SDK within Wagmi, you can use the following command to override it:
+
+```bash
+npm pkg set overrides.@base-org/account="latest"
+```
+Or you can use a specific version by adding the version to the overrides:
+```bash
+npm pkg set overrides.@base-org/account="2.2.0"
+```
+
+Make sure to delete your `node_modules` and `package-lock.json` and run a new install to ensure the overrides are applied.
 </Tip>
 
 ## Configuration

--- a/docs/base-account/framework-integrations/wagmi/sign-in-with-base.mdx
+++ b/docs/base-account/framework-integrations/wagmi/sign-in-with-base.mdx
@@ -20,6 +20,20 @@ To implement Sign in with Base with Wagmi, you need to:
 
 This follows the same flow as shown in the [authenticate users guide](/base-account/guides/authenticate-users), but integrates with Wagmi's connector system.
 
+<Tip>
+To get access to the latest version of the Base Account SDK within Wagmi, you can use the following command to override it:
+
+```bash
+npm pkg set overrides.@base-org/account="latest"
+```
+Or you can use a specific version by adding the version to the overrides:
+```bash
+npm pkg set overrides.@base-org/account="2.2.0"
+```
+
+Make sure to delete your `node_modules` and `package-lock.json` and run a new install to ensure the overrides are applied.
+</Tip>
+
 ## Implementation
 
 ### Code Snippets


### PR DESCRIPTION
**What changed? Why?**

Add tip on how to override latest base account version in wagmi