### PR TITLE
Fix XMTP agent getting started guide Step 4

### DIFF
--- a/docs/base-app/agents/getting-started.mdx
+++ b/docs/base-app/agents/getting-started.mdx
@@ -60,34 +60,74 @@ XMTP_ENV=dev # Environment (local, dev, production)
 
 **STEP 4: WRITE YOUR AGENT LOGIC**
 
-Create a basic agent that responds to messages:
+Create a basic agent that responds to messages.
+
+**1. Create your agent file in the project root:**
+
+```bash
+touch index.ts
+```
+
+**2. Add the following code to `index.ts`:**
 
 ```javascript
-import { Agent, getTestUrl } from "@xmtp/agent-sdk";
+// Import dotenv to load environment variables from .env file
+import "dotenv/config";
+import { Agent } from "@xmtp/agent-sdk";
 
-// 2. Spin up the agent
+// Create the agent using environment variables from .env file
 const agent = await Agent.createFromEnv({
-  env: "dev", // or 'production' for base app
+  env: "dev", // Use "production" when deploying to Base App
 });
 
-// 3. Respond to text messages
+// Listen for incoming text messages and respond automatically
+// ctx.sendText() sends a message back to the user who messaged the agent
 agent.on("text", async (ctx) => {
   await ctx.sendText("Hello from my XMTP Agent! 👋");
 });
 
-// 4. Log when we're ready
+// Log when the agent starts successfully
+// The agent.address is where users can message your agent
+
 agent.on("start", () => {
-  console.log(`We are online: ${getTestUrl(agent)}`);
+  console.log(`Agent is online at address: ${agent.address}`);
 });
 
+// Start the agent and begin listening for messages
 await agent.start();
 ```
 
-Then run your agent:
+<Tip>
+The `import "dotenv/config"` line at the top is **critical** - without it, you'll get an error: `XMTP_WALLET_KEY env is not in hex (0x) format`. This import loads your `.env` file so the agent can access your wallet key.
+</Tip>
+
+**3. Run your agent:**
 
 ```bash
-npm run dev
+npx tsx --watch index.ts
 ```
+
+After running successfully, you'll see output like:
+
+```
+Agent is online at address: 0x4a86dfa0ad31801256dd5f8bdf95b3ea5bbe2ba9
+```
+
+**4. Test your agent:**
+
+Since the agent doesn't output a direct chat link, you need to manually test it:
+
+1. Copy the agent address from your terminal output
+2. Go to [xmtp.chat](https://xmtp.chat)
+3. Connect your wallet (MetaMask, Coinbase Wallet, etc.)
+4. Switch to **Dev environment** in xmtp.chat settings (top right)
+5. Click "Create a new direct message"
+6. Paste your agent's address
+7. Send any message - your agent should respond with "Hello from my XMTP Agent! 👋"
+
+<Tip>
+Make sure the environment in xmtp.chat matches your agent's environment. If your agent uses `env: "dev"`, you must be in Dev mode on xmtp.chat. For production agents, use Production mode.
+</Tip>
 
 ### Getting the address of a user
 
@@ -100,7 +140,9 @@ agent.on("text", async (ctx) => {
 });
 ```
 
-You can also explore example implementations in the `/examples` folder, including:
+### Exploring Example Agents
+
+You can explore pre-built example implementations in the `/examples` folder:
 
 - [xmtp-gm](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-gm): A simple agent that replies to all text messages with "gm"
 - [xmtp-gpt](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-gpt): An example using GPT API's to answer messages


### PR DESCRIPTION
## What changed? Why?

This PR fixes critical issues in **Step 4 of the XMTP agent getting started guide** that prevented users from successfully creating and running their first agent.  

While following the tutorial, I encountered multiple blocking errors that made it impossible to complete the guide.

---

### **Issue 1: Deprecated `getTestUrl` import causing SyntaxError**

**Problem:**  
The documentation shows this import:

```javascript
import { Agent, getTestUrl } from "@xmtp/agent-sdk";
```

**Error encountered:**
```
SyntaxError: The requested module '@xmtp/agent-sdk' does not provide an export named 'getTestUrl'
```

**Root cause:**  
The `getTestUrl` export has been removed or deprecated from the `@xmtp/agent-sdk` package.

**Solution:**  
Removed the deprecated import and simplified the start event logging to only show the agent address.

---

### **Issue 2: Missing environment variable loading causing `XMTP_WALLET_KEY` error**

**Problem:**  
When running the agent code from the documentation, it immediately failed with:

```
AgentError: XMTP_WALLET_KEY env is not in hex (0x) format.
    at Agent.createFromEnv (/node_modules/@xmtp/agent-sdk/src/core/Agent.ts:190:13)
```

**Root cause:**  
The `.env` file existed with correct values, but the code wasn’t loading environment variables before calling `Agent.createFromEnv()`.

**Solution:**  
Added `import "dotenv/config";` at the top of the code to load environment variables before the agent initializes.

---

### **Issue 3: Unclear file location for agent code**

**Problem:**  
Step 4 showed the agent code but never explicitly stated where to create the file. I was left guessing whether to:

- Create it in the examples folder  
- Create it in the root  
- Replace an existing file  

**Solution:**  
Added explicit instructions to create `index.ts` in the project root using:

```bash
touch index.ts
```

---

### **Issue 4: Incorrect run command**

**Problem:**  
The documentation mentioned `npm run dev`, but this runs the default example (`xmtp-gm`) from `package.json`, not the developer's newly created agent.

**Solution:**  
Updated instructions to use:

```bash
npx tsx --watch index.ts
```

which directly runs the dev's agent file.

---

### **Issue 5: Adding testing instructions**

**Problem:**  
After fixing the above issues, the agent runs successfully but only outputs:

```
Agent is online at address: 0x4a86dfa0ad31801256dd5f8bdf95b3ea5bbe2ba9
```

There were no clickable links or instructions on how to interact with the agent.

**Solution:**  
Added **comprehensive testing instructions**:

1. Copy the agent address from terminal  
2. Go to [xmtp.chat](https://xmtp.chat)  
3. Connect wallet  
4. Switch to **Dev environment**  
5. Start new conversation with the agent address  
6. Send a message and verify the response  

---

### **Added explanatory comments to code **

Added detailed inline comments explaining:

- Why `dotenv/config` is needed  
- What `createFromEnv` does  
- How the event listeners work  
- What each parameter means  


### **Added**

- 💡 **Tip callout** explaining the critical importance of `import "dotenv/config"`.  
- Clear file creation instructions (`touch index.ts` in root).  
- Correct run command (`npx tsx --watch index.ts`).  
- Step-by-step testing instructions for [xmtp.chat](https://xmtp.chat).  
- Tip about environment matching (`dev` vs `production`).  
- Detailed Inline code comments for more clarity.

---

### **Removed**

- Deprecated `getTestUrl` import and usage.  
- Confusing sections about the examples folder workflow.

---

## **Notes to Reviewers**

These changes address **real, blocking errors** that prevented me from completing the tutorial.  
Every change is based on actual errors encountered during testing:
The updated code has been **tested end-to-end** and works successfully.  
I also **spun up the documentation site locally** to verify formatting and that the Tip callouts render correctly.

---

## **How has it been tested?**

Started from a fresh clone of the `xmtp-agent-examples` repository  
Verified agent started without errors  
Sent test messages and confirmed agent responded with  
`"Hello from my XMTP Agent! 👋"`  
Spun up documentation site locally

