### PR TITLE
Fixed broken links in base-solana-bridge page

### DIFF
--- a/docs/base-chain/quickstart/base-solana-bridge.mdx
+++ b/docs/base-chain/quickstart/base-solana-bridge.mdx
@@ -94,7 +94,7 @@ When bridging from Solana to Base, native SOL/SPL are locked and ERC20 SOL is mi
 
 Reference scripts (auto-relay, token wrapping, CLI utilities) live in the `scripts/` directory of the official repository:
 
-<GithubRepoCard title="Solana → Base CLI Scripts" githubUrl="https://github.com/base/bridge/tree/main/scripts/src/commands/sol/onchain/bridge" />
+<GithubRepoCard title="Solana → Base CLI Scripts" githubUrl="https://github.com/base/bridge/tree/main/scripts/src/commands/sol/bridge" />
 
 ### Auto-Relay Example
 This is a sample script that shows how to bridge SOL with auto-relay
@@ -122,7 +122,7 @@ const ixs = [
 await buildAndSendTransaction(SOLANA_RPC_URL, ixs, payer);
 ```
 
-For more details, see the [Solana to Base Relay Script](https://github.com/base/bridge/blob/main/scripts/src/commands/sol/onchain/bridge/solana-to-base/bridge-sol.handler.ts).
+For more details, see the [Solana to Base Relay Script](https://github.com/base/bridge/blob/main/scripts/src/commands/sol/bridge/solana-to-base/bridge-sol.handler.ts).
 
 ### Wrap Custom SPL Tokens
 
@@ -130,7 +130,7 @@ The example above shows how to bridge native SOL to Base.
 To bridge custom SPL tokens,
 you need to create wrapped ERC20 representations on Base using the CrossChainERC20Factory.
 
-<GithubRepoCard title="Token Wrapping Example" githubUrl="https://github.com/base/bridge/blob/main/scripts/src/commands/sol/onchain/bridge/solana-to-base/wrap-token.handler.ts" />
+<GithubRepoCard title="Token Wrapping Example" githubUrl="https://github.com/base/bridge/blob/main/scripts/src/commands/sol/bridge/solana-to-base/wrap-token.handler.ts" />
 
 ```typescript wrapSolTokenOnBase/index.ts expandable
 // Deploy wrapped token on Base


### PR DESCRIPTION
**What changed? Why?**
https://docs.base.org/base-chain/quickstart/base-solana-bridge have multiple broken links.

**Notes to reviewers**

**How has it been tested?**
Manually checked
