### PR TITLE
remove dead-link reference to data driven growth

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -453,7 +453,6 @@
           {
             "group": "Technical Guides",
             "pages": [
-              "mini-apps/technical-guides/data-driven-growth",
               "mini-apps/technical-guides/search-and-discovery",
               "mini-apps/technical-guides/sharing-and-social-graph",
               "mini-apps/technical-guides/sign-manifest",


### PR DESCRIPTION
The Data Driven technical guide was still listed in the docs.json navigation object despite being removed from docs