### PR TITLE
Fix github Anchor Base Account

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -381,7 +381,7 @@
           "anchors": [
             {
               "anchor": "GitHub",
-              "href": "https://github.com/coinbase/onchainkit",
+              "href": "https://github.com/base/account-sdk",
               "icon": "github"
             },
             {


### PR DESCRIPTION
**What changed? Why?**

Fixing link to GH anchor for base account section