### PR TITLE
Change function argument types from uint to int

### DIFF
--- a/docs/learn/contracts-and-basic-functions/basic-functions-exercise.mdx
+++ b/docs/learn/contracts-and-basic-functions/basic-functions-exercise.mdx
@@ -23,8 +23,8 @@ Create a contract called `BasicMath`. It should not inherit from any other contr
 
 A function called `adder`. It must:
 
-- Accept two `uint` arguments, called `_a` and `_b`
-- Return a `uint` `sum` and a `bool` `error`
+- Accept two `int` arguments, called `_a` and `_b`
+- Return a `int` `sum` and a `bool` `error`
 - If `_a` + `_b` does not overflow, it should return the `sum` and an `error` of `false`
 - If `_a` + `_b` overflows, it should return `0` as the `sum`, and an `error` of `true`
 
@@ -33,6 +33,6 @@ A function called `adder`. It must:
 A function called `subtractor`. It must:
 
 - Accept two `uint` arguments, called `_a` and `_b`
-- Return a `uint` `difference` and a `bool` `error`
+- Return a `int` `difference` and a `bool` `error`
 - If `_a` - `_b` does not underflow, it should return the `difference` and an `error` of `false`
 - If `_a` - `_b` underflows, it should return `0` as the `difference`, and an `error` of `true`


### PR DESCRIPTION


**What changed? Why?**
uint data type

When dealing with uint you're not allowed to pass in negative numbers and the exercise requires you to pass in a negative number to check for underflow or overflow errors.

if the data type is uint when a negative value is provided you'd run into a (value out of bounds error) which will stop the function from running.

**Notes to reviewers**

**How has it been tested?**
tested via remix IDE
