### PR TITLE
Add missing link to node providers in L1 RPC URL section

### DIFF
--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -47,7 +47,7 @@ This tutorial assumes you are familiar with [Docker](https://www.docker.com/) an
 
 ### L1 RPC URL
 
-You'll need your own L1 RPC URL. This can be one that you run yourself, or via a third-party provider, such as our [partners].
+You'll need your own L1 RPC URL. This can be one that you run yourself, or via a third-party provider, such as our [partners](/base-chain/tools/node-providers).
 
 ## Running a Node
 


### PR DESCRIPTION
**What changed? Why?**
Updated the L1 RPC URL section to include a link to node providers. It was missing

**Notes to reviewers**

**How has it been tested?**
