### PR TITLE
chore: update mainnet contract addresses after U17

### DIFF
--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -61,14 +61,14 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | DelayedWETHProxy (FDG)       | [0x2453c1216e49704d84ea98a4dacd95738f2fc8ec](https://etherscan.io/address/0x2453c1216e49704d84ea98a4dacd95738f2fc8ec) |
 | DelayedWETHProxy (PDG)       | [0x64ae5250958cdeb83f6b61f913b5ac6ebe8efd4d](https://etherscan.io/address/0x64ae5250958cdeb83f6b61f913b5ac6ebe8efd4d) |
 | DisputeGameFactoryProxy      | [0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e](https://etherscan.io/address/0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e) |
-| FaultDisputeGame             | [0xe4066890367BF8A51d58377431808083A01b1E0c](https://etherscan.io/address/0xe4066890367BF8A51d58377431808083A01b1E0c) |
+| FaultDisputeGame             | [0x979Cb7E329bA213fB9d6c5F7771eC6a3109BDC93](https://etherscan.io/address/0x979Cb7E329bA213fB9d6c5F7771eC6a3109BDC93) |
 | L1CrossDomainMessenger       | [0x866E82a600A1414e583f7F13623F1aC5d58b0Afa](https://etherscan.io/address/0x866E82a600A1414e583f7F13623F1aC5d58b0Afa) |
 | L1ERC721Bridge               | [0x608d94945A64503E642E6370Ec598e519a2C1E53](https://etherscan.io/address/0x608d94945A64503E642E6370Ec598e519a2C1E53) |
 | L1StandardBridge             | [0x3154Cf16ccdb4C6d922629664174b904d80F2C35](https://etherscan.io/address/0x3154Cf16ccdb4C6d922629664174b904d80F2C35) |
-| MIPS                         | [0x07BABE08EE4D07dBA236530183B24055535A7011](https://etherscan.io/address/0x07BABE08EE4D07dBA236530183B24055535A7011) |
+| MIPS                         | [0x6463dEE3828677F6270d83d45408044fc5eDB908](https://etherscan.io/address/0x6463dEE3828677F6270d83d45408044fc5eDB908) |
 | OptimismMintableERC20Factory | [0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84](https://etherscan.io/address/0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84) |
 | OptimismPortal               | [0x49048044D57e1C92A77f79988d21Fa8fAF74E97e](https://etherscan.io/address/0x49048044D57e1C92A77f79988d21Fa8fAF74E97e) |
-| PermissionedDisputeGame      | [0xe3803582fd5BCdc62720D2b80f35e8dDeA94e2ec](https://etherscan.io/address/0xe3803582fd5BCdc62720D2b80f35e8dDeA94e2ec) |
+| PermissionedDisputeGame      | [0x6f8c1Ea88CB410571739d36EB00811B250574cB2](https://etherscan.io/address/0x6f8c1Ea88CB410571739d36EB00811B250574cB2) |
 | PreimageOracle               | [0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3](https://etherscan.io/address/0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3) |
 | ProxyAdmin                   | [0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E](https://etherscan.io/address/0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E) |
 | SystemConfig                 | [0x73a79Fab69143498Ed3712e519A88a918e1f4072](https://etherscan.io/address/0x73a79Fab69143498Ed3712e519A88a918e1f4072) |


### PR DESCRIPTION
**What changed? Why?**
Updates addresses for the new FaultDisputeGame, PermissionedDisputeGame and MIPs contracts

**Notes to reviewers**

**How has it been tested?**
