### PR TITLE
Fix typo: 'monetiziation' -> 'monetization' in get-started/base.mdx

### DIFF
--- a/docs/get-started/base.mdx
+++ b/docs/get-started/base.mdx
@@ -16,7 +16,7 @@ Build on Base and choose the features that fits your needs — from sub-cent glo
   </Accordion>
   <Accordion title="Creator Tools">
     **Creator Monetization:** Creators of all kinds are exploring new ways to
-    monetize their work. Innovate on the frontier of creator monetiziation with
+    monetize their work. Innovate on the frontier of creator monetization with
     the creator economy on Base.
   </Accordion>
   <Accordion title="Builder Experience">


### PR DESCRIPTION
## What Changed
- Fixed spelling error in the get-started/base.mdx file
- Changed 'monetiziation' to 'monetization' in creator monetization section

## Why
This improves the readability and professionalism of the documentation.

## Testing
- [x] Verified the change locally
- [x] Confirmed the typo is fixed
- [x] Checked that the page still renders correctly