### PR TITLE
Fix broken OnchainKit link in build checklist

### DIFF
--- a/docs/mini-apps/quickstart/build-checklist.mdx
+++ b/docs/mini-apps/quickstart/build-checklist.mdx
@@ -53,7 +53,7 @@ Build for compact, touch‑first contexts: respect safe areas, keep interfaces c
 
 <CardGroup cols={2}>
   <Card title="Design patterns" icon="puzzle-piece" href="/mini-apps/featured-guidelines/design-guidelines" />
-  <Card title="OnchainKit" icon="box" href="/mini-apps/featured-guidelines/product-guidelines/foundations" />
+  <Card title="OnchainKit" icon="box" href="/onchainkit/latest/components/minikit/overview" />
 </CardGroup>
 
 


### PR DESCRIPTION
Update the OnchainKit link in the UX Best Practices section to point to the correct MiniKit overview page instead of a non-existent path.

Fixes #713