### PR TITLE
update addresses for u16a on Mainnet

### DIFF
--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -65,7 +65,7 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | L1CrossDomainMessenger       | [0x866E82a600A1414e583f7F13623F1aC5d58b0Afa](https://etherscan.io/address/0x866E82a600A1414e583f7F13623F1aC5d58b0Afa) |
 | L1ERC721Bridge               | [0x608d94945A64503E642E6370Ec598e519a2C1E53](https://etherscan.io/address/0x608d94945A64503E642E6370Ec598e519a2C1E53) |
 | L1StandardBridge             | [0x3154Cf16ccdb4C6d922629664174b904d80F2C35](https://etherscan.io/address/0x3154Cf16ccdb4C6d922629664174b904d80F2C35) |
-| MIPS                         | [0xF027F4A985560fb13324e943edf55ad6F1d15Dc1](https://etherscan.io/address/0xF027F4A985560fb13324e943edf55ad6F1d15Dc1) |
+| MIPS                         | [0x07BABE08EE4D07dBA236530183B24055535A7011](https://etherscan.io/address/0x07BABE08EE4D07dBA236530183B24055535A7011) |
 | OptimismMintableERC20Factory | [0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84](https://etherscan.io/address/0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84) |
 | OptimismPortal               | [0x49048044D57e1C92A77f79988d21Fa8fAF74E97e](https://etherscan.io/address/0x49048044D57e1C92A77f79988d21Fa8fAF74E97e) |
 | PermissionedDisputeGame      | [0xe3803582fd5BCdc62720D2b80f35e8dDeA94e2ec](https://etherscan.io/address/0xe3803582fd5BCdc62720D2b80f35e8dDeA94e2ec) |


### PR DESCRIPTION
**What changed? Why?**

This PR updates the docs to reflect the updated addresses following the u16a Mainnet upgrade.