### PR TITLE
Fix broken redirects

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2761,15 +2761,15 @@
       "destination": "/mini-apps/quickstart/create-new-miniapp"
     },
     {
-      "source": "mini-apps/design-ux/:slug*",
+      "source": "/mini-apps/design-ux/:slug*",
       "destination": "/mini-apps/featured-guidelines/design-guidelines"
     },
     {
-      "source": "mini-apps/get-featured/requirements",
+      "source": "/mini-apps/get-featured/requirements",
       "destination": "/mini-apps/featured-guidelines/overview"
     },
     {
-      "source": "mini-apps/quickstart/launch-checklist",
+      "source": "/mini-apps/quickstart/launch-checklist",
       "destination": "/mini-apps/quickstart/build-checklist"
     }
   ],


### PR DESCRIPTION
Several redirects were broken due to missing forward slash at the start of the `source` field
