### PR TITLE
chore: fixing getOnrampBuyUrl to display session token auth

### DIFF
--- a/docs/onchainkit/fund/get-onramp-buy-url.mdx
+++ b/docs/onchainkit/fund/get-onramp-buy-url.mdx
@@ -2,14 +2,20 @@
 title: getOnrampBuyUrl
 ---
 
-
 The `getOnrampBuyUrl` utility is a helper method to generate a Coinbase Onramp URL. It helps you customize the funding
 experience for your users. For example:
 
-- Selecting which assets should be available to buy/send
-- Selecting which networks crypto should be received on
-- Setting a default buy/send amount
+- Setting a default buy/send amount, defaultAsset, or defaultNetwork
 - Setting a redirect URL to return your users to your app after they complete the fund flow
+
+<Info>
+**Session Token Required:** This utility requires a session token generated on your backend server using your CDP API keys. The session token encapsulates user addresses, supported assets, and client IP.
+
+**Note:** Restricting assets and addresses are done during session token creation on your backend.
+
+See [Session Token Authentication](https://docs.cdp.coinbase.com/onramp-&-offramp/session-token-authentication) for implementation details.
+
+</Info>
 
 ## Usage
 
@@ -17,20 +23,23 @@ experience for your users. For example:
 ```tsx code
 import { getOnrampBuyUrl } from '@coinbase/onchainkit/fund';
 
-const projectId = 'YOUR_CDP_PROJECT_ID';
+// First, generate a session token on your backend server
+// See: https://docs.cdp.coinbase.com/onramp-&-offramp/session-token-authentication
+const sessionToken = 'YOUR_SESSION_TOKEN';
+
 const onrampBuyUrl = getOnrampBuyUrl({
-  projectId,
-  addresses: { '0x1': ['base'] },
-  assets: ['USDC'],
-  presetFiatAmount: 20,
-  fiatCurrency: 'USD',
-  redirectUrl: 'https://yourapp.com/onramp-return?param=foo',
+sessionToken,
+presetFiatAmount: 20,
+fiatCurrency: 'USD',
+redirectUrl: 'https://yourapp.com/onramp-return?param=foo',
 });
-```
+
+````
 
 ```json return value
-'https://pay.coinbase.com/buy?addresses=%7B%220x1%22%3A%5B%22base%22%5D%7D&appId=project-id&assets=%5B%22USDC%22%5D&fiatCurrency=USD&presetFiatAmount=20&redirectUrl=https%3A%2F%2Fyourapp.com%2Fonramp-return%3Fparam%3Dfoo'
-```
+'https://pay.coinbase.com/buy/select-asset?sessionToken=YOUR_SESSION_TOKEN&fiatCurrency=USD&presetFiatAmount=20&redirectUrl=https%3A%2F%2Fyourapp.com%2Fonramp-return%3Fparam%3Dfoo'
+````
+
 </CodeGroup>
 
 ## Returns
@@ -39,5 +48,14 @@ const onrampBuyUrl = getOnrampBuyUrl({
 
 ## Parameters
 
-[`GetOnrampUrlWithProjectIdParams`](/onchainkit/fund/types#getonrampurlwithprojectidparams) | [`GetOnrampUrlWithSessionTokenParams`](/onchainkit/fund/types#getonrampurlwithsessiontokenparams)
+[`GetOnrampUrlParams`](/onchainkit/fund/types#getonrampurlparams)
 
+## Session Token Generation
+
+Session tokens must be generated on your backend server using the CDP API. The token encapsulates:
+
+- User wallet addresses
+- Supported assets and blockchains
+- Client IP address
+
+For complete implementation details, see the [Session Token Authentication Guide](https://docs.cdp.coinbase.com/onramp-&-offramp/session-token-authentication).

--- a/docs/onchainkit/fund/types.mdx
+++ b/docs/onchainkit/fund/types.mdx
@@ -4,7 +4,6 @@ description: Glossary of Types.
 sidebarTitle: Fund
 ---
 
-
 ## `FundCardPropsReact`
 
 ```ts
@@ -27,23 +26,23 @@ type FundCardPropsReact = {
 ```ts
 type LifecycleStatus =
   | {
-      statusName: 'init';
+      statusName: "init";
       statusData: null;
     }
   | {
-      statusName: 'exit';
+      statusName: "exit";
       statusData: null;
     }
   | {
-      statusName: 'error';
+      statusName: "error";
       statusData: OnrampError;
     }
   | {
-      statusName: 'transactionSuccess';
+      statusName: "transactionSuccess";
       statusData: SuccessEventData;
     }
   | {
-      statusName: 'transactionPending';
+      statusName: "transactionPending";
       statusData: null;
     };
 ```
@@ -51,7 +50,7 @@ type LifecycleStatus =
 ## `PresetAmountInputs`
 
 ```ts
- type PresetAmountInputItemPropsReact = {
+type PresetAmountInputItemPropsReact = {
   presetAmountInput: string;
   currency: string;
   onClick: (presetAmountInput: string) => void;
@@ -77,78 +76,31 @@ type FundButtonReact = {
   hideText?: boolean; // An optional prop to hide the text in the button component
   hideIcon?: boolean; // An optional prop to hide the icon in the button component
   fundingUrl?: string; // An optional prop to provide a custom funding URL
-  openIn?: 'popup' | 'tab'; // Whether to open the funding flow in a tab or a popup window
+  openIn?: "popup" | "tab"; // Whether to open the funding flow in a tab or a popup window
   /**
    * Note: popupSize will be ignored when using a Coinbase Onramp URL
    * (i.e. https://pay.coinbase.com/*) as it requires a fixed popup size.
    */
-  popupSize?: 'sm' | 'md' | 'lg'; // Size of the popup window if `openIn` is set to `popup`
+  popupSize?: "sm" | "md" | "lg"; // Size of the popup window if `openIn` is set to `popup`
   rel?: string; // Specifies the relationship between the current document and the linked document
   target?: string; // Where to open the target if `openIn` is set to tab
 };
 ```
 
-## `GetOnrampUrlWithProjectIdParams`
-
-Props used to get an Onramp buy URL by directly providing a CDP project ID.
-
-See https://docs.cdp.coinbase.com/onramp/docs/api-initializing#generating-the-coinbase-onramp-buysell-url
-
-```ts
-type GetOnrampUrlWithProjectIdParams = {
-  /**
-   * The Project ID of your CDP project created at {@link https://portal.cdp.coinbase.com/}
-   * This must be provided if you don't provide a sessionToken.
-   */
-  projectId: string;
-  sessionToken?: never; // You cannot provide sessionToken when using projectId
-  /**
-   * The addresses to which the customer's funds should be delivered.
-   *
-   * Each entry in the record represents a wallet address and the networks it is valid for. There should only be a
-   * single address for each network your app supports. Users will be able to buy/send any asset supported by any of
-   * the networks you specify. See the assets param if you want to restrict the available assets.
-   *
-   * Some common examples:
-   *
-   * Support all assets that are available for sending on the base network, only on the base network:
-   *
-   * `{ "0x1": ["base"] }`
-   */
-  addresses: Record<string, string[]>;
-  /**
-   * This optional parameter will restrict the assets available for the user to buy/send. It acts as a filter on the
-   * networks specified in the {addresses} param.
-   *
-   * Some common examples:
-   *
-   * Support only USDC on either the base network or the ethereum network:
-   *
-   * `addresses: { "0x1": ["base", "ethereum"] }, assets: ["USDC"]`
-   *
-   * The values in this list can either be asset symbols like BTC, ETH, or asset UUIDs that you can get from the Buy
-   * Options API {@link https://docs.cdp.coinbase.com/onramp/docs/api-configurations/#buy-options}.
-   */
-  assets?: string[];
-} & GetOnrampBuyUrlOptionalProps;
-```
-
-## `GetOnrampUrlWithSessionTokenParams`
+## `GetOnrampUrlParams`
 
 Props used to get an Onramp buy URL using a session token created using the Onramp session token API.
 
-See https://docs.cdp.coinbase.com/onramp/docs/api-initializing#getting-an-coinbase-onramp-buysell-session-token
+See [Session Token Authentication](https://docs.cdp.coinbase.com/onramp-&-offramp/session-token-authentication)
 
 ```ts
-type GetOnrampUrlWithSessionTokenParams = {
+type GetOnrampUrlParams = {
   /**
    * A session token created using the Onramp session token API. The token will
    * be linked to the project ID, addresses, and assets params provided in the
+   * create session token API request.
    */
   sessionToken: string;
-  projectId?: never; // You cannot provide projectId when using sessionToken
-  addresses?: never; // You cannot provide addresses when using sessionToken
-  assets?: never; // You cannot provide assets when using sessionToken
 } & GetOnrampBuyUrlOptionalProps;
 ```
 
@@ -189,6 +141,12 @@ type GetOnrampBuyUrlOptionalProps = {
    */
   presetFiatAmount?: number;
   /**
+   * The default payment method that will be selected for the user in the
+   * Onramp UI. Should be one of the payment methods supported for the user's
+   * location.
+   */
+  defaultPaymentMethod?: string;
+  /**
    * The currency code of the fiat amount provided in the presetFiatAmount
    * param e.g. USD, CAD, EUR.
    */
@@ -199,6 +157,11 @@ type GetOnrampBuyUrlOptionalProps = {
    * Coinbase Developer Platform (https://portal.cdp.coinbase.com/products/onramp).
    */
   redirectUrl?: string;
+  /**
+   * The name of the component that is calling the Onramp buy URL. This will
+   * be used for analytics.
+   */
+  originComponentName?: string;
 };
 ```
 
@@ -298,7 +261,6 @@ type OnrampTransaction = {
   paymentMethod: string;
   transactionId: string;
 };
-
 ```
 
 ## `SuccessEventData`
@@ -317,10 +279,10 @@ type SuccessEventData = {
 ```ts
 type OnrampError = {
   errorType:
-    | 'internal_error'
-    | 'handled_error'
-    | 'network_error'
-    | 'unknown_error';
+    | "internal_error"
+    | "handled_error"
+    | "network_error"
+    | "unknown_error";
   code?: string;
   debugMessage?: string;
 };
@@ -374,4 +336,3 @@ type OnrampQuoteResponseData = {
   quoteId: string;
 };
 ```
-

--- a/docs/onchainkit/latest/utilities/fund/get-onramp-buy-url.mdx
+++ b/docs/onchainkit/latest/utilities/fund/get-onramp-buy-url.mdx
@@ -5,10 +5,17 @@ title: getOnrampBuyUrl
 The `getOnrampBuyUrl` utility is a helper method to generate a Coinbase Onramp URL. It helps you customize the funding
 experience for your users. For example:
 
-- Selecting which assets should be available to buy/send
-- Selecting which networks crypto should be received on
-- Setting a default buy/send amount
+- Setting a default buy/send amount, defaultAsset, or defaultNetwork
 - Setting a redirect URL to return your users to your app after they complete the fund flow
+
+<Info>
+**Session Token Required:** This utility requires a session token generated on your backend server using your CDP API keys. The session token encapsulates user addresses, supported assets, and client IP.
+
+**Note:** Restricting assets and addresses are done during session token creation on your backend.
+
+See [Session Token Authentication](https://docs.cdp.coinbase.com/onramp-&-offramp/session-token-authentication) for implementation details.
+
+</Info>
 
 ## Usage
 
@@ -16,21 +23,22 @@ experience for your users. For example:
 ```tsx code
 import { getOnrampBuyUrl } from '@coinbase/onchainkit/fund';
 
-const projectId = 'YOUR_CDP_PROJECT_ID';
+// First, generate a session token on your backend server
+// See: https://docs.cdp.coinbase.com/onramp-&-offramp/session-token-authentication
+const sessionToken = 'YOUR_SESSION_TOKEN';
+
 const onrampBuyUrl = getOnrampBuyUrl({
-projectId,
-addresses: { '0x1': ['base'] },
-assets: ['USDC'],
+sessionToken,
 presetFiatAmount: 20,
 fiatCurrency: 'USD',
 redirectUrl: 'https://yourapp.com/onramp-return?param=foo',
 });
 
-```
+````
 
 ```json return value
-'https://pay.coinbase.com/buy?addresses=%7B%220x1%22%3A%5B%22base%22%5D%7D&appId=project-id&assets=%5B%22USDC%22%5D&fiatCurrency=USD&presetFiatAmount=20&redirectUrl=https%3A%2F%2Fyourapp.com%2Fonramp-return%3Fparam%3Dfoo'
-```
+'https://pay.coinbase.com/buy/select-asset?sessionToken=YOUR_SESSION_TOKEN&fiatCurrency=USD&presetFiatAmount=20&redirectUrl=https%3A%2F%2Fyourapp.com%2Fonramp-return%3Fparam%3Dfoo'
+````
 
 </CodeGroup>
 
@@ -40,140 +48,14 @@ redirectUrl: 'https://yourapp.com/onramp-return?param=foo',
 
 ## Parameters
 
-```typescript
-type GetOnrampUrlWithProjectIdParams = {
-  /**
-   * The Project ID of your CDP project created at https://portal.cdp.coinbase.com/
-   * This must be provided if you don't provide a sessionToken.
-   */
-  projectId: string;
-  sessionToken?: never;
-  /**
-   * The addresses that the customer's funds should be delivered to.
-   *
-   * Each entry in the record represents a wallet address and the networks it is valid for. There should only be a
-   * single address for each network your app supports. Users will be able to buy/send any asset supported by any of
-   * the networks you specify. See the assets param if you want to restrict the available assets.
-   *
-   * Some common examples:
-   *
-   * Support all assets that are available for sending on the base network, only on the base network:
-   *
-   * `{ "0x1": ["base"] }`
-   */
-  addresses: Record<string, string[]>;
-  /**
-   * This optional parameter will restrict the assets available for the user to buy/send. It acts as a filter on the
-   * networks specified in the {addresses} param.
-   *
-   * Some common examples:
-   *
-   * Support only USDC on either the base network or the ethereum network:
-   *
-   * `addresses: { "0x1": ["base", "ethereum"] }, assets: ["USDC"]`
-   *
-   * The values in this list can either be asset symbols like BTC, ETH, or asset UUIDs that you can get from the Buy
-   * Options API {@link https://docs.cdp.coinbase.com/onramp/docs/api-configurations/#buy-options}.
-   */
-  assets?: string[];
-  /**
-   * If specified, this asset will be automatically selected for the user in the Onramp UI. Should be a valid asset
-   * symbol e.g. BTC, ETH, USDC.
-   */
-  defaultAsset?: string;
-  /**
-   * If specified, this network will be automatically selected for the user in the Onramp UI. Should be a valid network
-   * name in lower case e.g. ethereum, base.
-   */
-  defaultNetwork?: string;
-  /**
-   * A unique identifier that will be associated with any transactions created by the user during their Onramp session.
-   * You can use this with the Transaction Status API to check the status of the user's transaction.
-   * See https://docs.cdp.coinbase.com/onramp/docs/api-reporting#buy-transaction-status
-   */
-  partnerUserId?: string;
-  /**
-   * This amount will be used to pre-fill the amount of crypto the user is buying or sending. The user can choose to
-   * change this amount in the UI. Only one of presetCryptoAmount or presetFiatAmount should be provided.
-   */
-  presetCryptoAmount?: number;
-  /**
-   * This amount will be used to pre-fill the fiat value of the crypto the user is buying or sending. The user can
-   * choose to change this amount in the UI. Only one of presetCryptoAmount or presetFiatAmount should be provided.
-   */
-  presetFiatAmount?: number;
-  /**
-   * The default payment method that will be selected for the user in the Onramp UI. Should be one of the payment methods
-   */
-  defaultPaymentMethod?: string;
-  /**
-   * The currency code of the fiat amount provided in the presetFiatAmount param e.g. USD, CAD, EUR.
-   */
-  fiatCurrency?: string;
-  /**
-   * A URL that the user will be automatically redirected to after a successful buy/send. The domain must match a domain
-   * on the domain allowlist in Coinbase Developer Platform (https://portal.cdp.coinbase.com/products/onramp).
-   */
-  redirectUrl?: string;
-  /**
-   * The name of the component that is calling the Onramp buy URL. This will be used for analytics.
-   */
-  originComponentName?: string;
-};
+[`GetOnrampUrlParams`](/onchainkit/fund/types#getonrampurlparams)
 
-type GetOnrampUrlWithSessionTokenParams = {
-  /**
-   * A session token create using the Onramp session token API. The token will be linked to the project ID, addresses,
-   * and assets params provided in the create session token API request.
-   */
-  sessionToken: string;
-  projectId?: never;
-  addresses?: never;
-  assets?: never;
-  /**
-   * If specified, this asset will be automatically selected for the user in the Onramp UI. Should be a valid asset
-   * symbol e.g. BTC, ETH, USDC.
-   */
-  defaultAsset?: string;
-  /**
-   * If specified, this network will be automatically selected for the user in the Onramp UI. Should be a valid network
-   * name in lower case e.g. ethereum, base.
-   */
-  defaultNetwork?: string;
-  /**
-   * A unique identifier that will be associated with any transactions created by the user during their Onramp session.
-   * You can use this with the Transaction Status API to check the status of the user's transaction.
-   * See https://docs.cdp.coinbase.com/onramp/docs/api-reporting#buy-transaction-status
-   */
-  partnerUserId?: string;
-  /**
-   * This amount will be used to pre-fill the amount of crypto the user is buying or sending. The user can choose to
-   * change this amount in the UI. Only one of presetCryptoAmount or presetFiatAmount should be provided.
-   */
-  presetCryptoAmount?: number;
-  /**
-   * This amount will be used to pre-fill the fiat value of the crypto the user is buying or sending. The user can
-   * choose to change this amount in the UI. Only one of presetCryptoAmount or presetFiatAmount should be provided.
-   */
-  presetFiatAmount?: number;
-  /**
-   * The default payment method that will be selected for the user in the Onramp UI. Should be one of the payment methods
-   */
-  defaultPaymentMethod?: string;
-  /**
-   * The currency code of the fiat amount provided in the presetFiatAmount param e.g. USD, CAD, EUR.
-   */
-  fiatCurrency?: string;
-  /**
-   * A URL that the user will be automatically redirected to after a successful buy/send. The domain must match a domain
-   * on the domain allowlist in Coinbase Developer Platform (https://portal.cdp.coinbase.com/products/onramp).
-   */
-  redirectUrl?: string;
-  /**
-   * The name of the component that is calling the Onramp buy URL. This will be used for analytics.
-   */
-  originComponentName?: string;
-};
-```
+## Session Token Generation
 
-The function accepts either `GetOnrampUrlWithProjectIdParams` OR `GetOnrampUrlWithSessionTokenParams`.
+Session tokens must be generated on your backend server using the CDP API. The token encapsulates:
+
+- User wallet addresses
+- Supported assets and blockchains
+- Client IP address
+
+For complete implementation details, see the [Session Token Authentication Guide](https://docs.cdp.coinbase.com/onramp-&-offramp/session-token-authentication).


### PR DESCRIPTION
**What changed? Why?**

the current documentation uses an outdated approach to creating onramp URLs with project id, addresses, and acceptable assets. the new approach will only use session tokens

will match the implementation in onchain kit - https://github.com/coinbase/onchainkit/blob/main/packages/onchainkit/src/fund/utils/getOnrampBuyUrl.ts

<img width="787" height="496" alt="Screenshot 2025-10-14 at 9 45 12 AM" src="https://github.com/user-attachments/assets/9ef6ab38-3bd9-497b-9082-43cf7b8dcb19" />

<img width="770" height="632" alt="Screenshot 2025-10-14 at 9 45 37 AM" src="https://github.com/user-attachments/assets/4198e59b-018f-41a4-bee8-819465e2a70c" />

<img width="716" height="438" alt="Screenshot 2025-10-14 at 9 45 51 AM" src="https://github.com/user-attachments/assets/d2d345fa-3dce-4c74-8b5a-f91bd0749f81" />

**Notes to reviewers**

**How has it been tested?**
