### PR TITLE
Fix typo in prompts section of build-app.mdx

### DIFF
--- a/docs/get-started/build-app.mdx
+++ b/docs/get-started/build-app.mdx
@@ -32,7 +32,7 @@ Base is a fast, low-cost, builder-friendly Ethereum L2 built to bring the next b
   npm create onchain@latest
   ```
 
-  The prompots will ask you for a CDP API Key which you can get [here](https://portal.cdp.coinbase.com/projects/api-keys/client-key).
+  The prompts will ask you for a CDP API Key which you can get [here](https://portal.cdp.coinbase.com/projects/api-keys/client-key).
 
   Once you've gone through the prompts, you'll have a new project directory with a basic OnchainKit app. Run the following to see it live.
 


### PR DESCRIPTION
**What changed? Why?**
Fixed typo in build an app docs
