### PR TITLE
chore: broken link Solana to Base Relay Script

### DIFF
--- a/docs/base-chain/quickstart/base-solana-bridge.mdx
+++ b/docs/base-chain/quickstart/base-solana-bridge.mdx
@@ -120,7 +120,7 @@ const ixs = [
 await buildAndSendTransaction(SOLANA_RPC_URL, ixs, payer);
 ```
 
-For more details, see the [Solana to Base Relay Script](https://github.com/base/bridge/blob/main/scripts/src/commands/sol/onchain/bridge/solana-to-base/bridge-sol.handler.ts).
+For more details, see the [Solana to Base Relay Script](https://github.com/base/bridge/blob/main/scripts/src/commands/sol/bridge/solana-to-base/bridge-sol.handler.ts).
 
 ### Wrap Custom SPL Tokens
 


### PR DESCRIPTION
There is also a misunderstanding regarding the address 
address: "0xB2068ECCDb908902C76E3f965c1712a9cF64171E", // Bridge - should be address: "0x01824a90d32A69022DdAEcC6C5C14Ed08dB4EB9B", // Bridge

remoteToken: toBytes("0xC5b9112382f3c87AFE8e1A28fa52452aF81085AD"), // SOL on Base - should be remoteToken: toBytes("0xCace0c896714DaF7098FFD8CC54aFCFe0338b4BC"), // Wrapped SOL

address: "0x58207331CBF8Af87BB6453b610E6579D9878e4EA", // Factor - should be address: "0x488EB7F7cb2568e31595D48cb26F63963Cc7565D", // CrossChainERC20Factory