### PR TITLE
Fix broken Coinbase x402 SDK link

### DIFF
--- a/docs/base-app/agents/x402-agents.mdx
+++ b/docs/base-app/agents/x402-agents.mdx
@@ -460,7 +460,7 @@ Never expose private keys in your code. Always use environment variables and sec
   Official x402 protocol website with examples and tools
 </Card>
 
-<Card title="Coinbase SDK" icon="code" href="https://github.com/coinbase/x402-sdk">
+<Card title="Coinbase SDK" icon="code" href="https://github.com/coinbase/x402">
   Official Coinbase x402 SDK for JavaScript/TypeScript
 </Card>
 


### PR DESCRIPTION
## What changed? Why?

This PR fixes a **broken link** in the **x402 agents documentation** that returns a 404 error.


The **"Coinbase SDK"** resource link points to:  
`https://github.com/coinbase/x402-sdk`,  
which does **not exist** and returns a **404 error**.  

### The Solution
Updated the link to the correct repository:  
`https://github.com/coinbase/x402`

---

### Notes to reviewers
This is a simple **one-line fix** to correct a broken link.  
The correct repository exists and contains the official **Coinbase x402 SDK** for JavaScript/TypeScript.

---

### How has it been tested?
Verified the new link is **accessible** 