### PR TITLE
Update doc for builder-code launch

### DIFF
--- a/docs/base-chain/quickstart/builder-codes.mdx
+++ b/docs/base-chain/quickstart/builder-codes.mdx
@@ -1,14 +1,17 @@
 ---
-title: "Builder Codes (coming soon)" 
-sidebarTitle: "Builder Codes"
+title: "Base Builder Codes" 
 description: "Integrate Builder Codes to attribute onchain activity to your app or wallet."
 ---
 
-<Warning>
-Base Builder Codes are still not fully live yet. Base will issue Builder Codes out of Base.dev **soon**. These docs are released ahead of launch to allow builders time to understand the implementation.
-</Warning>
+## What are Builder Codes
 
-Builder Codes allow you to attribute onchain activity to your app or wallet, unlocking analytics, rewards, and future incentives. This guide covers the implementation steps for both application developers and wallet providers.
+Base Builder Codes are an ERC-721 NFT collection where unique codes (e.g. “abc123”) are minted to help identify builders onchain.
+
+Each code has associated metadata. Onchain metadata primarily includes a “payout address” where each code declares where potential rewards should be sent to. Offchain metadata includes more details about the app including its name and site.
+
+## Automatic Builder-Code Attribution on Base
+
+Once your app is registered on [Base.dev](http://base.dev/), the Base App will auto-append your Base Builder Code to transactions its users make in your app (e.g. via your mini app, or the Base App's browser). This powers your onchain analytics in [Base.dev](http://base.dev/) and qualifies you for potential future rewards.
 
 
 


### PR DESCRIPTION
**What changed? Why?**

Update builder code docs for launch. Clarifies what builder codes are and that there is auto attribution in the base app
