### PR TITLE
Fixed broken links for Foundry "cast wallet import"

### DIFF
--- a/docs/learn/onchain-app-development/cross-chain/send-messages-and-tokens-from-base-chainlink.mdx
+++ b/docs/learn/onchain-app-development/cross-chain/send-messages-and-tokens-from-base-chainlink.mdx
@@ -448,7 +448,7 @@ forge build
 
 Before you can deploy your smart contract to the Base network, you will need to set up a wallet to be used as the deployer.
 
-To do so, you can use the [`cast wallet import`](https://book.getfoundry.sh/reference/cast/cast-wallet-import) command to import the private key of the wallet into Foundry's securely encrypted keystore:
+To do so, you can use the [`cast wallet import`](https://getfoundry.sh/cast/reference/wallet/import/#cast-wallet-import) command to import the private key of the wallet into Foundry's securely encrypted keystore:
 
 ```bash
 cast wallet import deployer --interactive

--- a/docs/learn/onchain-app-development/finance/access-real-time-asset-data-pyth-price-feeds.mdx
+++ b/docs/learn/onchain-app-development/finance/access-real-time-asset-data-pyth-price-feeds.mdx
@@ -159,7 +159,7 @@ forge build
 
 Before you can deploy your smart contract to the Base network, you will need to set up a wallet to be used as the deployer.
 
-To do so, you can use the [`cast wallet import`](https://book.getfoundry.sh/reference/cast/cast-wallet-import) command to import the private key of the wallet into Foundry's securely encrypted keystore:
+To do so, you can use the [`cast wallet import`](https://getfoundry.sh/cast/reference/wallet/import/#cast-wallet-import) command to import the private key of the wallet into Foundry's securely encrypted keystore:
 
 ```bash
 cast wallet import deployer --interactive

--- a/docs/learn/onchain-app-development/finance/access-real-world-data-chainlink.mdx
+++ b/docs/learn/onchain-app-development/finance/access-real-world-data-chainlink.mdx
@@ -150,7 +150,7 @@ forge build
 
 Before you can deploy your smart contract to the Base network, you will need to set up a wallet to be used as the deployer.
 
-To do so, you can use the [`cast wallet import`](https://book.getfoundry.sh/reference/cast/cast-wallet-import) command to import the private key of the wallet into Foundry's securely encrypted keystore:
+To do so, you can use the [`cast wallet import`](https://getfoundry.sh/cast/reference/wallet/import/#cast-wallet-import) command to import the private key of the wallet into Foundry's securely encrypted keystore:
 
 ```bash
 cast wallet import deployer --interactive


### PR DESCRIPTION
What changed? Why?
change broken links for Foundry "cast wallet import"

docs/learn/onchain-app-development/cross-chain/send-messages-and-tokens-from-base-chainlink.mdx

docs/learn/onchain-app-development/finance/access-real-time-asset-data-pyth-price-feeds.mdx

docs/learn/onchain-app-development/finance/access-real-world-data-chainlink.mdx

Notes to reviewers

How has it been tested?
I have manually tested every link now links are redirecting to correctly website.