### PR TITLE
Add new faucet (ethfaucet.com)

### DIFF
--- a/docs/base-chain/tools/network-faucets.mdx
+++ b/docs/base-chain/tools/network-faucets.mdx
@@ -38,17 +38,6 @@ The [Alchemy Faucet](https://basefaucet.com/) is a fast and reliable network fau
 Requests to Alchemy's Base Sepolia Faucet are limited to one claim per 24 hours.
 </Note>
 
-
-## ethfaucet.com
-
-[ethfaucet.com](https://ethfaucet.com/networks/base) provides developers with free Base Sepolia testnet ETH and small amounts of Base mainnet ETH for contract deployment.  
-It is operated and maintained by [BringID](https://www.bringid.org/).
-
-<Note>
-Base Sepolia claims are rate-limited per 24 hours, and Base Mainnet ETH can only be claimed once.
-</Note>
-
-
 ## Bware Labs Faucet
 
 [Bware Labs Faucet](https://bwarelabs.com/faucets) is an easy to use faucet with no registration required. You can use Bware Labs Faucet to claim Base Sepolia testnet ETH for free - one claim per 24 hours.
@@ -64,6 +53,17 @@ Requests to Bware Labs Faucet are limited to one claim per 24 hours.
 <Note>
 Chainstack faucet drips 0.5 ETH every 24 hours.
 </Note>
+
+
+## ethfaucet.com
+
+[ethfaucet.com](https://ethfaucet.com/networks/base) provides developers with free Base Sepolia testnet ETH and small amounts of Base mainnet ETH for contract deployment.  
+It is operated and maintained by [BringID](https://www.bringid.org/).
+
+<Note>
+Base Sepolia claims are rate-limited per 24 hours, and Base Mainnet ETH can only be claimed once.
+</Note>
+
 
 ## Ponzifun Faucet
 


### PR DESCRIPTION
**New Faucet:** Added documentation for ethfaucet.com as an additional source for obtaining Base Sepolia ETH and Base Mainnet ETH.

**What changed? Why?**
Included a new section describing ethfaucet.com, a new faucet operated by BringID.
This provides developers with another reliable option for claiming Base Sepolia ETH (0.5 ETH / 24h) and a one-time Base Mainnet ETH drip.

**Notes to reviewers**
Please verify the faucet logic (claim limits, balance checks, and request validation). Pay attention to the anti-abuse mechanisms (e.g : BringID anti-bot protection).

**How has it been tested?**
The faucet is operational and at the time of this PR there has been: 
- 274 Base Sepolia ETH claims:https://sepolia.basescan.org/txs?a=0xE99ae3eE8d8C0dCF151613563c9E9f59Ff5730d4
- 686 Base Mainnet ETH claims: https://basescan.org/address/0x1F9Cb1cCD312d631559944A3B04Ac332251B5e8c