### PR TITLE
chore(CHAIN-2170): update sepolia dispute game addresses

### DIFF
--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -91,7 +91,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | DelayedWETHProxy (FDG)       | [0xd3683e4947A7769603Ab6418eC02f000CE3cF30b](https://sepolia.etherscan.io/address/0xd3683e4947A7769603Ab6418eC02f000CE3cF30b) |
 | DelayedWETHProxy (PDG)       | [0x32cE910d9C6c8F78dc6779c1499aB05F281A054e](https://sepolia.etherscan.io/address/0x32cE910d9C6c8F78dc6779c1499aB05F281A054e) |
 | DisputeGameFactoryProxy      | [0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1](https://sepolia.etherscan.io/address/0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1) |
-| FaultDisputeGame             | [0x32b37BBd2c81e853EA098ce45856aE305Df10dD1](https://sepolia.etherscan.io/address/0x32b37BBd2c81e853EA098ce45856aE305Df10dD1) |
+| FaultDisputeGame             | [0xf83157709129Bd03fB02e96950Be288E8c2c1c67](https://sepolia.etherscan.io/address/0xf83157709129Bd03fB02e96950Be288E8c2c1c67) |
 | L1CrossDomainMessenger       | [0xC34855F4De64F1840e5686e64278da901e261f20](https://sepolia.etherscan.io/address/0xC34855F4De64F1840e5686e64278da901e261f20) |
 | L1ERC721Bridge               | [0x21eFD066e581FA55Ef105170Cc04d74386a09190](https://sepolia.etherscan.io/address/0x21eFD066e581FA55Ef105170Cc04d74386a09190) |
 | L1StandardBridge             | [0xfd0Bf71F60660E2f608ed56e1659C450eB113120](https://sepolia.etherscan.io/address/0xfd0Bf71F60660E2f608ed56e1659C450eB113120) |
@@ -99,7 +99,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | MIPS                         | [0x07BABE08EE4D07dBA236530183B24055535A7011](https://sepolia.etherscan.io/address/0x07BABE08EE4D07dBA236530183B24055535A7011) |
 | OptimismMintableERC20Factory | [0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37](https://sepolia.etherscan.io/address/0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37) |
 | OptimismPortal               | [0x49f53e41452C74589E85cA1677426Ba426459e85](https://sepolia.etherscan.io/address/0x49f53e41452C74589E85cA1677426Ba426459e85) |
-| PermissionedDisputeGame      | [0x217e725700DE4Dc599360aDbd57dbb7DE280817E](https://sepolia.etherscan.io/address/0x217e725700DE4Dc599360aDbd57dbb7DE280817E) |
+| PermissionedDisputeGame      | [0x5920bD6aB4c1b96bFd4Efc56EB6cf9b018e3bF4c](https://sepolia.etherscan.io/address/0x5920bD6aB4c1b96bFd4Efc56EB6cf9b018e3bF4c) |
 | PreimageOracle               | [0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3](https://sepolia.etherscan.io/address/0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3) |
 | ProxyAdmin                   | [0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3](https://sepolia.etherscan.io/address/0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3) |
 | SystemConfig                 | [0xf272670eb55e895584501d564AfEB048bEd26194](https://sepolia.etherscan.io/address/0xf272670eb55e895584501d564AfEB048bEd26194) |
@@ -108,24 +108,24 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 
 ### Base Mainnet
 
-| Admin Role                       | Address                                                                                                               | Type of Key                               |
-| :------------------------------- | :-------------------------------------------------------------------------------------------------------------------- | :---------------------------------------- |
-| Batch Sender                     | [0x5050f69a9786f081509234f1a7f4684b5e5b76c9](https://etherscan.io/address/0x5050f69a9786f081509234f1a7f4684b5e5b76c9) | EOA managed by Coinbase Technologies      |
-| Batch Inbox                      | [0xff00000000000000000000000000000000008453](https://etherscan.io/address/0xff00000000000000000000000000000000008453) | EOA (with no known private key)           |
-| Output Proposer                  | [0x642229f238fb9de03374be34b0ed8d9de80752c5](https://etherscan.io/address/0x642229f238fb9de03374be34b0ed8d9de80752c5) | EOA managed by Coinbase Technologies      |
-| Proxy Admin Owner (L1)           | [0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c](https://etherscan.io/address/0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c) | Gnosis Safe                               |
-| Challenger                       | [0x8Ca1E12404d16373Aef756179B185F27b2994F3a](https://etherscan.io/address/0x8Ca1E12404d16373Aef756179B185F27b2994F3a) | EOA managed by Coinbase Technologies      |
-| System config owner              | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                               |
-| Guardian                         | [0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2](https://etherscan.io/address/0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2) | Gnosis Safe                               |
+| Admin Role             | Address                                                                                                               | Type of Key                          |
+| :--------------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------- |
+| Batch Sender           | [0x5050f69a9786f081509234f1a7f4684b5e5b76c9](https://etherscan.io/address/0x5050f69a9786f081509234f1a7f4684b5e5b76c9) | EOA managed by Coinbase Technologies |
+| Batch Inbox            | [0xff00000000000000000000000000000000008453](https://etherscan.io/address/0xff00000000000000000000000000000000008453) | EOA (with no known private key)      |
+| Output Proposer        | [0x642229f238fb9de03374be34b0ed8d9de80752c5](https://etherscan.io/address/0x642229f238fb9de03374be34b0ed8d9de80752c5) | EOA managed by Coinbase Technologies |
+| Proxy Admin Owner (L1) | [0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c](https://etherscan.io/address/0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c) | Gnosis Safe                          |
+| Challenger             | [0x8Ca1E12404d16373Aef756179B185F27b2994F3a](https://etherscan.io/address/0x8Ca1E12404d16373Aef756179B185F27b2994F3a) | EOA managed by Coinbase Technologies |
+| System config owner    | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                          |
+| Guardian               | [0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2](https://etherscan.io/address/0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2) | Gnosis Safe                          |
 
 ### Base Testnet (Sepolia)
 
-| Admin Role             | Address                                                                                                                            | Type of Key                          |
-| :--------------------- | :--------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------- |
-| Batch Sender           | [0x6CDEbe940BC0F26850285cacA097C11c33103E47](https://sepolia.etherscan.io/address/0x6CDEbe940BC0F26850285cacA097C11c33103E47)      | EOA managed by Coinbase Technologies |
-| Batch Inbox            | [0xff00000000000000000000000000000000084532](https://sepolia.etherscan.io/address/0xff00000000000000000000000000000000084532)      | EOA (with no known private key)      |
-| Output Proposer        | [0x037637067c1DbE6d2430616d8f54Cb774Daa5999](https://sepolia.etherscan.io/address/0x037637067c1DbE6d2430616d8f54Cb774Daa5999)      | EOA managed by Coinbase Technologies |
-| Proxy Admin Owner (L1) | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9)      | Gnosis Safe                          |
-| Challenger             | [0x8b8c52B04A38f10515C52670fcb23f3C4C44474F](https://sepolia.etherscan.io/address/0x8b8c52B04A38f10515C52670fcb23f3C4C44474F)      | EOA managed by Coinbase Technologies |
-| System config owner    | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9)      | Gnosis Safe                          |
-| Guardian               | [0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E](https://sepolia.etherscan.io/address/0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E)      | EOA managed by Coinbase Technologies |
+| Admin Role             | Address                                                                                                                       | Type of Key                          |
+| :--------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :----------------------------------- |
+| Batch Sender           | [0x6CDEbe940BC0F26850285cacA097C11c33103E47](https://sepolia.etherscan.io/address/0x6CDEbe940BC0F26850285cacA097C11c33103E47) | EOA managed by Coinbase Technologies |
+| Batch Inbox            | [0xff00000000000000000000000000000000084532](https://sepolia.etherscan.io/address/0xff00000000000000000000000000000000084532) | EOA (with no known private key)      |
+| Output Proposer        | [0x037637067c1DbE6d2430616d8f54Cb774Daa5999](https://sepolia.etherscan.io/address/0x037637067c1DbE6d2430616d8f54Cb774Daa5999) | EOA managed by Coinbase Technologies |
+| Proxy Admin Owner (L1) | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9) | Gnosis Safe                          |
+| Challenger             | [0x8b8c52B04A38f10515C52670fcb23f3C4C44474F](https://sepolia.etherscan.io/address/0x8b8c52B04A38f10515C52670fcb23f3C4C44474F) | EOA managed by Coinbase Technologies |
+| System config owner    | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9) | Gnosis Safe                          |
+| Guardian               | [0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E](https://sepolia.etherscan.io/address/0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E) | EOA managed by Coinbase Technologies |


### PR DESCRIPTION
**What changed? Why?**

Updates our `FaultDisputeGame` and `PermissionedDisputeGame` addresses on Sepolia which are changing as a result of our Fusaka Defense task on Oct 10th.

**Notes to reviewers**

**How has it been tested?**
