### PR TITLE
Added comments for GetAttestationOptions for 0.38.x

### DIFF
--- a/docs/onchainkit/identity/types.mdx
+++ b/docs/onchainkit/identity/types.mdx
@@ -115,10 +115,10 @@ type GetAddressReturnType = Address | null;
 
 ```ts
 type GetAttestationsOptions = {
-  schemas?: EASSchemaUid[];
-  revoked?: boolean;
-  expirationTime?: number;
-  limit?: number;
+  schemas?: EASSchemaUid[]; // Array of schema UIDs to filter by
+  revoked?: boolean; // Filter by revocation status
+  expirationTime?: number; // Filter by expiration time
+  limit?: number; // Limit number of results
 };
 ```
 


### PR DESCRIPTION
**What changed? Why?**

These doc comments were in the latest docs, but this type was copied and didn't have the comment strings. Porting these to the older version of this doc.

**Notes to reviewers**

**How has it been tested?**
1. `npx mint dev`
2. Change version selection to 0.38.x
3. In the navigation bar under `Types` click on [Identity](http://localhost:3000/onchainkit/identity/types)
4. See that `GetAttestationOptions` is the only type without comments
5. See that comments were back-ported in this commit to 0.38.x from Open http://localhost:3000/onchainkit/latest/utilities/identity/get-attestations