### PR TITLE
docs(quickstart): replace deprecated `testFail*` using `test_Revert_*` and `vm.expectRevert`

### DIFF
--- a/docs/get-started/launch-token.mdx
+++ b/docs/get-started/launch-token.mdx
@@ -326,17 +326,18 @@ contract MyTokenTest is Test {
         assertEq(token.totalSupply(), INITIAL_SUPPLY - burnAmount);
     }
     
-    function testFailMintExceedsMaxSupply() public {
+    function test_Revert_MintExceedsMaxSupply() public {
         // This test should fail when trying to mint more than max supply
         uint256 excessiveAmount = token.MAX_SUPPLY() + 1;
-        
         vm.prank(owner);
+        vm.expectRevert("Minting would exceed max supply");
         token.mint(user, excessiveAmount);
     }
     
-    function testFailUnauthorizedMinting() public {
+    function test_Revert_UnauthorizedMinting() public {
         // This test should fail when non-owner tries to mint
         vm.prank(user);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", user));
         token.mint(user, 1000 * 10**18);
     }
 }


### PR DESCRIPTION
This updates the Quickstart → Launch a token test example.

Following the guide: https://docs.base.org/get-started/launch-token#token-launch-platforms-on-base I got the error:
```
Ran 2 tests for test/MyToken.t.sol:MyTokenTest
[FAIL: `testFail*` has been removed. Consider changing to test_Revert[If|When]_Condition and expecting a revert] testFailMintExceedsMaxSupply() (gas: 0)
[FAIL: `testFail*` has been removed. Consider changing to test_Revert[If|When]_Condition and expecting a revert] testFailUnauthorizedMinting() (gas: 0)
Suite result: FAILED. 0 passed; 2 failed; 0 skipped; finished in 3.27ms (0.00ns CPU time)
```

Foundry removed support for `testFail*` tests. Tests should now explicitly expect reverts using `vm.expectRevert(...)` and use the `test_Revert_*` naming pattern e.g https://getfoundry.sh/forge/tests/writing-tests/
