### PR TITLE
Add eth_getLogs documentation for Flashblocks

### DIFF
--- a/docs/base-chain/flashblocks/apps.mdx
+++ b/docs/base-chain/flashblocks/apps.mdx
@@ -172,6 +172,34 @@ curl https://sepolia-preconf.base.org -X POST -H "Content-Type: application/json
 }
 ```
 
+#### eth_getLogs
+
+Use the `pending` tag for `toBlock` to retrieve logs from the latest Flashblock:
+```
+curl https://sepolia-preconf.base.org -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"latest","toBlock":"pending","address":"0x...","topics":["0x..."]}],"id":1}'
+```
+
+**Example Response**
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "address": "0x...",
+      "topics": ["0x..."],
+      "data": "0x...",
+      "blockNumber": "0x1234",
+      "transactionHash": "0x...",
+      "transactionIndex": "0x0",
+      "blockHash": "0x...",
+      "logIndex": "0x0",
+      "removed": false
+    }
+  ]
+}
+```
+
 ### Libraries
 
 You will need to use a Flashblocks-aware RPC endpoint to use Flashblocks with the following libraries:

--- a/docs/base-chain/flashblocks/docs.mdx
+++ b/docs/base-chain/flashblocks/docs.mdx
@@ -67,6 +67,7 @@ Currently the ones that have flashblocks enabled are:
 - eth_call (with pending tag)
 - eth_simulateV1 (with pending tag)
 - eth_estimateGas (with pending tag)
+- eth_getLogs (with pending tag)
 
 ## Node
 


### PR DESCRIPTION
  Summary

  - Add documentation for eth_getLogs RPC method with Flashblocks support
  - Include example request/response showing proper usage with pending tag
  - Update FAQ to list eth_getLogs as a supported Flashblocks-aware method

  Changes

  - apps.mdx: Added complete eth_getLogs section with curl example and response format
  - docs.mdx: Updated FAQ to include eth_getLogs (with pending tag) in supported methods list

  Technical Details

  - Uses toBlock: "pending" to retrieve logs from the latest Flashblock
  - Example shows fromBlock: "latest" to avoid size limit issues when querying large block ranges
  - Follows same documentation pattern as other Flashblocks RPC methods