### PR TITLE
Added eth_call flashblocks support docs + updated reorg FAQ

### DIFF
--- a/docs/base-chain/flashblocks/apps.mdx
+++ b/docs/base-chain/flashblocks/apps.mdx
@@ -114,6 +114,64 @@ curl https://sepolia-preconf.base.org -X POST -H "Content-Type: application/json
 }
 ```
 
+#### eth_call
+
+Use the `pending` tag to execute a smart contract call against the latest Flashblock:
+```
+curl https://sepolia-preconf.base.org -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0x...","data":"0x..."},"pending"],"id":1}'
+```
+
+**Example Response**
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
+}
+```
+
+#### eth_simulateV1
+
+Use the `pending` tag to simulate transactions against the latest Flashblock:
+```
+curl https://sepolia-preconf.base.org -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_simulateV1","params":[{"blockStateCalls":[{"calls":[{"to":"0x...","data":"0x..."}],"stateOverrides":{}}],"traceTransfers":true,"validation":true},"pending"],"id":1}'
+```
+
+**Example Response**
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "calls": [
+        {
+          "status": "0x1",
+          "gasUsed": "0x5208",
+          "returnData": "0x"
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### eth_estimateGas
+
+Use the `pending` tag to estimate gas against the latest Flashblock:
+```
+curl https://sepolia-preconf.base.org -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"to":"0x...","data":"0x..."},"pending"],"id":1}'
+```
+
+**Example Response**
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x5208"
+}
+```
+
 ### Libraries
 
 You will need to use a Flashblocks-aware RPC endpoint to use Flashblocks with the following libraries:

--- a/docs/base-chain/flashblocks/docs.mdx
+++ b/docs/base-chain/flashblocks/docs.mdx
@@ -26,7 +26,7 @@ Unfortunately there's no way to guarantee which flashblock a transaction lands i
 
 ### How frequently do flashblocks reorg happen?
 
-Flashblocks reorg currently happens once approx. every ~300 blocks. You can also view the stats by visiting https://www.base.org/stats (the flashblocks section at the bottom).
+Flashblocks reorgs on Base Mainnet is currently effectively zero, with only rare exceptions. We are committed to maintaining a reorg rate below 0.01% going forward. You can check the latest metrics in the Flashblocks section at https://base.org/stats
 
 ### What does it mean when a flashblock is reorged?
 
@@ -64,10 +64,9 @@ Currently the ones that have flashblocks enabled are:
 - eth_getTransactionReceipt
 - eth_getTransactionByHash (with pending tag)
 - eth_getTransactionCount (with pending tag)
-
-### What about eth_call, eth_estimate, etc?
-
-We will support these soon, ETA at the end of Q3 2025.
+- eth_call (with pending tag)
+- eth_simulateV1 (with pending tag)
+- eth_estimateGas (with pending tag)
 
 ## Node
 


### PR DESCRIPTION
**What changed? Why?**
Updated Flashblocks docs section to mention new RPC methods (eth_call).

Also updated the reorg question to mention now reorg is effectively zero.

**Notes to reviewers**

**How has it been tested?**
