### PR TITLE
Fix deployment tutorial: add --broadcast flag and clarify env setup

### DIFF
--- a/docs/base-chain/quickstart/deploy-on-base.mdx
+++ b/docs/base-chain/quickstart/deploy-on-base.mdx
@@ -100,38 +100,67 @@ Never share or commit your private key. Always keep it secure and handle with ca
 
 Now that your environment is set up, let's deploy your contracts to Base Sepolia.
 
-1. Use the following command to compile and deploy your contract
+1. (Optional) First, perform a dry run to simulate the deployment and verify everything is configured correctly:
 
 ```bash
 forge create ./src/Counter.sol:Counter --rpc-url $BASE_SEPOLIA_RPC_URL --account deployer
 ```
 
+This performs a simulation without broadcasting the transaction to the network. You'll see the transaction details and contract ABI, but no actual deployment will occur.
+
+2. Deploy your contract by adding the `--broadcast` flag:
+
+```bash
+forge create ./src/Counter.sol:Counter --rpc-url $BASE_SEPOLIA_RPC_URL --account deployer --broadcast
+```
+
+<Tip>
+The `--broadcast` flag is **required** to actually deploy your contract to the network. Without it, Foundry only performs a dry run simulation.
+</Tip>
+
 Note the format of the contract being deployed is `<contract-path>:<contract-name>`.
 
-2. After successful deployment, the transaction hash will be printed to the console output
+3. After successful deployment, you'll see output including:
 
-3. Copy the deployed contract address and add it to your `.env` file
+```
+Deployer: 0x...
+Deployed to: 0x...  <-- YOUR CONTRACT ADDRESS
+Transaction hash: 0x...
+```
+
+4. Copy the deployed contract address and add it to your `.env` file:
 
 ```bash
 COUNTER_CONTRACT_ADDRESS="0x..."
 ```
 
-4. Load the new environment variable
+Replace `0x...` with your actual deployed contract address from the output above.
+
+5. Load the new environment variable:
 
 ```bash
 source .env
 ```
 
+<Tip>
+You need to run `source .env` after modifying your `.env` file to load the new variables in your current terminal session.
+</Tip>
+
 ### Verify Your Deployment
 
 To ensure your contract was deployed successfully:
 
-1. Check the transaction on [Sepolia Basescan](https://sepolia.basescan.org/).
-2. Use the `cast` command to interact with your deployed contract from the command line
+1. Check the transaction on [Sepolia Basescan](https://sepolia.basescan.org/) using your transaction hash
+2. Use the `cast` command to interact with your deployed contract from the command line:
 
 ```bash
 cast call $COUNTER_CONTRACT_ADDRESS "number()(uint256)" --rpc-url $BASE_SEPOLIA_RPC_URL
 ```
+
+<Tip>
+Make sure you've added `COUNTER_CONTRACT_ADDRESS` to your `.env` file and run `source .env` before running this command. Otherwise, the environment variable will be undefined and the command will fail.
+</Tip>
+
 This will return the initial value of the Counter contract's `number` storage variable, which will be `0`.
 
 **Congratulations! You've deployed your smart contracts to Base Sepolia!**


### PR DESCRIPTION
## What changed? Why?

This PR fixes two critical issues in the Deploy on base tutorial that were discovered while following the tutorial step-by-step.

**Issue 1: Missing `--broadcast` flag in deployment command**

The current documentation provides a deployment command that only performs a dry run simulation without actually deploying the contract to the network. Delopers see transaction details but receive a warning `"Dry run enabled, not broadcasting transaction"`, and no contract address is generated. This causes confusion because users expect successful deployment but no transaction hash is printed to the console.

**Changes:**
- Added optional dry run step to explain simulation behavior
- Updated deployment command to include the `--broadcast` flag
- Added tip callout explaining that `--broadcast` is required for actual deployment
- Enhanced output format display to show exactly what users will see after deployment

**Issue 2: Unclear environment variable setup for verification**

The verification section instructs users to run a cast call using `$COUNTER_CONTRACT_ADDRESS`, but the documentation never clearly explains when to copy the contract address, what the deployment output looks like, or that `source .env` must be run after adding the variable. This results in an undefined environment variable and a confusing error: `error: invalid value 'number()(uint256)' for '[TO]': odd number of digits`.

**Changes:**
- Added explicit step showing the deployment output format with clear labels
- Clarified instructions to copy the "Deployed to:" address to `.env`
- Added reminder to run `source .env` after modifying the file
- Included tip in verification section warning about undefined environment variables

These changes prevent silent failures, make environment variable setup explicit, and provide helpful guidance at points where developers are likely to get stuck.

## Notes to reviewers

The changes maintain the tutorial's flow while adding critical missing information. The new tips use the existing `<Tip>` component for consistency with the rest of the documentation. All instructions are actionable and specific, reducing ambiguity for first-time users.

## How has it been tested?

I followed the updated tutorial from start to finish on Base Sepolia and verified that:
- The dry run command shows simulation without deploying
- The deployment command with `--broadcast` successfully deploys the contract  
- The contract address and transaction hash appears in the deployment output as documented
- Adding the address to `.env` and running `source .env` works correctly
- The verification command successfully calls the contract
- The transaction appears on Sepolia Basescan

I also spun up the documentation site locally and reviewed the updated pages to ensure the formatting displays correctly, the tips render properly, and the content flows naturally within the existing tutorial structure.