### PR TITLE
README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Prerequisite: Node.js v19+.
 npm i -g mint
 ```
 
-3. Preview locally (run from the `docs/` directory where `docs.json` lives):
+3. Preview locally (run from the `docs/` directory where `mint.json` lives):
 
 ```bash
 cd docs
@@ -53,7 +53,7 @@ npx mint dev
 
 ### Troubleshooting
 
-- Ensure Node.js v19+ is installed and that you run `mint dev` from the directory containing `docs.json` (usually `docs/`).
+- Ensure Node.js v19+ is installed and that you run `mint dev` from the directory containing `mint.json` (usually `docs/`).
 - Local preview differs from production: run `mint update` to update the CLI.
 
 ## How to contribute


### PR DESCRIPTION
What this change does
- Fixes the Mintlify config filename in README: docs.json → mint.json in Local development and Troubleshooting sections.

Why
- Mintlify uses mint.json as the config file. Correcting this prevents confusion and failed local previews.

Scope / risk
- Docs-only change (README). No impact on code, build, or runtime.

