### PR TITLE
Fix: correct link to Privacy Policy on cookie-policy page

### DIFF
--- a/docs/cookie-policy.mdx
+++ b/docs/cookie-policy.mdx
@@ -21,7 +21,7 @@ control our use of them.
 
 In some cases, we may use cookies and similar technologies to collect personal information,
 or information that becomes personal information if we combine it with other information.
-In such cases, the [Base Privacy Policy](/privacy-policy) will apply
+In such cases, the [Base Privacy Policy](privacy-policy.mdx) will apply
 in addition to this Cookie Policy.
 
 ## 1. What Are Cookies?


### PR DESCRIPTION
- /privacy-policy → privacy-policy.mdx (relative link)
Reason: absolute root links break in nested deployments; relative MDX link resolves correctly within docs.
