### PR TITLE
docs(get-started): add Mint Club to “Launch a Token” platform list

### DIFF
--- a/docs/get-started/launch-token.mdx
+++ b/docs/get-started/launch-token.mdx
@@ -85,6 +85,21 @@ Flaunch leverages Uniswap V4 to enable programmable revenue splits, automated bu
 
 [Get started with Flaunch →](https://flaunch.gg)
 
+### Mint Club
+**Best for:** Token families and community-driven assets
+
+Mint Club enables anyone to launch new tokens or NFTs backed by existing ERC-20 tokens. Each trade locks the parent token in a bonding curve pool, creating onchain, auto-managed liquidity that strengthens the parent token while supporting new community assets.
+
+**Key Features:**
+- Launch tokens or NFTs from any ERC-20 token
+- Automated liquidity with customizable bonding curves
+- Integrated trading interface with cross-chain swap
+- Built-in airdrop and lock-up tools
+- Simple trading for tokens and NFTs
+- Creator revenue sharing
+
+[Get started with Mint Club →](https://mint.club)
+
 ## Technical Implementation with Foundry
 
 For developers who want full control over their token implementation, here's how to create and deploy a custom ERC-20 token on Base using Foundry.


### PR DESCRIPTION
## What changed?
Adds **Mint Club** to the **Token Launch Platforms on Base** section in the Get Started guide.

- File: `docs/get-started/launch-token.mdx`
- Content: brief description of Mint Club’s bonding-curve–backed token/NFT launches, plus “Get started” links.
- Order: appended after existing platform entries to preserve current structure.

## Why?
To mirror the Cookbook update from PR #158 (merged) and keep the Get Started guide consistent while surfacing an additional community-friendly launch path for Base users.

## Notes to reviewers
- Minimal, text-only addition; no navigation or structural changes.
- Wording/format matches existing entries (headline → short paragraph → key features → external link).
- No other files modified.

## Testing
- Previewed locally; verified headings and links render properly.

## Related
- PR #158 — docs: add Mint Club to token launch platforms on Base
- Links: https://mint.club • https://docs.mint.club