### PR TITLE
Fix Wagmi prerequisite links in sub-accounts.mdx

### DIFF
--- a/docs/base-account/framework-integrations/wagmi/sub-accounts.mdx
+++ b/docs/base-account/framework-integrations/wagmi/sub-accounts.mdx
@@ -8,8 +8,8 @@ Learn how to create and manage Sub Accounts using Wagmi hooks and Base Account p
 ## Prerequisites
 
 Make sure you have:
-- [Set up Wagmi with Base Account](/base-account/framework-integrations/wagmi/setup)
-- [Implemented Sign in with Base](/base-account/framework-integrations/wagmi/sign-in-with-base)
+- [Set up Wagmi with Base Account](./setup.mdx)
+- [Implemented Sign in with Base](./setup.mdx)
 
 ## Overview
 


### PR DESCRIPTION
This PR corrects two prerequisite links in `docs/base-account/framework-integrations/wagmi/sub-accounts.mdx`:

- Set up Wagmi with Base Account → `./setup.mdx`
- Implement Sign in with Base   → `./sign-in-with-base.mdx`

Absolute `/base-account/...` links can break under nested routes; relative MDX links are reliable across environments.
