### PR TITLE
docs: update Base Goerli references to Sepolia and fix outdated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <!-- Badge row 2 - links and profiles -->
 
 [![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org)
-[![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/)
+[![Blog](https://img.shields.io/badge/blog-up-green)](https://blog.base.org/)
 [![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
 [![Discord](https://img.shields.io/discord/1067165013397213286?label=discord)](https://base.org/discord)
 [![Twitter Base](https://img.shields.io/twitter/follow/Base?style=social)](https://twitter.com/Base)

--- a/docs/base-app/agents/chat-agents.mdx
+++ b/docs/base-app/agents/chat-agents.mdx
@@ -40,7 +40,7 @@ This guide will walk you through creating, testing, and deploying your first XMT
 - [Getting Started with XMTP (Video)](https://www.youtube.com/watch?v=djRLnWUvwIA)
 - [Building Agents on XMTP](https://github.com/ephemeraHQ/xmtp-agent-examples)
 - [Cursor Rules](https://github.com/ephemeraHQ/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc)
-- [XMTP Documentation](https://docs.xmtp.org/agents)
+- [XMTP Documentation](https://docs.xmtp.org/agents/get-started/build-an-agent)
 - [Faucets](https://portal.cdp.coinbase.com/products/faucet)
 
 **STEP 1: SET UP YOUR DEVELOPMENT ENVIRONMENT**

--- a/docs/base-app/agents/getting-started.mdx
+++ b/docs/base-app/agents/getting-started.mdx
@@ -22,7 +22,7 @@ This guide will walk you through creating, testing, and deploying your first XMT
 - [Getting Started with XMTP (Video)](https://www.youtube.com/watch?v=djRLnWUvwIA)
 - [Building Agents on XMTP](https://github.com/ephemeraHQ/xmtp-agent-examples)
 - [Cursor Rules](https://github.com/ephemeraHQ/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc)
-- [XMTP Documentation](https://docs.xmtp.org/agents)
+- [XMTP Documentation](https://docs.xmtp.org/agents/get-started/build-an-agent)
 - [Faucets](https://portal.cdp.coinbase.com/products/faucet)
 
 **STEP 1: SET UP YOUR DEVELOPMENT ENVIRONMENT**

--- a/docs/get-started/base-mentorship-program.mdx
+++ b/docs/get-started/base-mentorship-program.mdx
@@ -16,7 +16,7 @@ Base Mentors are experienced founders, operators, and subject matter experts acr
 | Name  | Affiliation |
 | ----- | ----- |
 | Alok Vasudev | [Standard Crypto](https://www.standardcrypto.vc/) |
-| Dariush Aghai | [Study Hall Creative](%20https://studyhall.design/about) |
+| Dariush Aghai | [Study Hall Creative](https://studyhall.design/about) |
 | David Espinel  | [Social Graph Ventures](https://www.socialgraph.vc/team) |
 | Ian Dutra  | [a16z crypto](https://a16zcrypto.com/team/ian-dutra/) |
 | Jack Gorman  | [Variant](https://variant.fund/people/jack-gorman/) |

--- a/docs/learn/arrays/arrays-exercise.mdx
+++ b/docs/learn/arrays/arrays-exercise.mdx
@@ -75,7 +75,7 @@ Add `public` functions called `resetSenders` and `resetTimestamps` that reset th
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/control-structures/control-structures-exercise.mdx
+++ b/docs/learn/control-structures/control-structures-exercise.mdx
@@ -40,7 +40,7 @@ Create a function called `doNotDisturb` that accepts a `uint` called `_time`, an
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/deployment-to-testnet/deployment-to-base-sepolia-sbs.mdx
+++ b/docs/learn/deployment-to-testnet/deployment-to-base-sepolia-sbs.mdx
@@ -36,7 +36,7 @@ Be safe and use separate wallets for separate purposes.
 
 First, add the [Coinbase](https://www.coinbase.com/wallet) or [Metamask](https://metamask.io/) wallet to your browser, and then [set up] a new wallet. As a developer, you need to be doubly careful about the security of your wallet! Many apps grant special powers to the wallet address that is the owner of the contract, such as allowing the withdrawal of all the Ether that customers have paid to the contract or changing critical settings.
 
-Once you've completed the wallet setup, enable developer settings and turn on testnets ([Coinbase Settings](https://docs.cloud.coinbase.com/wallet-sdk/docs/developer-settings), [Metamask Settings](https://support.metamask.io/hc/en-us/articles/13946422437147-How-to-view-testnets-in-MetaMask)).
+Once you've completed the wallet setup, enable developer settings and turn on testnets ([Coinbase Settings](https://docs.cloud.coinbase.com/wallet-sdk/docs/developer-settings), [Metamask Settings](https://support.metamask.io/configure/networks/how-to-view-testnets-in-metamask/)).
 
 ### Add Base Sepolia to your Wallet
 

--- a/docs/learn/deployment-to-testnet/deployment-to-testnet-exercise.mdx
+++ b/docs/learn/deployment-to-testnet/deployment-to-testnet-exercise.mdx
@@ -19,7 +19,7 @@ Stay tuned for updates!
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/error-triage/error-triage-exercise.mdx
+++ b/docs/learn/error-triage/error-triage-exercise.mdx
@@ -80,7 +80,7 @@ contract ErrorTriageExercise {
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/foundry/generate-random-numbers-contracts.md
+++ b/docs/learn/foundry/generate-random-numbers-contracts.md
@@ -399,5 +399,5 @@ Congratulations! You have successfully deployed and interacted with a smart cont
 
 To learn more about VRF and using Supra dVRF to generate random numbers within your smart contracts on Base, check out the following resources:
 
-- [Oracles](https://docs.base.org/tools/oracles)
+- [Oracles](https://docs.base.org/base-chain/tools/oracles)
 - [Supra dVRF - Developer Guide V2](https://supraoracles.com/docs/vrf/v2-guide)

--- a/docs/learn/imports/imports-exercise.mdx
+++ b/docs/learn/imports/imports-exercise.mdx
@@ -74,7 +74,7 @@ To simplify the verification of your contract on a blockchain explorer like Base
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/inheritance/inheritance-exercise.mdx
+++ b/docs/learn/inheritance/inheritance-exercise.mdx
@@ -101,7 +101,7 @@ contract InheritanceSubmission {
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/mappings/mappings-exercise.mdx
+++ b/docs/learn/mappings/mappings-exercise.mdx
@@ -57,7 +57,7 @@ Add a function called `resetUserFavorites` that resets `userFavorites` for the s
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/new-keyword/new-keyword-exercise.mdx
+++ b/docs/learn/new-keyword/new-keyword-exercise.mdx
@@ -76,7 +76,7 @@ The `AddressBookFactory` contains one function, `deploy`. It creates an instance
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-biconomy.mdx
+++ b/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-biconomy.mdx
@@ -38,11 +38,11 @@ This tutorial requires you to have a wallet. You can create a wallet by download
 
 ### Wallet funds
 
-To complete this tutorial, you will need to fund a wallet with ETH on Base Goerli.
+To complete this tutorial, you will need to fund a wallet with ETH on Base Sepolia.
 
 The ETH is required for covering gas fees associated with deploying smart contracts to the network.
 
-- To fund your wallet with ETH on Base Goerli, visit a faucet listed on the [Base Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
+- To fund your wallet with ETH on Base Sepolia, visit a faucet listed on the [Base Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
 
 ## What is Biconomy?
 
@@ -151,20 +151,20 @@ cast wallet list
 To deploy the smart contract, you can use the `forge create` command. The command requires you to specify the smart contract you want to deploy, an RPC URL of the network you want to deploy to, and the account you want to deploy with.
 
 <Info>
-Your wallet must be funded with ETH on the Base Goerli testnet to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
+Your wallet must be funded with ETH on the Base Sepolia testnet to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
 
 To get testnet ETH, see the [prerequisites](#prerequisites).
 </Info>
 
-To deploy the smart contract to the Base Goerli testnet, run the following command:
+To deploy the smart contract to the Base Sepolia testnet, run the following command:
 
 ```bash
-forge create ./src/Counter.sol:Counter --rpc-url https://goerli.base.org --account deployer
+forge create ./src/Counter.sol:Counter --rpc-url https://sepolia.base.org --account deployer
 ```
 
 When prompted, enter the password that you set earlier, when you imported your wallet's private key.
 
-After running the command above, the contract will be deployed on the Base Goerli test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
+After running the command above, the contract will be deployed on the Base Sepolia test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
 
 ## Setting up the Paymaster and Bundler
 
@@ -177,7 +177,7 @@ Add and register a Paymaster by completing the following steps:
 1. Visit the sign in to the [Biconomy Dashboard](https://dashboard.biconomy.io/)
 1. From the dashboard, select the **Paymasters** tab and click **Add your first Paymaster**
 1. Provide a **Name** for your paymaster
-1. Select **Base Goerli** from the **Network** dropdown
+1. Select **Base Sepolia** from the **Network** dropdown
 1. Click **Register**
 
 You should now have a registered Biconomy paymaster.
@@ -217,7 +217,7 @@ Set up and fund the paymaster's gas tank by completing the following steps:
 1. From the dashboard, select the **Bundlers** tab
 
 <Info>
-At the time of writing this tutorial, the Bundler service is still under development, however a **Bundler URL** is provided for testing out UserOperations on test networks. You can specify the chain ID **84531** to use the Bundler URL on **Base Goerli** testnet.
+At the time of writing this tutorial, the Bundler service is still under development, however a **Bundler URL** is provided for testing out UserOperations on test networks. You can specify the chain ID **84531** to use the Bundler URL on **Base Sepolia** testnet.
 </Info>
 
 ## Setting up the frontend

--- a/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-privy-and-the-base-paymaster.mdx
+++ b/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-privy-and-the-base-paymaster.mdx
@@ -411,7 +411,7 @@ This address is the [bundler], which is a special node that bundles user operati
 
 #### EntryPoint
 
-The EntryPoint contract for Base Goerli is located at `0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789`. Strangely, in your transaction receipt you'll see that the transaction includes a transfer of ETH **from** the EntryPoint **to** the bundler. This transaction is how the bundler gets compensated for performing the service of bundling user ops and turning them into transactions -- the EntryPoint calculates the gas used by user ops and multiplies that by the fee percentage and send it to the bundler.
+The EntryPoint contract for Base Sepolia is located at `0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789`. Strangely, in your transaction receipt you'll see that the transaction includes a transfer of ETH **from** the EntryPoint **to** the bundler. This transaction is how the bundler gets compensated for performing the service of bundling user ops and turning them into transactions -- the EntryPoint calculates the gas used by user ops and multiplies that by the fee percentage and send it to the bundler.
 
 ### Review the Example Code
 
@@ -425,7 +425,7 @@ Starting on line 63, the exported `SmartAccountProvider` does the following:
 
 1. Fetch the user's wallets and find their Privy wallet. This wallet is provided, and if need be created, by the `PrivyProvider`
 1. Set up state variables to manage and share connection status and the smart account itself
-1. Initialize an RPC client for the [Base Paymaster] (on Goerli). The URL is hardcoded in `lib/constants.ts`
+1. Initialize an RPC client for the [Base Paymaster] (on Sepolia). The URL is hardcoded in `lib/constants.ts`
 1. Initialize an ERC-4337 RPC client for Alchemy's network. This network is where the bundler address comes from
 1. Create a smart wallet. In this case, the `signer` is your EOA embedded wallet created by Privy and fetched in the first step
 1. The EOA address is displayed in the example app as `YOUR SIGNER ADDRESS`
@@ -456,13 +456,13 @@ When a user clicks, the app first creates a viem `RpcTransactionRequest` for the
 }
 ```
 
-The app then updates the toast component to update the users while it `await`s first the `userOpHash`, then the `transactionHash`, indicating that transaction has completed successfully. It then updates the link in the toast to send the user to that transaction on Goerli BaseScan.
+The app then updates the toast component to update the users while it `await`s first the `userOpHash`, then the `transactionHash`, indicating that transaction has completed successfully. It then updates the link in the toast to send the user to that transaction on Sepolia BaseScan.
 
 ### Implementing the Paymaster in your own App
 
 Create a new project using Privy's [`create-next-app`] template, and complete the setup instructions in the readme.
 
-Add an environment variable for `NEXT_PUBLIC_ALCHEMY_API_KEY` and paste in the an API key for a Base Goerli app. If you need a key, go to [add an app] and create a new one.
+Add an environment variable for `NEXT_PUBLIC_ALCHEMY_API_KEY` and paste in the an API key for a Base Sepolia app. If you need a key, go to [add an app] and create a new one.
 
 #### Copying and Updating the Source Files
 
@@ -514,7 +514,7 @@ useEffect(() => {
 
 #### Configuring the PrivyProvider and Adding SmartAccountProvider
 
-By default, the `PrivyProvider` allows logging in with a wallet or email address. To limit it to only the wallet, update the config. You can also set the default chain here. You'll need to import `baseGoerli` to do so.
+By default, the `PrivyProvider` allows logging in with a wallet or email address. To limit it to only the wallet, update the config. You can also set the default chain here. You'll need to import `baseSepolia` to do so.
 
 You also need to import and wrap the app with `SmartAccountProvider`, imported from `hooks/SmartAccountContext.tsx`.
 
@@ -534,7 +534,7 @@ Its instance type 'SmartAccountProvider<Transport>' is not a valid JSX element.
   onSuccess={() => router.push('/dashboard')}
   config={{
     loginMethods: ['wallet'],
-    defaultChain: baseGoerli,
+    defaultChain: baseSepolia,
   }}
 >
   <SmartAccountProvider>
@@ -553,7 +553,7 @@ Grab the snippet from the original demo that displays the user's addresses, and 
 </p>
 <a
   className="mt-2 text-sm text-zinc-500 hover:text-violet-600"
-  href={`${BASE_GOERLI_SCAN_URL}/address/${smartAccountAddress}#tokentxnsErc721`}
+  href={`${BASE_SEPOLIA_SCAN_URL}/address/${smartAccountAddress}#tokentxnsErc721`}
 >
   {smartAccountAddress}
 </a>
@@ -562,7 +562,7 @@ Grab the snippet from the original demo that displays the user's addresses, and 
 </p>
 <a
   className="mt-2 text-sm text-zinc-500 hover:text-violet-600"
-  href={`${BASE_GOERLI_SCAN_URL}/address/${eoa?.address}`}
+  href={`${BASE_SEPOLIA_SCAN_URL}/address/${eoa?.address}`}
 >
   {eoa?.address}
 </a>
@@ -570,7 +570,7 @@ Grab the snippet from the original demo that displays the user's addresses, and 
 
 Paste it above the `<p>` for the `User Object` window.
 
-You'll need to import `BASE_GOERLI_SCAN_URL` from `constants.ts`. The `useSmartAccount` hook returns `smartAccountProvider` and `eoa`. Import it and add it under the `usePrivy` hook. You don't need them just yet, but go ahead and decompose `smartAccountProvider` and `sendSponsoredUserOperation` as well:
+You'll need to import `BASE_SEPOLIA_SCAN_URL` from `constants.ts`. The `useSmartAccount` hook returns `smartAccountProvider` and `eoa`. Import it and add it under the `usePrivy` hook. You don't need them just yet, but go ahead and decompose `smartAccountProvider` and `sendSponsoredUserOperation` as well:
 
 ```tsx
 const router = useRouter();
@@ -604,7 +604,7 @@ The app sometimes gets confused with login state after you've made changes to `c
 
 #### Calling a Smart Contract Function
 
-You've adjusted the foundation of the app to allow you to use the Base Goerli Paymaster with your normal wallet as the signer. Now, it's time to call a smart contract function.
+You've adjusted the foundation of the app to allow you to use the Base Sepolia Paymaster with your normal wallet as the signer. Now, it's time to call a smart contract function.
 
 Start by using the `mint` function in the original example. In the `DashboardPage` component, add a state variable holding an empty element:
 
@@ -639,7 +639,7 @@ const onMint = async () => {
     const transactionHash = await smartAccountProvider.waitForUserOperationTransaction(userOpHash);
 
     setTransactionLink(
-      <a href={`${BASE_GOERLI_SCAN_URL}/tx/${transactionHash}`}>
+      <a href={`${BASE_SEPOLIA_SCAN_URL}/tx/${transactionHash}`}>
         Successfully minted! Click here to see your transaction.
       </a>,
     );
@@ -672,7 +672,7 @@ For simplicity, we've stripped out the code to disable the button while it is mi
 
 #### Calling Another Function
 
-The [Base Paymaster] on Goerli is very permissive. To call another function, all you need to do is to change the `RpcTransactionRequest` in `sendSponsoredUserOperation` to match the address, abi, function name, and arguments of your function on your smart contract.
+The [Base Paymaster] on Sepolia is very permissive. To call another function, all you need to do is to change the `RpcTransactionRequest` in `sendSponsoredUserOperation` to match the address, abi, function name, and arguments of your function on your smart contract.
 
 For example, to call the `claim` function in the Weighted Voting contract we've used in other tutorials, you'd simply need to import the Hardhat-style [artifact] for the contract and use it to call the function:
 
@@ -712,8 +712,8 @@ In this article, we've explored the transformative potential of Account Abstract
 [securely stored]: https://docs.privy.io/guide/security#user-data-management
 [paymaster example]: https://github.com/privy-io/base-paymaster-example/blob/main/README.md
 [ERC-4337]: https://eips.ethereum.org/EIPS/eip-4337
-[NFT Contract]: https://goerli.basescan.org/address/0x6527e5052de5521fe370ae5ec0afcc6cd5a221de
-[view for the contract itself]: https://goerli.basescan.org/address/0x6527e5052de5521fe370ae5ec0afcc6cd5a221de
+[NFT Contract]: https://sepolia.basescan.org/address/0x6527e5052de5521fe370ae5ec0afcc6cd5a221de
+[view for the contract itself]: https://sepolia.basescan.org/address/0x6527e5052de5521fe370ae5ec0afcc6cd5a221de
 [Base Paymaster]: https://github.com/base-org/paymaster
 [EntryPoint]: https://github.com/eth-infinitism/account-abstraction/releases
 [bundler]: https://www.alchemy.com/overviews/what-is-a-bundler

--- a/docs/learn/onchain-app-development/account-abstraction/gasless-transactions-with-paymaster.mdx
+++ b/docs/learn/onchain-app-development/account-abstraction/gasless-transactions-with-paymaster.mdx
@@ -31,7 +31,7 @@ This tutorial assumes you have:
    Foundry is a development environment, testing framework, and smart contract toolkit for Ethereum. You’ll need it installed locally for generating key pairs and interacting with smart contracts.
 
 > **Testnet vs. Mainnet**  
-> If you prefer not to spend real funds, you can switch to **Base Goerli** (testnet). The steps below are conceptually the same. Just select _Base Goerli_ in the Coinbase Developer Platform instead of _Base Mainnet_, and use a contract deployed on Base testnet for your allowlisted methods.
+> If you prefer not to spend real funds, you can switch to **Base Sepolia** (testnet). The steps below are conceptually the same. Just select _Base Sepolia_ in the Coinbase Developer Platform instead of _Base Mainnet_, and use a contract deployed on Base testnet for your allowlisted methods.
 
 ## Set Up a Base Paymaster & Bundler
 
@@ -55,7 +55,7 @@ In this section, you will configure a Paymaster to sponsor payments on behalf of
 
 ### Allowlist a Sponsorable Contract
 
-1. From the Configuration page, ensure **Base Mainnet** (or **Base Goerli** if you’re testing) is selected.
+1. From the Configuration page, ensure **Base Mainnet** (or **Base Sepolia** if you’re testing) is selected.
 2. Enable your paymaster by clicking the toggle button.
 3. Click **Add** to add an allowlisted contract.
 4. For this example, add [`0x83bd615eb93eE1336acA53e185b03B54fF4A17e8`][simple NFT contract], and add the function `mintTo(address)`.

--- a/docs/learn/onchain-app-development/cross-chain/send-messages-and-tokens-from-base-chainlink.mdx
+++ b/docs/learn/onchain-app-development/cross-chain/send-messages-and-tokens-from-base-chainlink.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sending messages and tokens from Base to other chains using Chainlink CCIP
-description: A tutorial that teaches how to use Chainlink CCIP to perform cross-chain messaging and token transfers from Base Goerli testnet to Optimism Goerli testnet.
+description: A tutorial that teaches how to use Chainlink CCIP to perform cross-chain messaging and token transfers from Base Sepolia testnet to Optimism Sepolia testnet.
 authors:
   - taycaldwell
 tags: ['cross-chain']
@@ -43,13 +43,13 @@ In order to deploy a smart contract, you will first need a wallet. You can creat
 
 ### Wallet funds
 
-For this tutorial you will need to fund your wallet with both ETH and LINK on Base Goerli and Optimism Goerli.
+For this tutorial you will need to fund your wallet with both ETH and LINK on Base Sepolia and Optimism Sepolia.
 
 The ETH is required for covering gas fees associated with deploying smart contracts to the blockchain, and the LINK token is required to pay for associated fees when using CCIP.
 
-- To fund your wallet with ETH on Base Goerli, visit a faucet listed on the [Base Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
-- To fund your wallet with ETH on Optimism Goerli, visit a faucet listed on the [Optimism Faucets](https://docs.optimism.io/builders/tools/faucets) page.
-- To fund your wallet with LINK, visit the [Chainlink Faucet](https://faucets.chain.link/base-testnet).
+- To fund your wallet with ETH on Base Sepolia, visit a faucet listed on the [Base Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
+- To fund your wallet with ETH on Optimism Sepolia, visit a faucet listed on the [Optimism Faucets](https://docs.optimism.io/builders/tools/faucets) page.
+- To fund your wallet with LINK, visit the [Chainlink Faucet](https://faucets.chain.link/base-sepolia).
 
 <Warning>
 If you are interested in building on Mainnet, you will need to [apply for Chainlink CCIP mainnet access](https://chainlinkcommunity.typeform.com/ccip-form?#ref_id=ccip_docs).
@@ -468,20 +468,20 @@ cast wallet list
 
 ### Setting up environment variables
 
-To setup your environment, create an `.env` file in the home directory of your project, and add the RPC URLs, [CCIP chain selectors](https://docs.chain.link/ccip/supported-networks/v1_2_0/testnet), [CCIP router addresses](https://docs.chain.link/ccip/supported-networks/v1_2_0/testnet), and [LINK token addresses](https://docs.chain.link/resources/link-token-contracts) for both Base Goerli and Optimism Goerli testnets:
+To setup your environment, create an `.env` file in the home directory of your project, and add the RPC URLs, [CCIP chain selectors](https://docs.chain.link/ccip/supported-networks/v1_2_0/testnet), [CCIP router addresses](https://docs.chain.link/ccip/supported-networks/v1_2_0/testnet), and [LINK token addresses](https://docs.chain.link/resources/link-token-contracts) for both Base Sepolia and Optimism Sepolia testnets:
 
 ```bash
-BASE_GOERLI_RPC="https://goerli.base.org"
-OPTIMISM_GOERLI_RPC="https://goerli.optimism.io"
+BASE_SEPOLIA_RPC="https://sepolia.base.org"
+OPTIMISM_SEPOLIA_RPC="https://sepolia.optimism.io"
 
-BASE_GOERLI_CHAIN_SELECTOR=5790810961207155433
-OPTIMISM_GOERLI_CHAIN_SELECTOR=2664363617261496610
+BASE_SEPOLIA_CHAIN_SELECTOR=5790810961207155433
+OPTIMISM_SEPOLIA_CHAIN_SELECTOR=2664363617261496610
 
-BASE_GOERLI_ROUTER_ADDRESS="0x80AF2F44ed0469018922c9F483dc5A909862fdc2"
-OPTIMISM_GOERLI_ROUTER_ADDRESS="0xcc5a0B910D9E9504A7561934bed294c51285a78D"
+BASE_SEPOLIA_ROUTER_ADDRESS="0x80AF2F44ed0469018922c9F483dc5A909862fdc2"
+OPTIMISM_SEPOLIA_ROUTER_ADDRESS="0xcc5a0B910D9E9504A7561934bed294c51285a78D"
 
-BASE_GOERLI_LINK_ADDRESS="0x6D0F8D488B669aa9BA2D0f0b7B75a88bf5051CD3"
-OPTIMISM_GOERLI_LINK_ADDRESS="0xdc2CC710e42857672E7907CF474a69B63B93089f"
+BASE_SEPOLIA_LINK_ADDRESS="0x6D0F8D488B669aa9BA2D0f0b7B75a88bf5051CD3"
+OPTIMISM_SEPOLIA_LINK_ADDRESS="0xdc2CC710e42857672E7907CF474a69B63B93089f"
 ```
 
 Once the `.env` file has been created, run the following command to load the environment variables in the current command line session:
@@ -497,34 +497,34 @@ With your contracts compiled and environment setup, you are ready to deploy the 
 To deploy a smart contract using Foundry, you can use the `forge create` command. The command requires you to specify the smart contract you want to deploy, an RPC URL of the network you want to deploy to, and the account you want to deploy with.
 
 <Info>
-Your wallet must be funded with ETH on the Base Goerli and Optimism Goerli to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
+Your wallet must be funded with ETH on the Base Sepolia and Optimism Sepolia to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
 
-To get testnet ETH for Base Goerli and Optimism Goerli, see the [prerequisites](#prerequisites).
+To get testnet ETH for Base Sepolia and Optimism Sepolia, see the [prerequisites](#prerequisites).
 </Info>
 
-#### Deploying the Sender contract to Base Goerli
+#### Deploying the Sender contract to Base Sepolia
 
-To deploy the `Sender` smart contract to the Base Goerli testnet, run the following command:
+To deploy the `Sender` smart contract to the Base Sepolia testnet, run the following command:
 
 ```bash
-forge create ./src/Sender.sol:Sender --rpc-url $BASE_GOERLI_RPC --constructor-args $BASE_GOERLI_ROUTER_ADDRESS $BASE_GOERLI_LINK_ADDRESS --account deployer
+forge create ./src/Sender.sol:Sender --rpc-url $BASE_SEPOLIA_RPC --constructor-args $BASE_SEPOLIA_ROUTER_ADDRESS $BASE_SEPOLIA_LINK_ADDRESS --account deployer
 ```
 
 When prompted, enter the password that you set earlier, when you imported your wallet's private key.
 
-After running the command above, the contract will be deployed on the Base Goerli test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
+After running the command above, the contract will be deployed on the Base Sepolia test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
 
-#### Deploying the Receiver contract to Optimism Goerli
+#### Deploying the Receiver contract to Optimism Sepolia
 
-To deploy the `Receiver` smart contract to the Optimism Goerli testnet, run the following command:
+To deploy the `Receiver` smart contract to the Optimism Sepolia testnet, run the following command:
 
 ```bash
-forge create ./src/Receiver.sol:Receiver --rpc-url $OPTIMISM_GOERLI_RPC --constructor-args $OPTIMISM_GOERLI_ROUTER_ADDRESS --account deployer
+forge create ./src/Receiver.sol:Receiver --rpc-url $OPTIMISM_SEPOLIA_RPC --constructor-args $OPTIMISM_SEPOLIA_ROUTER_ADDRESS --account deployer
 ```
 
 When prompted, enter the password that you set earlier, when you imported your wallet's private key.
 
-After running the command above, the contract will be deployed on the Optimism Goerli test network. You can view the deployment status and contract by using the [OP Goerli block explorer](https://goerli-optimism.etherscan.io/).
+After running the command above, the contract will be deployed on the Optimism Sepolia test network. You can view the deployment status and contract by using the [OP Sepolia block explorer](https://sepolia-optimism.etherscan.io/).
 
 ### Funding your smart contracts
 
@@ -533,10 +533,10 @@ In order to pay for the fees associated with sending messages, the `Sender` cont
 Fund your contract directly from your wallet, or by running the following `cast` command:
 
 ```bash
-cast send $BASE_GOERLI_LINK_ADDRESS --rpc-url $BASE_GOERLI_RPC "transfer(address,uint256)" `SENDER_CONTRACT_ADDRESS` 5 --account deployer
+cast send $BASE_SEPOLIA_LINK_ADDRESS --rpc-url $BASE_SEPOLIA_RPC "transfer(address,uint256)" `SENDER_CONTRACT_ADDRESS` 5 --account deployer
 ```
 
-The above command sends `5` LINK tokens on Base Goerli testnet to the `Sender` contract.
+The above command sends `5` LINK tokens on Base Sepolia testnet to the `Sender` contract.
 
 <Info>
 Replace `SENDER_CONTRACT_ADDRESS` with the contract address of your deployed Sender contract before running the provided cast command.
@@ -548,15 +548,15 @@ Foundry provides the `cast` command-line tool that can be used to interact with 
 
 ### Sending data
 
-The `cast` command can be used to call the `sendMessage(uint64, address, string)` function on the `Sender` contract deployed to Base Goerli in order to send message data to the `Receiver` contract on Optimism Goerli.
+The `cast` command can be used to call the `sendMessage(uint64, address, string)` function on the `Sender` contract deployed to Base Sepolia in order to send message data to the `Receiver` contract on Optimism Sepolia.
 
 To call the `sendMessage(uint64, address, string)` function of the `Sender` smart contract, run:
 
 ```bash
-cast send `SENDER_CONTRACT_ADDRESS` --rpc-url $BASE_GOERLI_RPC "sendMessage(uint64, address, string)" $OPTIMISM_GOERLI_CHAIN_SELECTOR `RECEIVER_CONTRACT_ADDRESS` "Based" --account deployer
+cast send `SENDER_CONTRACT_ADDRESS` --rpc-url $BASE_SEPOLIA_RPC "sendMessage(uint64, address, string)" $OPTIMISM_SEPOLIA_CHAIN_SELECTOR `RECEIVER_CONTRACT_ADDRESS` "Based" --account deployer
 ```
 
-The command above calls the `sendMessage(uint64, address, string)` to send a message. The parameters passed in to the method include: The chain selector to the destination chain (Optimism Goerli), the `Receiver` contract address, and the text data to be included in the message (`Based`).
+The command above calls the `sendMessage(uint64, address, string)` to send a message. The parameters passed in to the method include: The chain selector to the destination chain (Optimism Sepolia), the `Receiver` contract address, and the text data to be included in the message (`Based`).
 
 <Info>
 Replace `SENDER_CONTRACT_ADDRESS` and `RECEIVER_CONTRACT_ADDRESS` with the contract addresses of your deployed Sender and Receiver contracts respectively before running the provided cast command.
@@ -564,7 +564,7 @@ Replace `SENDER_CONTRACT_ADDRESS` and `RECEIVER_CONTRACT_ADDRESS` with the contr
 
 After running the command, a unique `messageId` should be returned.
 
-Once the transaction has been finalized, it will take a few minutes for CCIP to deliver the data to Optimism Goerli and call the `ccipReceive` function on the `Receiver` contract.
+Once the transaction has been finalized, it will take a few minutes for CCIP to deliver the data to Optimism Sepolia and call the `ccipReceive` function on the `Receiver` contract.
 
 <Info>
 You can use the [CCIP explorer](https://ccip.chain.link/) to see the status of the CCIP transaction.
@@ -572,12 +572,12 @@ You can use the [CCIP explorer](https://ccip.chain.link/) to see the status of t
 
 ### Receiving data
 
-The `cast` command can also be used to call the `getMessage()` function on the `Receiver` contract deployed to Optimism Goerli in order to read the received message data.
+The `cast` command can also be used to call the `getMessage()` function on the `Receiver` contract deployed to Optimism Sepolia in order to read the received message data.
 
 To call the `getMessage()` function of the `Receiver` smart contract, run:
 
 ```bash
-cast send `RECEIVER_CONTRACT_ADDRESS` --rpc-url $OPTIMISM_GOERLI_RPC "getMessage()" --account deployer
+cast send `RECEIVER_CONTRACT_ADDRESS` --rpc-url $OPTIMISM_SEPOLIA_RPC "getMessage()" --account deployer
 ```
 
 <Info>

--- a/docs/learn/onchain-app-development/finance/access-real-world-data-chainlink.mdx
+++ b/docs/learn/onchain-app-development/finance/access-real-world-data-chainlink.mdx
@@ -39,7 +39,7 @@ In order to deploy a smart contract, you will first need a wallet. You can creat
 
 Deploying contracts to the blockchain requires a gas fee. Therefore, you will need to fund your wallet with ETH to cover those gas fees.
 
-For this tutorial, you will be deploying a contract to the Base Goerli test network. You can fund your wallet with Base Goerli ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
+For this tutorial, you will be deploying a contract to the Base Sepolia test network. You can fund your wallet with Base Sepolia ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
 
 ## What are Chainlink Data Feeds?
 
@@ -99,7 +99,7 @@ Once your project has been created and dependencies have been installed, you can
 
 The Solidity code below defines a smart contract named `DataConsumerV3`. The code uses the `AggregatorV3Interface` interface from the [Chainlink contracts library](https://docs.chain.link/data-feeds/api-reference#aggregatorv3interface) to provide access to price feed data.
 
-The smart contract passes an address to `AggregatorV3Interface`. This address (`0xcD2A119bD1F7DF95d706DE6F2057fDD45A0503E2`) corresponds to the `ETH/USD` price feed on the Base Goerli network.
+The smart contract passes an address to `AggregatorV3Interface`. This address (`0xcD2A119bD1F7DF95d706DE6F2057fDD45A0503E2`) corresponds to the `ETH/USD` price feed on the Base Sepolia network.
 
 <Info>
 Chainlink provides a number of price feeds for Base. For a list of available price feeds on Base, visit the [Chainlink documentation](https://docs.chain.link/data-feeds/price-feeds/addresses/?network=base&page=1).
@@ -115,7 +115,7 @@ Chainlink provides a number of price feeds for Base. For a list of available pri
        AggregatorV3Interface internal priceFeed;
 
       /**
-       * Network: Base Goerli
+       * Network: Base Sepolia
        * Aggregator: ETH/USD
        * Address: 0xcD2A119bD1F7DF95d706DE6F2057fDD45A0503E2
        */
@@ -170,12 +170,12 @@ To confirm that the wallet was imported as the `deployer` account in your Foundr
 cast wallet list
 ```
 
-### Setting up environment variables for Base Goerli
+### Setting up environment variables for Base Sepolia
 
-To setup your environment for deploying to the Base network, create an `.env` file in the home directory of your project, and add the RPC URL for the Base Goerli testnet:
+To setup your environment for deploying to the Base network, create an `.env` file in the home directory of your project, and add the RPC URL for the Base Sepolia testnet:
 
 ```
-BASE_GOERLI_RPC="https://goerli.base.org"
+BASE_SEPOLIA_RPC="https://sepolia.base.org"
 ```
 
 Once the `.env` file has been created, run the following command to load the environment variables in the current command line session:
@@ -184,27 +184,27 @@ Once the `.env` file has been created, run the following command to load the env
 source .env
 ```
 
-### Deploying the smart contract to Base Goerli
+### Deploying the smart contract to Base Sepolia
 
-With your contract compiled and environment setup, you are ready to deploy the smart contract to the Base Goerli Testnet!
+With your contract compiled and environment setup, you are ready to deploy the smart contract to the Base Sepolia Testnet!
 
 For deploying a single smart contract using Foundry, you can use the `forge create` command. The command requires you to specify the smart contract you want to deploy, an RPC URL of the network you want to deploy to, and the account you want to deploy with.
 
-To deploy the `DataConsumerV3` smart contract to the Base Goerli test network, run the following command:
+To deploy the `DataConsumerV3` smart contract to the Base Sepolia test network, run the following command:
 
 ```bash
-forge create ./src/DataConsumerV3.sol:DataConsumerV3 --rpc-url $BASE_GOERLI_RPC --account deployer
+forge create ./src/DataConsumerV3.sol:DataConsumerV3 --rpc-url $BASE_SEPOLIA_RPC --account deployer
 ```
 
 When prompted, enter the password that you set earlier, when you imported your wallet's private key.
 
 <Info>
-Your wallet must be funded with ETH on the Base Goerli Testnet to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
+Your wallet must be funded with ETH on the Base Sepolia Testnet to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
 
-To get testnet ETH for Base Goerli, see the [prerequisites](#prerequisites).
+To get testnet ETH for Base Sepolia, see the [prerequisites](#prerequisites).
 </Info>
 
-After running the command above, the contract will be deployed on the Base Goerli test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
+After running the command above, the contract will be deployed on the Base Sepolia test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
 
 ## Interacting with the Smart Contract
 
@@ -213,7 +213,7 @@ Foundry provides the `cast` command-line tool that can be used to interact with 
 To call the `getLatestPrice()` function of the smart contract, run:
 
 ```bash
-cast call <DEPLOYED_ADDRESS> --rpc-url $BASE_GOERLI_RPC "getLatestPrice()"
+cast call <DEPLOYED_ADDRESS> --rpc-url $BASE_SEPOLIA_RPC "getLatestPrice()"
 ```
 
 You should receive the latest `ETH / USD` price in hexadecimal form.

--- a/docs/learn/storage/storage-exercise.mdx
+++ b/docs/learn/storage/storage-exercise.mdx
@@ -101,7 +101,7 @@ function debugResetShares() public {
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/structs/structs-exercise.mdx
+++ b/docs/learn/structs/structs-exercise.mdx
@@ -61,7 +61,7 @@ Add a public function called `resetMyGarage`. It should delete the entry in `gar
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/token-development/erc-20-token/erc-20-exercise.mdx
+++ b/docs/learn/token-development/erc-20-token/erc-20-exercise.mdx
@@ -101,7 +101,7 @@ If this vote takes the total number of votes to or above the `quorum` for that v
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/token-development/erc-721-token/erc-721-exercise.mdx
+++ b/docs/learn/token-development/erc-721-token/erc-721-exercise.mdx
@@ -70,7 +70,7 @@ The contract specification contains actions that can only be performed once by a
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](../deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](../deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/token-development/minimal-tokens/minimal-tokens-exercise.mdx
+++ b/docs/learn/token-development/minimal-tokens/minimal-tokens-exercise.mdx
@@ -48,7 +48,7 @@ A failure of either of these checks should result in a revert with an `UnsafeTra
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://blog.base.org/goerli-to-sepolia-evolving-bases-testnet-infrastructure), in favor of Base Sepolia.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 

--- a/docs/learn/token-development/nft-guides/signature-mint.mdx
+++ b/docs/learn/token-development/nft-guides/signature-mint.mdx
@@ -363,7 +363,7 @@ In this tutorial, you've learned how to create a signature mint, which allows yo
 [ERC-721 Tokens]: https://docs.base.org/base-learn/docs/erc-721-token/erc-721-standard-video
 [Vercel]: https://vercel.com
 [deploying with Vercel]: /tutorials/farcaster-frames-deploy-to-vercel
-[OpenZeppelin ERC-721]: https://docs.openzeppelin.com/contracts/2.x/api/token/erc721
+[OpenZeppelin ERC-721]: https://docs.openzeppelin.com/contracts/5.x/erc721#constructing-an-erc-721-token-contract
 [Pinata]: https://www.pinata.cloud/
 [ERC-191]: https://eips.ethereum.org/EIPS/eip-191
 [EIP-712]: https://eips.ethereum.org/EIPS/eip-712

--- a/docs/learn/token-development/nft-guides/thirdweb-unreal-nft-items.mdx
+++ b/docs/learn/token-development/nft-guides/thirdweb-unreal-nft-items.mdx
@@ -617,19 +617,19 @@ In this tutorial, you've learned how to set up Thirdweb's engine and use it to c
 
 [Base Learn]: https://docs.base.org/learn/welcome
 [ERC-721 Tokens]: https://docs.base.org/learn/erc-721-token/erc-721-standard-video
-[OpenZeppelin ERC-721]: https://docs.openzeppelin.com/contracts/2.x/api/token/erc721
+[OpenZeppelin ERC-721]: https://docs.openzeppelin.com/contracts/5.x/erc721#constructing-an-erc-721-token-contract
 [OpenZeppelin]: https://www.openzeppelin.com/
 [Unreal Engine]: https://www.unrealengine.com/en-US
 [thirdweb]: https://thirdweb.com/
-[Gaming SDK]: https://portal.thirdweb.com/solutions/gaming/overview
-[Unreal Engine Quickstart]: https://portal.thirdweb.com/solutions/gaming/unreal-engine/quickstart
+[Gaming SDK]: https://portal.thirdweb.com/unreal-engine
+[Unreal Engine Quickstart]: https://portal.thirdweb.com/unreal-engine
 [contract provided below]: #random-color-nft-contract
 [Engine]: https://github.com/thirdweb-dev/engine
 [run it locally]: https://portal.thirdweb.com/engine/self-host
 [Docker]: https://www.docker.com/
 [Postgres]: https://www.postgresql.org/
 [thirdweb API key]: https://thirdweb.com/dashboard/settings/api-keys
-[environment variables]: https://portal.thirdweb.com/engine/self-host#environment-variables
+[environment variables]: https://portal.thirdweb.com/engine/v2/self-host#environment-variables
 [engine-express]: https://github.com/thirdweb-example/engine-express
 [Token Drop]: https://thirdweb.com/thirdweb.eth/DropERC20
 [Unreal Demo]: https://github.com/thirdweb-example/unreal_demo

--- a/docs/mini-apps/resources/templates.mdx
+++ b/docs/mini-apps/resources/templates.mdx
@@ -71,7 +71,7 @@ Production-ready code repositories that you can clone and deploy immediately.
  <Card 
     title="Full Mini Demo" 
     icon="github" 
-    href="https://github.com/base/demos/tree/master/minikit/mini-app-full-demo"
+    href="https://github.com/base/demos/tree/master/mini-apps/templates/minikit/mini-app-full-demo-minikit"
   >
     A comprehensive showcase demonstrating the complete range of MiniKit capabilities and Base ecosystem integrations.
   </Card>


### PR DESCRIPTION
**What changed? Why?**
This PR updates all remaining references from **Base Goerli** to **Base Sepolia** across the documentation and fixes several outdated or broken links.  
All content now aligns with the current **Base Sepolia testnet** infrastructure and the latest official resource URLs.

## Changes
- Replaced all `Goerli` and `GOERLI` references with `Sepolia` and `SEPOLIA` in relevant guides.  
- Updated Base Goerli → Base Sepolia examples in code snippets, `.env` variables, and faucet instructions.  
- Replaced deprecated **Mirror** blog links (`base.mirror.xyz/...`) with the new **Base Blog** URLs (`blog.base.org/...`).  
- Fixed incorrect or outdated documentation links:  
  - `https://docs.xmtp.org/agents` → `https://docs.xmtp.org/agents/get-started/build-an-agent`  
  - Old Metamask testnet config link → updated support article  
  - Oracles docs updated to `/base-chain/tools/oracles`  
  - Outdated OpenZeppelin v2.x docs → v5.x canonical URLs  
- Fixed a malformed **Study Hall Creative** link (removed stray `%20`).  
- Updated example repository references (e.g., MiniKit demo path under `/mini-apps/templates/`).  

---
## Context
These changes ensure all learning materials, code samples, and resource links reflect the migration from **Goerli → Sepolia** as outlined.
## Notes
All required Goerli → Sepolia conversions have been applied consistently across the entire `/docs` directory, including environment variables, faucet URLs, and testnet deployment guides.
**Notes to reviewers**

**How has it been tested?**
