### PR TITLE
Remove Figma link from Base Account reference

### DIFF
--- a/docs/base-account/reference/ui-elements/brand-guidelines.mdx
+++ b/docs/base-account/reference/ui-elements/brand-guidelines.mdx
@@ -205,5 +205,5 @@ Following are some DOs and DON'Ts for the Base branding:
 
 ## Media Assets
 
-You can find the full set of Base Pay and Sign in with Base media assets in the [Base Brand Assets Figma File](https://www.figma.com/design/L8K5httaDFjiAqfWrChMFi/Sign-in-with-Base---Base-Pay%E2%80%94Media-Kit?node-id=0-1&p=f&t=5766QEX963be2lrj-0).
 
+You can find the full set of Base Brand Assets in the [Base Brand Page](https://base.org/brand).

--- a/docs/base-account/reference/ui-elements/brand-guidelines.mdx
+++ b/docs/base-account/reference/ui-elements/brand-guidelines.mdx
@@ -205,5 +205,4 @@ Following are some DOs and DON'Ts for the Base branding:
 
 ## Media Assets
 
-
 You can find the full set of Base Brand Assets in the [Base Brand Page](https://base.org/brand).


### PR DESCRIPTION
**What changed? Why?**
Removing the figma link and putting Base Brand main link
