### PR TITLE
fix: temporarily remove sub accounts quickstart / auto

### DIFF
--- a/docs/base-account/improve-ux/sub-accounts.mdx
+++ b/docs/base-account/improve-ux/sub-accounts.mdx
@@ -51,34 +51,7 @@ bun add @base-org/account
 ```
 </CodeGroup>
 
-## Quickstart
-
-The fastest way to adopt Sub Accounts is to enable automatic Sub Accounts by setting `subAccounts.mode` to `auto` in the SDK configuration.
-
-```tsx
-const sdk = createBaseAccountSDK({
-  // ...
-  subAccounts: {
-    mode: 'auto',
-  }
-});
-```
-
-This will automatically create a Sub Account for the user when they connect their Base Account and transactions will automatically be sent from the Sub Account unless you specify the `from` parameter in your transaction request to be the universal account address. Spend Permissions will also be automatically requested for the Sub Account as your app needs them.
-
-This is what the user will see when they connect their Base Account and automatic Sub Accounts are enabled:
-
-<div style={{ display: 'flex', justifyContent: 'center'}}>
-  <img src="/images/base-account/SubAccountCreationConnect.png" alt="Sub Account Creation Flow" style={{ width: '300px', height: 'auto' }} />
-</div>
-
-<Tip>
-We recommend using a [Paymaster](/base-account/improve-ux/sponsor-gas/paymasters) to sponsor gas to ensure the best user experience when integrating Sub Accounts. You can set a paymaster to be used for all transactions by configuring the `paymasterUrls` parameter in the SDK configuration. See the [createBaseAccount](/base-account/reference/core/createBaseAccount#param-paymaster-urls) reference for more information.
-</Tip>
-
 ## Using Sub Accounts
-
-If you don't want to use automatic Sub Accounts, you can create and manage them manually.
 
 ### Initialize the SDK
 


### PR DESCRIPTION
**What changed? Why?**
Temporarily removed quickstart section because auto sub accounts configuration is not live yet.

**Notes to reviewers**

**How has it been tested?**
