### PR TITLE
Update Sepolia addresses following U16a upgrade

### DIFF
--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -87,16 +87,16 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | Name                         | Address                                                                                                                       |
 | :--------------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
 | AddressManager               | [0x709c2B8ef4A9feFc629A8a2C1AF424Dc5BD6ad1B](https://sepolia.etherscan.io/address/0x709c2B8ef4A9feFc629A8a2C1AF424Dc5BD6ad1B) |
-| AnchorStateRegistryProxy     | [0x0729957c92A1F50590A84cb2D65D761093f3f8eB](https://sepolia.etherscan.io/address/0x0729957c92A1F50590A84cb2D65D761093f3f8eB) |
-| DelayedWETHProxy (FDG)       | [0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F](https://sepolia.etherscan.io/address/0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F) |
-| DelayedWETHProxy (PDG)       | [0x27A6128F707de3d99F89Bf09c35a4e0753E1B808](https://sepolia.etherscan.io/address/0x27A6128F707de3d99F89Bf09c35a4e0753E1B808) |
+| AnchorStateRegistryProxy     | [0x2fF5cC82dBf333Ea30D8ee462178ab1707315355](https://sepolia.etherscan.io/address/0x2fF5cC82dBf333Ea30D8ee462178ab1707315355) |
+| DelayedWETHProxy (FDG)       | [0xd3683e4947A7769603Ab6418eC02f000CE3cF30b](https://sepolia.etherscan.io/address/0xd3683e4947A7769603Ab6418eC02f000CE3cF30b) |
+| DelayedWETHProxy (PDG)       | [0x32cE910d9C6c8F78dc6779c1499aB05F281A054e](https://sepolia.etherscan.io/address/0x32cE910d9C6c8F78dc6779c1499aB05F281A054e) |
 | DisputeGameFactoryProxy      | [0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1](https://sepolia.etherscan.io/address/0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1) |
 | FaultDisputeGame             | [0x32b37BBd2c81e853EA098ce45856aE305Df10dD1](https://sepolia.etherscan.io/address/0x32b37BBd2c81e853EA098ce45856aE305Df10dD1) |
 | L1CrossDomainMessenger       | [0xC34855F4De64F1840e5686e64278da901e261f20](https://sepolia.etherscan.io/address/0xC34855F4De64F1840e5686e64278da901e261f20) |
 | L1ERC721Bridge               | [0x21eFD066e581FA55Ef105170Cc04d74386a09190](https://sepolia.etherscan.io/address/0x21eFD066e581FA55Ef105170Cc04d74386a09190) |
 | L1StandardBridge             | [0xfd0Bf71F60660E2f608ed56e1659C450eB113120](https://sepolia.etherscan.io/address/0xfd0Bf71F60660E2f608ed56e1659C450eB113120) |
 | L2OutputOracle               | [0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254](https://sepolia.etherscan.io/address/0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254) |
-| MIPS                         | [0xF027F4A985560fb13324e943edf55ad6F1d15Dc1](https://sepolia.etherscan.io/address/0xF027F4A985560fb13324e943edf55ad6F1d15Dc1) |
+| MIPS                         | [0x07BABE08EE4D07dBA236530183B24055535A7011](https://sepolia.etherscan.io/address/0x07BABE08EE4D07dBA236530183B24055535A7011) |
 | OptimismMintableERC20Factory | [0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37](https://sepolia.etherscan.io/address/0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37) |
 | OptimismPortal               | [0x49f53e41452C74589E85cA1677426Ba426459e85](https://sepolia.etherscan.io/address/0x49f53e41452C74589E85cA1677426Ba426459e85) |
 | PermissionedDisputeGame      | [0x217e725700DE4Dc599360aDbd57dbb7DE280817E](https://sepolia.etherscan.io/address/0x217e725700DE4Dc599360aDbd57dbb7DE280817E) |
@@ -128,4 +128,4 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | Proxy Admin Owner (L1) | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9)      | Gnosis Safe                          |
 | Challenger             | [0x8b8c52B04A38f10515C52670fcb23f3C4C44474F](https://sepolia.etherscan.io/address/0x8b8c52B04A38f10515C52670fcb23f3C4C44474F)      | EOA managed by Coinbase Technologies |
 | System config owner    | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9)      | Gnosis Safe                          |
-| Guardian               | [0xA9FF930151130fd19DA1F03E5077AFB7C78F8503](https://sepolia.etherscan.io/address/0xA9FF930151130fd19DA1F03E5077AFB7C78F8503)      | EOA managed by Coinbase Technologies |
+| Guardian               | [0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E](https://sepolia.etherscan.io/address/0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E)      | EOA managed by Coinbase Technologies |

--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -91,7 +91,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | DelayedWETHProxy (FDG)       | [0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F](https://sepolia.etherscan.io/address/0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F) |
 | DelayedWETHProxy (PDG)       | [0x27A6128F707de3d99F89Bf09c35a4e0753E1B808](https://sepolia.etherscan.io/address/0x27A6128F707de3d99F89Bf09c35a4e0753E1B808) |
 | DisputeGameFactoryProxy      | [0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1](https://sepolia.etherscan.io/address/0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1) |
-| FaultDisputeGame             | [0xcfce7dd673fbbbffd16ab936b7245a2f2db31c9a](https://sepolia.etherscan.io/address/0xcfce7dd673fbbbffd16ab936b7245a2f2db31c9a) |
+| FaultDisputeGame             | [0x32b37BBd2c81e853EA098ce45856aE305Df10dD1](https://sepolia.etherscan.io/address/0x32b37BBd2c81e853EA098ce45856aE305Df10dD1) |
 | L1CrossDomainMessenger       | [0xC34855F4De64F1840e5686e64278da901e261f20](https://sepolia.etherscan.io/address/0xC34855F4De64F1840e5686e64278da901e261f20) |
 | L1ERC721Bridge               | [0x21eFD066e581FA55Ef105170Cc04d74386a09190](https://sepolia.etherscan.io/address/0x21eFD066e581FA55Ef105170Cc04d74386a09190) |
 | L1StandardBridge             | [0xfd0Bf71F60660E2f608ed56e1659C450eB113120](https://sepolia.etherscan.io/address/0xfd0Bf71F60660E2f608ed56e1659C450eB113120) |
@@ -99,7 +99,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | MIPS                         | [0xF027F4A985560fb13324e943edf55ad6F1d15Dc1](https://sepolia.etherscan.io/address/0xF027F4A985560fb13324e943edf55ad6F1d15Dc1) |
 | OptimismMintableERC20Factory | [0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37](https://sepolia.etherscan.io/address/0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37) |
 | OptimismPortal               | [0x49f53e41452C74589E85cA1677426Ba426459e85](https://sepolia.etherscan.io/address/0x49f53e41452C74589E85cA1677426Ba426459e85) |
-| PermissionedDisputeGame      | [0xf0102ffe22649a5421d53acc96e309660960cf44](https://sepolia.etherscan.io/address/0xf0102ffe22649a5421d53acc96e309660960cf44) |
+| PermissionedDisputeGame      | [0x217e725700DE4Dc599360aDbd57dbb7DE280817E](https://sepolia.etherscan.io/address/0x217e725700DE4Dc599360aDbd57dbb7DE280817E) |
 | PreimageOracle               | [0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3](https://sepolia.etherscan.io/address/0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3) |
 | ProxyAdmin                   | [0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3](https://sepolia.etherscan.io/address/0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3) |
 | SystemConfig                 | [0xf272670eb55e895584501d564AfEB048bEd26194](https://sepolia.etherscan.io/address/0xf272670eb55e895584501d564AfEB048bEd26194) |


### PR DESCRIPTION
This PR updates the Sepolia addresses for `FaultDisputeGame` and `PermissionedDisputeGame` in `base-contracts.mdx` following the U16a upgrade that occurred on 22/09/25.