### PR TITLE
fix: Rename isFrameReady and setFrameReady

### DIFF
--- a/docs/cookbook/minikit/add-minikit.mdx
+++ b/docs/cookbook/minikit/add-minikit.mdx
@@ -42,7 +42,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 ## Initialize MiniKit in your page
 
-Use `useMiniKit()` to call `setFrameReady()` when your app is ready.
+Use `useMiniKit()` to call `setMiniAppReady()` when your app is ready.
 
 ```jsx app/page.tsx
 'use client';
@@ -50,11 +50,11 @@ import { useEffect } from 'react';
 import { useMiniKit } from '@coinbase/onchainkit/minikit';
 
 export default function HomePage() {
-  const { setFrameReady, isFrameReady } = useMiniKit();
+  const { setMiniAppReady, isMiniAppReady } = useMiniKit();
 
   useEffect(() => {
-    if (!isFrameReady) setFrameReady();
-  }, [isFrameReady, setFrameReady]);
+    if (!isMiniAppReady) setMiniAppReady();
+  }, [isMiniAppReady, setMiniAppReady]);
 
   return <div>Your app content goes here</div>;
 }

--- a/docs/onchainkit/latest/components/minikit/hooks/useMiniKit.mdx
+++ b/docs/onchainkit/latest/components/minikit/hooks/useMiniKit.mdx
@@ -45,11 +45,11 @@ Where the Mini App was launched from (e.g., "cast", "launcher", "notification").
 </Expandable>
 </ResponseField>
 
-<ResponseField name="isFrameReady" type="boolean">
+<ResponseField name="isMiniAppReady" type="boolean">
 Whether the frame has signaled readiness to the host application.
 </ResponseField>
 
-<ResponseField name="setFrameReady" type="() => void">
+<ResponseField name="setMiniAppReady" type="() => void">
 Function to signal frame readiness to the host application. Call this once your Mini App has finished loading.
 </ResponseField>
 
@@ -61,13 +61,13 @@ import { useMiniKit } from '@coinbase/onchainkit/minikit';
 import { useEffect } from 'react';
 
 export default function MyMiniApp() {
-  const { context, isFrameReady, setFrameReady } = useMiniKit();
+  const { context, isMiniAppReady, setMiniAppReady } = useMiniKit();
 
   useEffect(() => {
-    if (!isFrameReady) {
-      setFrameReady();
+    if (!isMiniAppReady) {
+      setMiniAppReady();
     }
-  }, [setFrameReady, isFrameReady]);
+  }, [setMiniAppReady, isMiniAppReady]);
 
   return (
     <div>
@@ -86,7 +86,7 @@ import { useMiniKit } from '@coinbase/onchainkit/minikit';
 
 export default function ClientSpecificFeatures() {
   const { context } = useMiniKit();
-  
+
   const isBaseApp = context.client.clientFid === '309857';
   const isFarcaster = context.client.clientFid === '1';
 
@@ -128,14 +128,14 @@ export default function AnalyticsTracker() {
 ## Usage Notes
 
 ### Frame Readiness
-Always call `setFrameReady()` once your Mini App has finished initial loading:
+Always call `setMiniAppReady()` once your Mini App has finished initial loading:
 
-```tsx components/FrameReady.tsx
+```tsx components/MiniAppReady.tsx
 useEffect(() => {
-  if (!isFrameReady) {
-    setFrameReady();
+  if (!isMiniAppReady) {
+    setMiniAppReady();
   }
-}, [setFrameReady, isFrameReady]);
+}, [setMiniAppReady, isMiniAppReady]);
 ```
 
 ### Context Data Security

--- a/docs/onchainkit/latest/components/minikit/overview.mdx
+++ b/docs/onchainkit/latest/components/minikit/overview.mdx
@@ -67,7 +67,7 @@ Add MiniKit to your existing Next.js application.
 ### Frame Lifecycle
 Mini Apps run within Farcaster frames and must signal readiness:
 1. **Initialize** MiniKitProvider in your app root
-2. **Signal readiness** with `setFrameReady()` in your main component
+2. **Signal readiness** with `setMiniAppReady()` in your main component
 3. **Handle interactions** through MiniKit hooks
 
 ### Context vs Authentication

--- a/docs/onchainkit/latest/components/minikit/provider-and-initialization.mdx
+++ b/docs/onchainkit/latest/components/minikit/provider-and-initialization.mdx
@@ -68,13 +68,13 @@ import { useMiniKit } from '@coinbase/onchainkit/minikit';
 import { useEffect } from 'react';
 
 export default function App() {
-  const { setFrameReady, isFrameReady } = useMiniKit();
+  const { setMiniAppReady, isMiniAppReady } = useMiniKit();
 
   useEffect(() => {
-    if (!isFrameReady) {
-      setFrameReady();
+    if (!isMiniAppReady) {
+      setMiniAppReady();
     }
-  }, [setFrameReady, isFrameReady]);
+  }, [setMiniAppReady, isMiniAppReady]);
 
   return (
     <div>
@@ -89,10 +89,10 @@ export default function App() {
 The `useMiniKit` hook provides access to frame state and user context:
 
 ```tsx any-component.tsx
-const { 
-  setFrameReady, 
-  isFrameReady, 
-  context 
+const {
+  setMiniAppReady,
+  isMiniAppReady,
+  context
 } = useMiniKit();
 ```
 


### PR DESCRIPTION
## What changed? Why?

Renamed deprecated `isFrameReady` and `setFrameReady` to `isMiniAppReady` and `setMiniAppReady` across all MiniKit documentation to align with the latest onchainkit API changes and deprecation notices.

## Notes to reviewers

- Updated references in:
  - `useMiniKit.mdx`
  - `overview.mdx`
  - `provider-and-initialization.mdx`
  - `add-minikit.mdx`
- All code examples verified against new API naming
- Related to: https://github.com/coinbase/onchainkit/commit/6d61f2b390fa0286ce35550fdf44a3bcd29b61ca

## How has it been tested?

Documentation reviewed across all files for consistency. All code examples updated and verified against the new API naming conventions.