### PR TITLE
Fix wrong highlighting in Batch Transactions guide

### DIFF
--- a/docs/base-account/improve-ux/batch-transactions.mdx
+++ b/docs/base-account/improve-ux/batch-transactions.mdx
@@ -273,7 +273,7 @@ const result = await provider.request({
 
 `wallet_getCallsStatus` returns the execution status for a batch you previously submitted with `wallet_sendCalls`. Capture the `callsId` returned by `wallet_sendCalls`, then poll for the batch status until it is confirmed or fails.
 
-```tsx batchTransactions.tsx lines wrap highlight={5-33} expandable
+```tsx batchTransactions.tsx lines expandable
 async function trackBatchTransaction(
   calls: Array<{
     to: `0x${string}`;


### PR DESCRIPTION
**What changed? Why?**

Fix wrong highlighting in Batch Transactions guide
