### PR TITLE
Fix: Update 4 broken internal links from /base-learn to /learn

### DIFF
--- a/docs/learn/hardhat/hardhat-tools-and-testing/analyzing-test-coverage.mdx
+++ b/docs/learn/hardhat/hardhat-tools-and-testing/analyzing-test-coverage.mdx
@@ -233,6 +233,6 @@ In this tutorial, you've learned how to profile and analyze the test coverage of
 
 [Hardhat]: https://hardhat.org/
 [Solidity Coverage]: https://github.com/sc-forks/solidity-coverage
-[Hardhat testing lesson]: https://docs.base.org/base-learn/docs/hardhat-testing/hardhat-testing-sbs
+[Hardhat testing lesson]: https://docs.base.org/learn/hardhat/hardhat-testing/hardhat-testing-sbs
 [Base Learn]: https://base.org/learn
 

--- a/docs/learn/hardhat/hardhat-tools-and-testing/overview.mdx
+++ b/docs/learn/hardhat/hardhat-tools-and-testing/overview.mdx
@@ -69,6 +69,6 @@ These guides assume that you're reasonably comfortable writing basic smart contr
 
 We also assume that you've got Hardhat up and running, and can write unit tests for your smart contracts. If you're not there yet, but already know Solidity, you can [setup Hardhat here].
 
-[setup Hardhat here]: https://docs.base.org/base-learn/docs/hardhat-setup-overview/hardhat-setup-overview-sbs
+[setup Hardhat here]: https://docs.base.org/learn/hardhat/hardhat-setup-overview/hardhat-setup-overview-sbs
 [Hardhat plugins]: https://hardhat.org/hardhat-runner/plugins
 [Base Learn]: https://base.org/learn

--- a/docs/learn/onchain-app-development/reading-and-displaying-data/useReadContract.mdx
+++ b/docs/learn/onchain-app-development/reading-and-displaying-data/useReadContract.mdx
@@ -451,7 +451,7 @@ contract FEWeightedVoting is ERC20 {
 [Wallet Connectors]: ../frontend-setup/wallet-connectors/
 [`useAccount`]: https://wagmi.sh/react/hooks/useAccount
 [hydration error]: https://nextjs.org/docs/messages/react-hydration-error
-[ERC 20 Tokens Exercise]: https://docs.base.org/base-learn/docs/erc-20-token/erc-20-exercise
+[ERC 20 Tokens Exercise]: https://docs.base.org/learn/token-development/erc-20-token/erc-20-exercise
 [Sepolia BaseScan]: https://sepolia.basescan.org/
 [`useAccount` hook]: ./useAccount
 [Hardhat]: https://hardhat.org/

--- a/docs/learn/token-development/nft-guides/signature-mint.mdx
+++ b/docs/learn/token-development/nft-guides/signature-mint.mdx
@@ -360,7 +360,7 @@ const data = encodeFunctionData({
 In this tutorial, you've learned how to create a signature mint, which allows you to set conditions on a backend before a user is allowed to mint your NFT. You've learned the detailed and specific steps needed to align [viem]'s method of signing messages with [OpenZeppelin]'s method of verifying them. Finally, you've learned a few of the risks and considerations needed in designing this type of mint.
 
 [Base Learn]: https://base.org/learn
-[ERC-721 Tokens]: https://docs.base.org/base-learn/docs/erc-721-token/erc-721-standard-video
+[ERC-721 Tokens]: https://docs.base.org/learn/token-development/erc-721-token/erc-721-standard-video
 [Vercel]: https://vercel.com
 [deploying with Vercel]: /tutorials/farcaster-frames-deploy-to-vercel
 [OpenZeppelin ERC-721]: https://docs.openzeppelin.com/contracts/2.x/api/token/erc721


### PR DESCRIPTION
### Summary

This Pull Request fixes 4 broken internal links within the documentation by updating the deprecated `/base-learn/docs/` prefix to the correct `/learn/` path.

The links were pointing to an old structure that no longer exists, resulting in 404 errors for users trying to access these tutorials.

### Changes

The following links were updated:

1.  **`analyzing-test-coverage.mdx`**: Link to Hardhat testing lesson.
    *   **Old path:** `/base-learn/docs/hardhat-testing/...`
    *   **New path:** `/learn/hardhat/hardhat-testing/...`
2.  **`overview.mdx`**: Link to Hardhat setup overview.
    *   **Old path:** `/base-learn/docs/hardhat-setup-overview/...`
    *   **New path:** `/learn/hardhat/hardhat-setup-overview/...`
3.  **`useReadContract.mdx`**: Link to ERC 20 Tokens Exercise.
    *   **Old path:** `/base-learn/docs/erc-20-token/...`
    *   **New path:** `/learn/token-development/erc-20-token/...`
4.  **`signature-mint.mdx`**: Link to ERC-721 Tokens video.
    *   **Old path:** `/base-learn/docs/erc-721-token/...`
    *   **New path:** `/learn/token-development/erc-721-token/...`

All new paths correspond to existing files in the current repository structure, ensuring the links are functional.
