### PR TITLE
Fix: CDP guide → correct link to Wagmi setup (wagmi/setup.mdx)

### DIFF
--- a/docs/base-account/framework-integrations/cdp.mdx
+++ b/docs/base-account/framework-integrations/cdp.mdx
@@ -610,7 +610,7 @@ We are actively working on native Base Account integration with CDP Embedded Wal
 
 - [CDP Embedded Wallets Documentation](https://docs.cdp.coinbase.com/embedded-wallets/)
 - [CDP React Components Documentation](https://docs.cdp.coinbase.com/embedded-wallets/components)
-- [Base Account Wagmi Setup](/base-account/framework-integrations/wagmi/setup)
+- [Base Account Wagmi Setup](wagmi/setup.mdx)
 - [CDP Portal](https://portal.cdp.coinbase.com/)
 - [Wagmi Documentation](https://wagmi.sh/)
 


### PR DESCRIPTION
- /base-account/.../wagmi/setup → wagmi/setup.mdx
Reason: use local relative link to the existing MDX page; absolute path breaks in nested contexts.