### PR TITLE
update base builder object to reference ownerAddress

### DIFF
--- a/docs/mini-apps/core-concepts/manifest.mdx
+++ b/docs/mini-apps/core-concepts/manifest.mdx
@@ -13,7 +13,7 @@ description: "Define how your mini app appears and behaves within the Base app, 
     "signature": "MHgxMGQwZGU4ZGYwZDUwZTdmMGIxN2YxMTU2NDI1MjRmZTY0MTUyZGU4ZGU1MWU0MThiYjU4ZjVmZmQxYjRjNDBiNGVlZTRhNDcwNmVmNjhlMzQ0ZGQ5MDBkYmQyMmNlMmVlZGY5ZGQ0N2JlNWRmNzMwYzUxNjE4OWVjZDJjY2Y0MDFj"
   },
   "baseBuilder": {
-    "allowedAddresses": ["0x..."]
+    "ownerAddress": "0x..." 
   },
   "miniapp": {
     "version": "1",
@@ -91,7 +91,7 @@ Signature over the payload.
 
 This verifies ownership and connects your Base Build account.This address should be the address of the wallet used when importing your mini app to Base Build.
 <Card>
-<ParamField path="allowedAddresses" type="Array of strings" required>
+<ParamField path="ownerAddress" type="string" required>
 This verifies ownership and connects your Base Build account.
 </ParamField>
 </Card>

--- a/docs/mini-apps/llms-full.txt
+++ b/docs/mini-apps/llms-full.txt
@@ -185,7 +185,7 @@ Example manifest fields (conceptual):
     "signature": "MHgxMGQwZGU4ZGYwZDUwZTdmMGIxN2YxMTU2NDI1MjRmZTY0MTUyZGU4ZGU1MWU0MThiYjU4ZjVmZmQxYjRjNDBiNGVlZTRhNDcwNmVmNjhlMzQ0ZGQ5MDBkYmQyMmNlMmVlZGY5ZGQ0N2JlNWRmNzMwYzUxNjE4OWVjZDJjY2Y0MDFj"
   },
   "baseBuilder": {
-    "allowedAddresses": ["0x..."]
+    "ownerAddress": "0x..."
   },
   "frame": {
     "version": "1",

--- a/docs/mini-apps/quickstart/migrate-existing-apps.mdx
+++ b/docs/mini-apps/quickstart/migrate-existing-apps.mdx
@@ -107,7 +107,7 @@ For details on each field, see the [field reference](/mini-apps/features/manifes
     "signature": ""
   },
   "baseBuilder": {
-    "allowedAddresses": [""] // add your Base Account address here
+    "ownerAddress": "0x" // add your Base Account address here
   },
   "miniapp": {
     "version": "1",

--- a/docs/mini-apps/troubleshooting/common-issues.mdx
+++ b/docs/mini-apps/troubleshooting/common-issues.mdx
@@ -204,7 +204,7 @@ Use the Coinbase Wallet validator for Base App compatibility analysis. This AI-p
     "signature": "your-farcaster-signature"
   },
     "baseBuilder": {
-    "allowedAddresses": ["0x..."]
+    "ownerAddress": "0x..."
   },
   "frame": {
     "name": "Your Mini App",


### PR DESCRIPTION
**What changed? Why?**
Only reference `ownerAddress` instead of `allowedAddresses` as it is the preferred method for adding app owner in Base Build

**Notes to reviewers**

**How has it been tested?**
