### PR TITLE
Updated dRPC NodeCloud to list of RPC providers

### DIFF
--- a/docs/base-chain/tools/node-providers.mdx
+++ b/docs/base-chain/tools/node-providers.mdx
@@ -82,12 +82,12 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 
 <HeaderNoToc title="Supported Networks"/>
 
-- Base Mainnet
-- Base Sepolia (Testnet)
+- [Base Mainnet](https://drpc.org/chainlist/base-mainnet-rpc)
+- [Base Sepolia] (https://drpc.org/chainlist/base-sepolia-rpc)
 
-## DRPC
+## dRPC NodeCloud
 
-[DRPC](https://drpc.org/) offers access to a distributed network of independent third-party partners and public nodes for Base. They provide a free tier that allows for an unlimited amount of requests over public nodes, or a paid tier which provides access to all providers, as well as other additional features.
+[dRPC NodeCloud](https://drpc.org/) is your go-to RPC endpoints management tool, so you can focus on building, not baby-sitting infra. Fast and reliable, with an AI-powered load balancer, it provides access to over 180 networks through its global permissioned network of providers accross 9 geoclusters. Open a free account (with limits) or jump into paid, starting at $10, for serious building. 
 
 <HeaderNoToc title="Supported Networks"/>
 


### PR DESCRIPTION


**What changed? Why?**
This update updated dRPC NodeCloud to the list of RPC providers supporting the Base network. Includes a short description and reference links to each networks page so it's easier for devs to arrive to the page where they can just grab the endpoints.

**Notes to reviewers**

**How has it been tested?**
