### PR TITLE
docs: Update learn section from Base Goerli to Base Sepolia

### DIFF
--- a/docs/learn/arrays/arrays-exercise.mdx
+++ b/docs/learn/arrays/arrays-exercise.mdx
@@ -75,11 +75,15 @@ Add `public` functions called `resetSenders` and `resetTimestamps` that reset th
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4),
+ is now the active test network and replaces the older testnets.
+Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
 </Note>
 
 

--- a/docs/learn/control-structures/control-structures-exercise.mdx
+++ b/docs/learn/control-structures/control-structures-exercise.mdx
@@ -40,11 +40,15 @@ Create a function called `doNotDisturb` that accepts a `uint` called `_time`, an
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
+
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
 </Note>
 
 

--- a/docs/learn/deployment-to-testnet/deployment-to-base-sepolia-sbs.mdx
+++ b/docs/learn/deployment-to-testnet/deployment-to-base-sepolia-sbs.mdx
@@ -81,10 +81,10 @@ The first time you do this, your wallet will ask you to confirm that you want to
 Once you are connected, you'll see the name of the network below the _Environment_ dropdown.
 
 <Frame>
-![Connected](/images/learn/deployment-to-testnet/remix-base-goerli-connected.png)
+![Connected](/images/learn/deployment-to-testnet/remix-base-sepolia-connected.png)
 </Frame>
 
-For Base Sepolia, you should see `Custom (84532) network`. The old network, Goerli, was `84531`. If you don't see the correct network, change the active network in your wallet.
+For Base Sepolia, you should see `Custom (84532) network`. If you don't see the correct network, change the active network in your wallet to Base sepolia.
 
 ### Deploy the Contract
 

--- a/docs/learn/deployment-to-testnet/deployment-to-testnet-exercise.mdx
+++ b/docs/learn/deployment-to-testnet/deployment-to-testnet-exercise.mdx
@@ -19,12 +19,15 @@ Stay tuned for updates!
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
-</Note>
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
+ </Note>
 
 
 {/* <CafeUnitTest nftNum={1}/> */}

--- a/docs/learn/deployment-to-testnet/test-networks.mdx
+++ b/docs/learn/deployment-to-testnet/test-networks.mdx
@@ -13,7 +13,7 @@ This article provides a concise overview of Base test networks, highlighting the
 By the end of this lesson you should be able to:
 
 - Describe the uses and properties of the Base testnet
-- Compare and contrast Ropsten, Rinkeby, Goerli, and Sepolia
+- Compare and contrast Ropsten, Rinkeby, and Sepolia
 
 ---
 
@@ -73,9 +73,9 @@ Several well-known testnets have emerged over the years, each with its own set o
 
 - **Rinkeby:** Rinkeby offered better security than Ropsten and used a proof-of-authority consensus mechanism. However, it lacked decentralization and client diversity, which ultimately led to its decline in popularity. After the Merge, Rinkeby is no longer a recommended test network.
 
-- **Goerli:** Launched in early 2019, Goerli initially utilized a multi-client proof-of-authority consensus model to improve stability and security. Following the Merge, it transitioned to a proof-of-stake consensus mechanism, maintaining its cross-client compatibility and making it an ideal choice for developers. As of January 2024, Goerli is being sunset in favor of Sepolia.
+- **Sepolia:** Sepolia was created in October 2021 by Ethereum core developers as a testnet, originally under a proof-of-authority consensus model.
 
-- **Sepolia:** As one of the two original primary testnets alongside Goerli, Sepolia is designed for developers seeking a lighter weight chain for faster synchronization and interaction. As of January 2024, it is now the preferred testnet and developers should migrate to using it.
+- **Sepolia:** As one of the two original primary testnetx, Sepolia is designed for developers seeking a lighter weight chain for faster synchronization and interaction. As of January 2024, it is now the preferred testnet and developers should migrate to using it.
 
 ### L2 Testnets
 

--- a/docs/learn/error-triage/error-triage-exercise.mdx
+++ b/docs/learn/error-triage/error-triage-exercise.mdx
@@ -80,11 +80,16 @@ contract ErrorTriageExercise {
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
 
 As these are separate networks with separate data, your NFTs **will not** transfer over.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
+
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
 </Note>
 
 

--- a/docs/learn/imports/imports-exercise.mdx
+++ b/docs/learn/imports/imports-exercise.mdx
@@ -74,12 +74,16 @@ To simplify the verification of your contract on a blockchain explorer like Base
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks)Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+ Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
 </Note>
+
 
 
 {/* <CafeUnitTest nftNum={19}/> */}

--- a/docs/learn/inheritance/inheritance-exercise.mdx
+++ b/docs/learn/inheritance/inheritance-exercise.mdx
@@ -101,12 +101,14 @@ contract InheritanceSubmission {
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+ Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
-</Note>
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.</Note>
 
 
 <Warning>

--- a/docs/learn/introduction-to-solidity/introduction-to-solidity-overview.mdx
+++ b/docs/learn/introduction-to-solidity/introduction-to-solidity-overview.mdx
@@ -34,7 +34,7 @@ By the end of this module, you should be able to:
   - Write a pure function that accepts argument and returns a value
 - **Deploying Smart Contracts to a Testnet**
   - Describe the uses and properties of the Ethereum testnet
-  - Compare and contrast Ropsten, Rinkeby, Goerli, and Sepolia
+  - Compare and contrast Ropsten, Rinkeby, and Sepolia
   - Deploy a contract to the Sepolia testnet and interact with it in Etherscan
 - **Control Structures**
   - Control code flow with if, else, while, and for

--- a/docs/learn/mappings/mappings-exercise.mdx
+++ b/docs/learn/mappings/mappings-exercise.mdx
@@ -57,12 +57,14 @@ Add a function called `resetUserFavorites` that resets `userFavorites` for the s
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+ Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
-</Note>
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.</Note>
 
 
 {/* <CafeUnitTest nftNum={5} /> */}

--- a/docs/learn/new-keyword/new-keyword-exercise.mdx
+++ b/docs/learn/new-keyword/new-keyword-exercise.mdx
@@ -76,11 +76,14 @@ The `AddressBookFactory` contains one function, `deploy`. It creates an instance
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+ Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
 </Note>
 
 {/* <CafeUnitTest nftNum={12} /> */}

--- a/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-biconomy.mdx
+++ b/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-biconomy.mdx
@@ -38,11 +38,11 @@ This tutorial requires you to have a wallet. You can create a wallet by download
 
 ### Wallet funds
 
-To complete this tutorial, you will need to fund a wallet with ETH on Base Goerli.
+To complete this tutorial, you will need to fund a wallet with ETH on Base sepolia.
 
 The ETH is required for covering gas fees associated with deploying smart contracts to the network.
 
-- To fund your wallet with ETH on Base Goerli, visit a faucet listed on the [Base Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
+- To fund your wallet with ETH on Base sepolia, visit a faucet listed on the [Base Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
 
 ## What is Biconomy?
 
@@ -151,20 +151,20 @@ cast wallet list
 To deploy the smart contract, you can use the `forge create` command. The command requires you to specify the smart contract you want to deploy, an RPC URL of the network you want to deploy to, and the account you want to deploy with.
 
 <Info>
-Your wallet must be funded with ETH on the Base Goerli testnet to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
+Your wallet must be funded with ETH on the Base sepolia testnet to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
 
 To get testnet ETH, see the [prerequisites](#prerequisites).
 </Info>
 
-To deploy the smart contract to the Base Goerli testnet, run the following command:
+To deploy the smart contract to the Base sepolia testnet, run the following command:
 
 ```bash
-forge create ./src/Counter.sol:Counter --rpc-url https://goerli.base.org --account deployer
+forge create ./src/Counter.sol:Counter --rpc-url https://sepolia.base.org --account deployer
 ```
 
 When prompted, enter the password that you set earlier, when you imported your wallet's private key.
 
-After running the command above, the contract will be deployed on the Base Goerli test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
+After running the command above, the contract will be deployed on the Base sepolia test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
 
 ## Setting up the Paymaster and Bundler
 
@@ -177,7 +177,7 @@ Add and register a Paymaster by completing the following steps:
 1. Visit the sign in to the [Biconomy Dashboard](https://dashboard.biconomy.io/)
 1. From the dashboard, select the **Paymasters** tab and click **Add your first Paymaster**
 1. Provide a **Name** for your paymaster
-1. Select **Base Goerli** from the **Network** dropdown
+1. Select **Base sepolia** from the **Network** dropdown
 1. Click **Register**
 
 You should now have a registered Biconomy paymaster.
@@ -217,7 +217,7 @@ Set up and fund the paymaster's gas tank by completing the following steps:
 1. From the dashboard, select the **Bundlers** tab
 
 <Info>
-At the time of writing this tutorial, the Bundler service is still under development, however a **Bundler URL** is provided for testing out UserOperations on test networks. You can specify the chain ID **84531** to use the Bundler URL on **Base Goerli** testnet.
+At the time of writing this tutorial, the Bundler service is still under development, however a **Bundler URL** is provided for testing out UserOperations on test networks. You can specify the chain ID **84531** to use the Bundler URL on **Base sepolia** testnet.
 </Info>
 
 ## Setting up the frontend

--- a/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-privy-and-the-base-paymaster.mdx
+++ b/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-privy-and-the-base-paymaster.mdx
@@ -411,7 +411,7 @@ This address is the [bundler], which is a special node that bundles user operati
 
 #### EntryPoint
 
-The EntryPoint contract for Base Goerli is located at `0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789`. Strangely, in your transaction receipt you'll see that the transaction includes a transfer of ETH **from** the EntryPoint **to** the bundler. This transaction is how the bundler gets compensated for performing the service of bundling user ops and turning them into transactions -- the EntryPoint calculates the gas used by user ops and multiplies that by the fee percentage and send it to the bundler.
+The EntryPoint contract for Base sepolia is located at `0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789`. Strangely, in your transaction receipt you'll see that the transaction includes a transfer of ETH **from** the EntryPoint **to** the bundler. This transaction is how the bundler gets compensated for performing the service of bundling user ops and turning them into transactions -- the EntryPoint calculates the gas used by user ops and multiplies that by the fee percentage and send it to the bundler.
 
 ### Review the Example Code
 
@@ -425,7 +425,7 @@ Starting on line 63, the exported `SmartAccountProvider` does the following:
 
 1. Fetch the user's wallets and find their Privy wallet. This wallet is provided, and if need be created, by the `PrivyProvider`
 1. Set up state variables to manage and share connection status and the smart account itself
-1. Initialize an RPC client for the [Base Paymaster] (on Goerli). The URL is hardcoded in `lib/constants.ts`
+1. Initialize an RPC client for the [Base Paymaster] (on sepolia). The URL is hardcoded in `lib/constants.ts`
 1. Initialize an ERC-4337 RPC client for Alchemy's network. This network is where the bundler address comes from
 1. Create a smart wallet. In this case, the `signer` is your EOA embedded wallet created by Privy and fetched in the first step
 1. The EOA address is displayed in the example app as `YOUR SIGNER ADDRESS`
@@ -456,13 +456,13 @@ When a user clicks, the app first creates a viem `RpcTransactionRequest` for the
 }
 ```
 
-The app then updates the toast component to update the users while it `await`s first the `userOpHash`, then the `transactionHash`, indicating that transaction has completed successfully. It then updates the link in the toast to send the user to that transaction on Goerli BaseScan.
+The app then updates the toast component to update the users while it `await`s first the `userOpHash`, then the `transactionHash`, indicating that transaction has completed successfully. It then updates the link in the toast to send the user to that transaction on sepolia BaseScan.
 
 ### Implementing the Paymaster in your own App
 
 Create a new project using Privy's [`create-next-app`] template, and complete the setup instructions in the readme.
 
-Add an environment variable for `NEXT_PUBLIC_ALCHEMY_API_KEY` and paste in the an API key for a Base Goerli app. If you need a key, go to [add an app] and create a new one.
+Add an environment variable for `NEXT_PUBLIC_ALCHEMY_API_KEY` and paste in the an API key for a Base sepolia app. If you need a key, go to [add an app] and create a new one.
 
 #### Copying and Updating the Source Files
 
@@ -514,7 +514,7 @@ useEffect(() => {
 
 #### Configuring the PrivyProvider and Adding SmartAccountProvider
 
-By default, the `PrivyProvider` allows logging in with a wallet or email address. To limit it to only the wallet, update the config. You can also set the default chain here. You'll need to import `baseGoerli` to do so.
+By default, the `PrivyProvider` allows logging in with a wallet or email address. To limit it to only the wallet, update the config. You can also set the default chain here. You'll need to import `basesepolia` to do so.
 
 You also need to import and wrap the app with `SmartAccountProvider`, imported from `hooks/SmartAccountContext.tsx`.
 
@@ -534,7 +534,7 @@ Its instance type 'SmartAccountProvider<Transport>' is not a valid JSX element.
   onSuccess={() => router.push('/dashboard')}
   config={{
     loginMethods: ['wallet'],
-    defaultChain: baseGoerli,
+    defaultChain: baseSepolia,
   }}
 >
   <SmartAccountProvider>
@@ -553,7 +553,7 @@ Grab the snippet from the original demo that displays the user's addresses, and 
 </p>
 <a
   className="mt-2 text-sm text-zinc-500 hover:text-violet-600"
-  href={`${BASE_GOERLI_SCAN_URL}/address/${smartAccountAddress}#tokentxnsErc721`}
+  href={`${BASE_SEPOLIA_SCAN_URL}/address/${smartAccountAddress}#tokentxnsErc721`}
 >
   {smartAccountAddress}
 </a>
@@ -562,7 +562,8 @@ Grab the snippet from the original demo that displays the user's addresses, and 
 </p>
 <a
   className="mt-2 text-sm text-zinc-500 hover:text-violet-600"
-  href={`${BASE_GOERLI_SCAN_URL}/address/${eoa?.address}`}
+  href={`${BASE_SEPOLIA
+  _SCAN_URL}/address/${eoa?.address}`}
 >
   {eoa?.address}
 </a>
@@ -570,7 +571,7 @@ Grab the snippet from the original demo that displays the user's addresses, and 
 
 Paste it above the `<p>` for the `User Object` window.
 
-You'll need to import `BASE_GOERLI_SCAN_URL` from `constants.ts`. The `useSmartAccount` hook returns `smartAccountProvider` and `eoa`. Import it and add it under the `usePrivy` hook. You don't need them just yet, but go ahead and decompose `smartAccountProvider` and `sendSponsoredUserOperation` as well:
+You'll need to import `BASE_SEPOLIA_SCAN_URL` from `constants.ts`. The `useSmartAccount` hook returns `smartAccountProvider` and `eoa`. Import it and add it under the `usePrivy` hook. You don't need them just yet, but go ahead and decompose `smartAccountProvider` and `sendSponsoredUserOperation` as well:
 
 ```tsx
 const router = useRouter();
@@ -604,7 +605,7 @@ The app sometimes gets confused with login state after you've made changes to `c
 
 #### Calling a Smart Contract Function
 
-You've adjusted the foundation of the app to allow you to use the Base Goerli Paymaster with your normal wallet as the signer. Now, it's time to call a smart contract function.
+You've adjusted the foundation of the app to allow you to use the Base sepolia Paymaster with your normal wallet as the signer. Now, it's time to call a smart contract function.
 
 Start by using the `mint` function in the original example. In the `DashboardPage` component, add a state variable holding an empty element:
 
@@ -639,7 +640,7 @@ const onMint = async () => {
     const transactionHash = await smartAccountProvider.waitForUserOperationTransaction(userOpHash);
 
     setTransactionLink(
-      <a href={`${BASE_GOERLI_SCAN_URL}/tx/${transactionHash}`}>
+      <a href={`${BASE_SEPOLIA_SCAN_URL}/tx/${transactionHash}`}>
         Successfully minted! Click here to see your transaction.
       </a>,
     );
@@ -672,7 +673,7 @@ For simplicity, we've stripped out the code to disable the button while it is mi
 
 #### Calling Another Function
 
-The [Base Paymaster] on Goerli is very permissive. To call another function, all you need to do is to change the `RpcTransactionRequest` in `sendSponsoredUserOperation` to match the address, abi, function name, and arguments of your function on your smart contract.
+The [Base Paymaster] on Sepolia is very permissive. To call another function, all you need to do is to change the `RpcTransactionRequest` in `sendSponsoredUserOperation` to match the address, abi, function name, and arguments of your function on your smart contract.
 
 For example, to call the `claim` function in the Weighted Voting contract we've used in other tutorials, you'd simply need to import the Hardhat-style [artifact] for the contract and use it to call the function:
 
@@ -712,8 +713,8 @@ In this article, we've explored the transformative potential of Account Abstract
 [securely stored]: https://docs.privy.io/guide/security#user-data-management
 [paymaster example]: https://github.com/privy-io/base-paymaster-example/blob/main/README.md
 [ERC-4337]: https://eips.ethereum.org/EIPS/eip-4337
-[NFT Contract]: https://goerli.basescan.org/address/0x6527e5052de5521fe370ae5ec0afcc6cd5a221de
-[view for the contract itself]: https://goerli.basescan.org/address/0x6527e5052de5521fe370ae5ec0afcc6cd5a221de
+[NFT Contract]: https://sepolia.basescan.org/address/0x6527e5052de5521fe370ae5ec0afcc6cd5a221de
+[view for the contract itself]: https://sepolia.basescan.org/address/0x6527e5052de5521fe370ae5ec0afcc6cd5a221de
 [Base Paymaster]: https://github.com/base-org/paymaster
 [EntryPoint]: https://github.com/eth-infinitism/account-abstraction/releases
 [bundler]: https://www.alchemy.com/overviews/what-is-a-bundler

--- a/docs/learn/onchain-app-development/account-abstraction/gasless-transactions-with-paymaster.mdx
+++ b/docs/learn/onchain-app-development/account-abstraction/gasless-transactions-with-paymaster.mdx
@@ -31,8 +31,7 @@ This tutorial assumes you have:
    Foundry is a development environment, testing framework, and smart contract toolkit for Ethereum. You’ll need it installed locally for generating key pairs and interacting with smart contracts.
 
 > **Testnet vs. Mainnet**  
-> If you prefer not to spend real funds, you can switch to **Base Goerli** (testnet). The steps below are conceptually the same. Just select _Base Goerli_ in the Coinbase Developer Platform instead of _Base Mainnet_, and use a contract deployed on Base testnet for your allowlisted methods.
-
+> If you prefer not to spend real funds, you can switch to Base Sepolia (testnet). The steps below are conceptually the same. Just select Base Sepolia in the Coinbase Developer Platform instead of Base Mainnet, and use a contract deployed on Base testnet for your allowlisted methods.
 ## Set Up a Base Paymaster & Bundler
 
 In this section, you will configure a Paymaster to sponsor payments on behalf of a specific smart contract for a specified amount.
@@ -55,7 +54,7 @@ In this section, you will configure a Paymaster to sponsor payments on behalf of
 
 ### Allowlist a Sponsorable Contract
 
-1. From the Configuration page, ensure **Base Mainnet** (or **Base Goerli** if you’re testing) is selected.
+1. From the Configuration page, ensure **Base Mainnet** (or **Base Sepolia** if you’re testing) is selected.
 2. Enable your paymaster by clicking the toggle button.
 3. Click **Add** to add an allowlisted contract.
 4. For this example, add [`0x83bd615eb93eE1336acA53e185b03B54fF4A17e8`][simple NFT contract], and add the function `mintTo(address)`.

--- a/docs/learn/onchain-app-development/cross-chain/send-messages-and-tokens-from-base-chainlink.mdx
+++ b/docs/learn/onchain-app-development/cross-chain/send-messages-and-tokens-from-base-chainlink.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sending messages and tokens from Base to other chains using Chainlink CCIP
-description: A tutorial that teaches how to use Chainlink CCIP to perform cross-chain messaging and token transfers from Base Goerli testnet to Optimism Goerli testnet.
+description: A tutorial that teaches how to use Chainlink CCIP to perform cross-chain messaging and token transfers from Base sepolia testnet to Optimism sepolia testnet.
 authors:
   - taycaldwell
 tags: ['cross-chain']
@@ -43,12 +43,12 @@ In order to deploy a smart contract, you will first need a wallet. You can creat
 
 ### Wallet funds
 
-For this tutorial you will need to fund your wallet with both ETH and LINK on Base Goerli and Optimism Goerli.
+For this tutorial you will need to fund your wallet with both ETH and LINK on Base sepolia and Optimism sepolia.
 
 The ETH is required for covering gas fees associated with deploying smart contracts to the blockchain, and the LINK token is required to pay for associated fees when using CCIP.
 
-- To fund your wallet with ETH on Base Goerli, visit a faucet listed on the [Base Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
-- To fund your wallet with ETH on Optimism Goerli, visit a faucet listed on the [Optimism Faucets](https://docs.optimism.io/builders/tools/faucets) page.
+- To fund your wallet with ETH on Base sepolia, visit a faucet listed on the [Base Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
+- To fund your wallet with ETH on Optimism sepolia, visit a faucet listed on the [Optimism Faucets](https://docs.optimism.io/builders/tools/faucets) page.
 - To fund your wallet with LINK, visit the [Chainlink Faucet](https://faucets.chain.link/base-testnet).
 
 <Warning>
@@ -468,20 +468,20 @@ cast wallet list
 
 ### Setting up environment variables
 
-To setup your environment, create an `.env` file in the home directory of your project, and add the RPC URLs, [CCIP chain selectors](https://docs.chain.link/ccip/supported-networks/v1_2_0/testnet), [CCIP router addresses](https://docs.chain.link/ccip/supported-networks/v1_2_0/testnet), and [LINK token addresses](https://docs.chain.link/resources/link-token-contracts) for both Base Goerli and Optimism Goerli testnets:
+To setup your environment, create an `.env` file in the home directory of your project, and add the RPC URLs, [CCIP chain selectors](https://docs.chain.link/ccip/supported-networks/v1_2_0/testnet), [CCIP router addresses](https://docs.chain.link/ccip/supported-networks/v1_2_0/testnet), and [LINK token addresses](https://docs.chain.link/resources/link-token-contracts) for both Base sepolia and Optimism sepolia testnets:
 
 ```bash
-BASE_GOERLI_RPC="https://goerli.base.org"
-OPTIMISM_GOERLI_RPC="https://goerli.optimism.io"
+BASE_SEPOLIA_RPC="https://sepolia.base.org"
+OPTIMISM_SEPOLIA_RPC="https://sepolia.optimism.io"
 
-BASE_GOERLI_CHAIN_SELECTOR=5790810961207155433
-OPTIMISM_GOERLI_CHAIN_SELECTOR=2664363617261496610
+BASE_SEPOLIA_CHAIN_SELECTOR=5790810961207155433
+OPTIMISM_SEPOLIA_CHAIN_SELECTOR=2664363617261496610
 
-BASE_GOERLI_ROUTER_ADDRESS="0x80AF2F44ed0469018922c9F483dc5A909862fdc2"
-OPTIMISM_GOERLI_ROUTER_ADDRESS="0xcc5a0B910D9E9504A7561934bed294c51285a78D"
+BASE_SEPOLIA_ROUTER_ADDRESS="0x80AF2F44ed0469018922c9F483dc5A909862fdc2"
+OPTIMISM_SEPOLIA_ROUTER_ADDRESS="0xcc5a0B910D9E9504A7561934bed294c51285a78D"
 
-BASE_GOERLI_LINK_ADDRESS="0x6D0F8D488B669aa9BA2D0f0b7B75a88bf5051CD3"
-OPTIMISM_GOERLI_LINK_ADDRESS="0xdc2CC710e42857672E7907CF474a69B63B93089f"
+BASE_SEPOLIA_LINK_ADDRESS="0x6D0F8D488B669aa9BA2D0f0b7B75a88bf5051CD3"
+OPTIMISM_SEPOLIA_LINK_ADDRESS="0xdc2CC710e42857672E7907CF474a69B63B93089f"
 ```
 
 Once the `.env` file has been created, run the following command to load the environment variables in the current command line session:
@@ -497,34 +497,34 @@ With your contracts compiled and environment setup, you are ready to deploy the 
 To deploy a smart contract using Foundry, you can use the `forge create` command. The command requires you to specify the smart contract you want to deploy, an RPC URL of the network you want to deploy to, and the account you want to deploy with.
 
 <Info>
-Your wallet must be funded with ETH on the Base Goerli and Optimism Goerli to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
+Your wallet must be funded with ETH on the Base sepolia and Optimism sepolia to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
 
-To get testnet ETH for Base Goerli and Optimism Goerli, see the [prerequisites](#prerequisites).
+To get testnet ETH for Base sepolia and Optimism sepolia, see the [prerequisites](#prerequisites).
 </Info>
 
-#### Deploying the Sender contract to Base Goerli
+#### Deploying the Sender contract to Base sepolia
 
-To deploy the `Sender` smart contract to the Base Goerli testnet, run the following command:
+To deploy the `Sender` smart contract to the Base sepolia testnet, run the following command:
 
 ```bash
-forge create ./src/Sender.sol:Sender --rpc-url $BASE_GOERLI_RPC --constructor-args $BASE_GOERLI_ROUTER_ADDRESS $BASE_GOERLI_LINK_ADDRESS --account deployer
+forge create ./src/Sender.sol:Sender --rpc-url $BASE_SEPOLIA_RPC --constructor-args $BASE_SEPOLIA_ROUTER_ADDRESS $BASE_SEPOLIA_LINK_ADDRESS --account deployer
 ```
 
 When prompted, enter the password that you set earlier, when you imported your wallet's private key.
 
-After running the command above, the contract will be deployed on the Base Goerli test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
+After running the command above, the contract will be deployed on the Base sepolia test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
 
-#### Deploying the Receiver contract to Optimism Goerli
+#### Deploying the Receiver contract to Optimism sepolia
 
-To deploy the `Receiver` smart contract to the Optimism Goerli testnet, run the following command:
+To deploy the `Receiver` smart contract to the Optimism sepolia testnet, run the following command:
 
 ```bash
-forge create ./src/Receiver.sol:Receiver --rpc-url $OPTIMISM_GOERLI_RPC --constructor-args $OPTIMISM_GOERLI_ROUTER_ADDRESS --account deployer
+forge create ./src/Receiver.sol:Receiver --rpc-url $OPTIMISM_SEPOLIA_RPC --constructor-args $OPTIMISM_SEPOLIA_ROUTER_ADDRESS --account deployer
 ```
 
 When prompted, enter the password that you set earlier, when you imported your wallet's private key.
 
-After running the command above, the contract will be deployed on the Optimism Goerli test network. You can view the deployment status and contract by using the [OP Goerli block explorer](https://goerli-optimism.etherscan.io/).
+After running the command above, the contract will be deployed on the Optimism sepolia test network. You can view the deployment status and contract by using the [OP sepolia block explorer](https://sepolia-optimism.etherscan.io/).
 
 ### Funding your smart contracts
 
@@ -533,10 +533,10 @@ In order to pay for the fees associated with sending messages, the `Sender` cont
 Fund your contract directly from your wallet, or by running the following `cast` command:
 
 ```bash
-cast send $BASE_GOERLI_LINK_ADDRESS --rpc-url $BASE_GOERLI_RPC "transfer(address,uint256)" `SENDER_CONTRACT_ADDRESS` 5 --account deployer
+cast send $BASE_SEPOLIA_LINK_ADDRESS --rpc-url $BASE_SEPOLIA_RPC "transfer(address,uint256)" `SENDER_CONTRACT_ADDRESS` 5 --account deployer
 ```
 
-The above command sends `5` LINK tokens on Base Goerli testnet to the `Sender` contract.
+The above command sends `5` LINK tokens on Base sepolia testnet to the `Sender` contract.
 
 <Info>
 Replace `SENDER_CONTRACT_ADDRESS` with the contract address of your deployed Sender contract before running the provided cast command.
@@ -548,23 +548,23 @@ Foundry provides the `cast` command-line tool that can be used to interact with 
 
 ### Sending data
 
-The `cast` command can be used to call the `sendMessage(uint64, address, string)` function on the `Sender` contract deployed to Base Goerli in order to send message data to the `Receiver` contract on Optimism Goerli.
+The `cast` command can be used to call the `sendMessage(uint64, address, string)` function on the `Sender` contract deployed to Base sepolia in order to send message data to the `Receiver` contract on Optimism sepolia.
 
 To call the `sendMessage(uint64, address, string)` function of the `Sender` smart contract, run:
 
 ```bash
-cast send `SENDER_CONTRACT_ADDRESS` --rpc-url $BASE_GOERLI_RPC "sendMessage(uint64, address, string)" $OPTIMISM_GOERLI_CHAIN_SELECTOR `RECEIVER_CONTRACT_ADDRESS` "Based" --account deployer
+cast send `SENDER_CONTRACT_ADDRESS` --rpc-url $BASE_sepolia_RPC "sendMessage(uint64, address, string)" $OPTIMISM_SEPOLIA_CHAIN_SELECTOR `RECEIVER_CONTRACT_ADDRESS` "Based" --account deployer
 ```
 
-The command above calls the `sendMessage(uint64, address, string)` to send a message. The parameters passed in to the method include: The chain selector to the destination chain (Optimism Goerli), the `Receiver` contract address, and the text data to be included in the message (`Based`).
-
+The command above calls the `sendMessage(uint64, address, string)` to send a message. The parameters passed in to the method include: The chain selector to the destination chain (Optimism sepolia), the `Receiver` contract address, and the text data to be included in the message (`Based`).
+ 
 <Info>
 Replace `SENDER_CONTRACT_ADDRESS` and `RECEIVER_CONTRACT_ADDRESS` with the contract addresses of your deployed Sender and Receiver contracts respectively before running the provided cast command.
 </Info>
 
 After running the command, a unique `messageId` should be returned.
 
-Once the transaction has been finalized, it will take a few minutes for CCIP to deliver the data to Optimism Goerli and call the `ccipReceive` function on the `Receiver` contract.
+Once the transaction has been finalized, it will take a few minutes for CCIP to deliver the data to Optimism sepolia and call the `ccipReceive` function on the `Receiver` contract.
 
 <Info>
 You can use the [CCIP explorer](https://ccip.chain.link/) to see the status of the CCIP transaction.
@@ -572,12 +572,12 @@ You can use the [CCIP explorer](https://ccip.chain.link/) to see the status of t
 
 ### Receiving data
 
-The `cast` command can also be used to call the `getMessage()` function on the `Receiver` contract deployed to Optimism Goerli in order to read the received message data.
+The `cast` command can also be used to call the `getMessage()` function on the `Receiver` contract deployed to Optimism sepolia in order to read the received message data.
 
 To call the `getMessage()` function of the `Receiver` smart contract, run:
 
 ```bash
-cast send `RECEIVER_CONTRACT_ADDRESS` --rpc-url $OPTIMISM_GOERLI_RPC "getMessage()" --account deployer
+cast send `RECEIVER_CONTRACT_ADDRESS` --rpc-url $OPTIMISM_SEPOLIA_RPC "getMessage()" --account deployer
 ```
 
 <Info>

--- a/docs/learn/onchain-app-development/finance/access-real-world-data-chainlink.mdx
+++ b/docs/learn/onchain-app-development/finance/access-real-world-data-chainlink.mdx
@@ -39,7 +39,7 @@ In order to deploy a smart contract, you will first need a wallet. You can creat
 
 Deploying contracts to the blockchain requires a gas fee. Therefore, you will need to fund your wallet with ETH to cover those gas fees.
 
-For this tutorial, you will be deploying a contract to the Base Goerli test network. You can fund your wallet with Base Goerli ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
+For this tutorial, you will be deploying a contract to the Base Sepolia test network. You can fund your wallet with Base Sepolia ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/base-chain/tools/network-faucets) page.
 
 ## What are Chainlink Data Feeds?
 
@@ -99,7 +99,7 @@ Once your project has been created and dependencies have been installed, you can
 
 The Solidity code below defines a smart contract named `DataConsumerV3`. The code uses the `AggregatorV3Interface` interface from the [Chainlink contracts library](https://docs.chain.link/data-feeds/api-reference#aggregatorv3interface) to provide access to price feed data.
 
-The smart contract passes an address to `AggregatorV3Interface`. This address (`0xcD2A119bD1F7DF95d706DE6F2057fDD45A0503E2`) corresponds to the `ETH/USD` price feed on the Base Goerli network.
+The smart contract passes an address to `AggregatorV3Interface`. This address (`0xcD2A119bD1F7DF95d706DE6F2057fDD45A0503E2`) corresponds to the `ETH/USD` price feed on the Base Sepolia network.
 
 <Info>
 Chainlink provides a number of price feeds for Base. For a list of available price feeds on Base, visit the [Chainlink documentation](https://docs.chain.link/data-feeds/price-feeds/addresses/?network=base&page=1).
@@ -115,7 +115,7 @@ Chainlink provides a number of price feeds for Base. For a list of available pri
        AggregatorV3Interface internal priceFeed;
 
       /**
-       * Network: Base Goerli
+       * Network: Base Sepolia
        * Aggregator: ETH/USD
        * Address: 0xcD2A119bD1F7DF95d706DE6F2057fDD45A0503E2
        */
@@ -170,12 +170,12 @@ To confirm that the wallet was imported as the `deployer` account in your Foundr
 cast wallet list
 ```
 
-### Setting up environment variables for Base Goerli
+### Setting up environment variables for Base Sepolia
 
-To setup your environment for deploying to the Base network, create an `.env` file in the home directory of your project, and add the RPC URL for the Base Goerli testnet:
+To setup your environment for deploying to the Base network, create an `.env` file in the home directory of your project, and add the RPC URL for the Base Sepolia testnet:
 
 ```
-BASE_GOERLI_RPC="https://goerli.base.org"
+BASE_SEPOLIA_RPC="https://Sepolia.base.org"
 ```
 
 Once the `.env` file has been created, run the following command to load the environment variables in the current command line session:
@@ -184,27 +184,27 @@ Once the `.env` file has been created, run the following command to load the env
 source .env
 ```
 
-### Deploying the smart contract to Base Goerli
+### Deploying the smart contract to Base Sepolia
 
-With your contract compiled and environment setup, you are ready to deploy the smart contract to the Base Goerli Testnet!
+With your contract compiled and environment setup, you are ready to deploy the smart contract to the Base Sepolia Testnet!
 
 For deploying a single smart contract using Foundry, you can use the `forge create` command. The command requires you to specify the smart contract you want to deploy, an RPC URL of the network you want to deploy to, and the account you want to deploy with.
 
-To deploy the `DataConsumerV3` smart contract to the Base Goerli test network, run the following command:
+To deploy the `DataConsumerV3` smart contract to the Base Sepolia test network, run the following command:
 
 ```bash
-forge create ./src/DataConsumerV3.sol:DataConsumerV3 --rpc-url $BASE_GOERLI_RPC --account deployer
+forge create ./src/DataConsumerV3.sol:DataConsumerV3 --rpc-url $BASE_SEPOLIA_RPC --account deployer
 ```
 
 When prompted, enter the password that you set earlier, when you imported your wallet's private key.
 
 <Info>
-Your wallet must be funded with ETH on the Base Goerli Testnet to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
+Your wallet must be funded with ETH on the Base Sepolia Testnet to cover the gas fees associated with the smart contract deployment. Otherwise, the deployment will fail.
 
-To get testnet ETH for Base Goerli, see the [prerequisites](#prerequisites).
+To get testnet ETH for Base Sepolia, see the [prerequisites](#prerequisites).
 </Info>
 
-After running the command above, the contract will be deployed on the Base Goerli test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
+After running the command above, the contract will be deployed on the Base Sepolia test network. You can view the deployment status and contract by using a [block explorer](/base-chain/tools/block-explorers).
 
 ## Interacting with the Smart Contract
 
@@ -213,7 +213,7 @@ Foundry provides the `cast` command-line tool that can be used to interact with 
 To call the `getLatestPrice()` function of the smart contract, run:
 
 ```bash
-cast call <DEPLOYED_ADDRESS> --rpc-url $BASE_GOERLI_RPC "getLatestPrice()"
+cast call <DEPLOYED_ADDRESS> --rpc-url $BASE_SEPOLIA_RPC "getLatestPrice()"
 ```
 
 You should receive the latest `ETH / USD` price in hexadecimal form.

--- a/docs/learn/storage/storage-exercise.mdx
+++ b/docs/learn/storage/storage-exercise.mdx
@@ -101,12 +101,15 @@ function debugResetShares() public {
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
-</Note>
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
+ </Note>
 
 
 {/* <CafeUnitTest nftNum={3}/> */}

--- a/docs/learn/structs/structs-exercise.mdx
+++ b/docs/learn/structs/structs-exercise.mdx
@@ -61,12 +61,15 @@ Add a public function called `resetMyGarage`. It should delete the entry in `gar
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
-</Note>
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
+ </Note>
 
 {/* <CafeUnitTest nftNum={7}/> */}
 

--- a/docs/learn/token-development/erc-20-token/erc-20-exercise.mdx
+++ b/docs/learn/token-development/erc-20-token/erc-20-exercise.mdx
@@ -101,12 +101,15 @@ If this vote takes the total number of votes to or above the `quorum` for that v
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
-</Note>
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
+ </Note>
 
 
 <Warning>

--- a/docs/learn/token-development/erc-721-token/erc-721-exercise.mdx
+++ b/docs/learn/token-development/erc-721-token/erc-721-exercise.mdx
@@ -70,12 +70,15 @@ The contract specification contains actions that can only be performed once by a
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](../deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
-</Note>
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
+ </Note>
 
 
 {/* <CafeUnitTest nftNum={15}/> */}

--- a/docs/learn/token-development/minimal-tokens/minimal-tokens-exercise.mdx
+++ b/docs/learn/token-development/minimal-tokens/minimal-tokens-exercise.mdx
@@ -48,12 +48,15 @@ A failure of either of these checks should result in a revert with an `UnsafeTra
 <Note>
 #### Hey, where'd my NFT go!?
 
-[Testnets](/learn/deployment-to-testnet/test-networks) are not permanent! Base Goerli [will soon be sunset](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), in favor of Base Sepolia.
+[Testnets](/learn/deployment-to-testnet/test-networks) Base Sepolia (https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4), is now the active test network and replaces the older testnets.
+Since these are separate networks with different data, your NFTs will not automatically transfer over.
 
-As these are separate networks with separate data, your NFTs **will not** transfer over.
+Don’t worry!
+We’ve already collected the addresses of all NFT owners from the previous testnet.
+When we release the mechanism to transfer these NFTs to mainnet later this year, all of those addresses will be included.
 
-**Don't worry!** We've captured the addresses of all NFT owners on Base Goerli and will include them when we release the mechanism to transfer these NFTs to mainnet later this year! You can also redeploy on Sepolia and resubmit if you'd like!
-</Note>
+If you’d like, you can also redeploy your NFTs on Base Sepolia and resubmit them.
+ </Note>
 
 
 <Warning>


### PR DESCRIPTION
This PR updates the learn section documentation to replace all references to Base Goerli with Base Sepolia, as Base Goerli is no longer supported.

## Changes Made

- **Updated 21 files** across the learn section with Base Goerli → Base Sepolia migration
- **Modified exercise files** to use Base Sepolia testnet endpoints
- **Updated deployment guides** to reference Base Sepolia instead of Base Goerli
- **Fixed network configurations** in onchain app development tutorials
- **Updated testnet references** in all learn section exercises

## Files Modified

### Core Learning Exercises
- `docs/learn/arrays/arrays-exercise.mdx`
- `docs/learn/control-structures/control-structures-exercise.mdx`
- `docs/learn/error-triage/error-triage-exercise.mdx`
- `docs/learn/imports/imports-exercise.mdx`
- `docs/learn/inheritance/inheritance-exercise.mdx`
- `docs/learn/mappings/mappings-exercise.mdx`
- `docs/learn/new-keyword/new-keyword-exercise.mdx`
- `docs/learn/storage/storage-exercise.mdx`
- `docs/learn/structs/structs-exercise.mdx`

### Token Development
- `docs/learn/token-development/erc-20-token/erc-20-exercise.mdx`
- `docs/learn/token-development/erc-721-token/erc-721-exercise.mdx`
- `docs/learn/token-development/minimal-tokens/minimal-tokens-exercise.mdx`

### Deployment & Testing
- `docs/learn/deployment-to-testnet/deployment-to-base-sepolia-sbs.mdx`
- `docs/learn/deployment-to-testnet/deployment-to-testnet-exercise.mdx`
- `docs/learn/deployment-to-testnet/test-networks.mdx`

### Onchain App Development
- `docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-biconomy.mdx`
- `docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-privy-and-the-base-paymaster.mdx`
- `docs/learn/onchain-app-development/account-abstraction/gasless-transactions-with-paymaster.mdx`
- `docs/learn/onchain-app-development/cross-chain/send-messages-and-tokens-from-base-chainlink.mdx`
- `docs/learn/onchain-app-development/finance/access-real-world-data-chainlink.mdx`

### Overview & Introduction
- `docs/learn/introduction-to-solidity/introduction-to-solidity-overview.mdx`

## Impact

- **324 total references** updated from Base Goerli to Base Sepolia
- **48 files** across the learn section now use the supported testnet
- **All exercise files** now reference working testnet endpoints
- **Deployment guides** updated to use current network configurations

## Testing

- [1] All references to Base Goerli have been replaced with Base Sepolia
- [2] Network configurations updated to use supported testnet
- [3] Exercise files maintain consistent formatting and structure
- [4] No breaking changes to existing documentation structure

## Related

This change ensures the learn section documentation remains current and functional, as Base Goerli testnet is no longer supported by Base.

---

**Note**: This is a focused, maintenance update that keeps the documentation current with Base's supported testnets. All changes are within the existing learn section structure and maintain consistency with the established documentation patterns.
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
by me 
