### PR TITLE
Update documentation links for Allium, Covalent, and The Indexing Company data indexers

### DIFF
--- a/docs/base-chain/tools/data-indexers.mdx
+++ b/docs/base-chain/tools/data-indexers.mdx
@@ -9,12 +9,12 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 
 [Allium](https://www.allium.so/) is an Enterprise Data Platform that serves accurate, fast, and simple blockchain data. Currently serving 15 blockchains and over 100+ schemas, Allium offers near real-time Base data for infrastructure needs and enriched Base data (NFT, DEX, Decoded, Wallet360) for research and analytics.
 
-Allium supports data delivery to multiple [destinations](https://docs.allium.so/integrations/overview), including Snowflake, Bigquery, Databricks, and AWS S3.
+Allium supports data delivery to multiple [destinations](https://docs.allium.so/datashares/overview), including Snowflake, Bigquery, Databricks, and AWS S3.
 
 Documentation:
 
-- [Real-time](https://docs.allium.so/real-time-data/base)
-- [Batch-enriched](https://docs.allium.so/data-tables/base)
+- [Real-time](https://docs.allium.so/api/developer/overview)
+- [Batch-enriched](https://docs.allium.so/datashares/overview)
 
 To get started, contact Allium [here](https://www.allium.so/contact).
 
@@ -33,19 +33,19 @@ References:
 
 ## Covalent
 
-[Covalent](https://www.covalenthq.com/?utm_source=base&utm_medium=partner-docs) is a hosted blockchain data solution providing access to historical and current on-chain data for [100+ supported blockchains](https://www.covalenthq.com/docs/networks/?utm_source=base&utm_medium=partner-docs), including [Base](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs).
+[Covalent](https://www.covalenthq.com/?utm_source=base&utm_medium=partner-docs) is a hosted blockchain data solution providing access to historical and current on-chain data for [100+ supported blockchains](https://goldrush.dev/docs/chains/overview), including [Base](https://goldrush.dev/docs/chains/base).
 
 Covalent maintains a full archival copy of every supported blockchain, meaning every balance, transaction, log event, and NFT asset data is available from the genesis block. This data is available via:
 
-1. [Unified API](https://www.covalenthq.com/docs/unified-api/?utm_source=base&utm_medium=partner-docs) - Incorporate blockchain data into your app with a familiar REST API
+1. [Unified API](https://goldrush.dev/docs/goldrush-foundational-api/overview) - Incorporate blockchain data into your app with a familiar REST API
 2. [Increment](https://www.covalenthq.com/docs/increment/?utm_source=base&utm_medium=partner-docs) - Create and embed custom charts with no-code analytics
 
 To get started, [sign up](https://www.covalenthq.com/platform/?utm_source=base&utm_medium=partner-docs) and visit the [developer documentation](https://www.covalenthq.com/docs/?utm_source=base&utm_medium=partner-docs).
 
 <HeaderNoToc title="Supported Networks"/>
 
-- [Base Mainnet](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs)
-- [Base Sepolia](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs) (Testnet)
+- [Base Mainnet](https://goldrush.dev/docs/chains/base#mainnet)
+- [Base Sepolia](https://goldrush.dev/docs/chains/base#testnet) (Testnet)
 
 
 
@@ -94,7 +94,7 @@ To get started, you can [sign up for an account](https://app.ghostlogs.xyz/ghost
 
 Our services include data transformations, aggregations, and streamlined data flows, allowing teams to develop their products faster while saving on developer resources, time, and money. Our solution is ideal for teams needing advanced data engineering for modular chain setups, multi-chain products, L1/L2/L3 chains and AI.
 
-To get started contact us [here](https://www.indexing.co/get-in-touch).
+To get started contact us [here](https://www.indexing.co/contact).
 
 <HeaderNoToc title="Supported Networks"/>
 


### PR DESCRIPTION
**What changed? Why?**
Changed : https://docs.base.org/base-chain/tools/data-indexers

Updated documentation links in the data indexers page to reflect current URL structures for:
- **Allium**: Updated destinations, Real-time API, and Batch-enriched documentation links to point to the correct documentation sections
- **Covalent**: Updated all Covalent links to point to the new Goldrush documentation site (goldrush.dev) instead of the legacy covalenthq.com URLs
- **The Indexing Company**: Updated contact link to point to the correct contact page

This ensures users can access the correct and up-to-date documentation for these data indexing platforms when using Base.

**Notes to reviewers**

- All link updates were verified against the provided documentation
- Only documentation links were updated; no content changes were made
- Covalent links now point to goldrush.dev which appears to be their new documentation platform
- The Increment link for Covalent was left unchanged as no updated URL was provided

**How has it been tested?**

- Verified all new URLs are valid and accessible
- Checked that link text accurately describes the destination
- Confirmed no broken links were introduced
- Manually tested that the updated links lead to the correct documentation sections
