### PR TITLE
Add Revnet section to launch-tokens documentation

### DIFF
--- a/docs/cookbook/launch-tokens.mdx
+++ b/docs/cookbook/launch-tokens.mdx
@@ -85,6 +85,19 @@ Flaunch leverages Uniswap V4 to enable programmable revenue splits, automated bu
 
 [Get started with Flaunch →](https://flaunch.gg)
 
+### Revnet
+**Best for:** Revenue generating projects with sophisticated tokenomics
+
+Tokenize revenues and fundraises. 100% autonomous.
+
+**Key Features:**
+- Revenue-backed token issuance
+- Programmed rulesets and splits
+- Token-backed loans
+- AMM integrated buy-back hooks
+
+[Get started with Revnet →](https://revnet.eth.limo or visit [revnet.app](https://revnet.app)
+
 ## Technical Implementation with Foundry
 
 For developers who want full control over their token implementation, here's how to create and deploy a custom ERC-20 token on Base using Foundry.


### PR DESCRIPTION
Added Revnet section detailing its features and benefits.

Ominchain token deployer from the Juicebox team
