### PR TITLE
Increase minimum base fee to 500,000 wei

### DIFF
--- a/docs/base-chain/network-information/configuration-changelog.mdx
+++ b/docs/base-chain/network-information/configuration-changelog.mdx
@@ -10,6 +10,7 @@ This page tracks configuration changes to the Base networks, including updates t
 
 | Date | Change | Documentation |
 |------|--------|---------------|
+| December 18, 2025 | Increased Minimum Base Fee to 500,000 wei | [Minimum Base Fee](/base-chain/network-information/network-fees#minimum-base-fee) |
 | December 4, 2025 | Enabled Minimum Base Fee (200,000 wei) | [Minimum Base Fee](/base-chain/network-information/network-fees#minimum-base-fee) |
 | September 17, 2025 | Enabled Per-Transaction Gas Maximum | [Per-Transaction Gas Maximum](/base-chain/network-information/block-building#per-transaction-gas-maximum) |
 | September 11, 2025 | Ended testing Per-Transaction Gas Maximum | [Per-Transaction Gas Maximum](/base-chain/network-information/block-building#per-transaction-gas-maximum) |

--- a/docs/base-chain/network-information/network-fees.mdx
+++ b/docs/base-chain/network-information/network-fees.mdx
@@ -30,7 +30,7 @@ documentation](https://docs.optimism.io/stack/transactions/fees).
 
 As part of the [Jovian upgrade], Base introduced a minimum base fee. This feature sets a floor for the L2 base fee, preventing it from dropping to extremely low levels during periods of low network activity.
 
-The minimum base fee for Base Mainnet was initially set to 200,000 wei (0.0002 gwei) on December 4th, 2025. This value may be periodically adjusted as we gather data on how it affects the chain. For reference, a minimum base fee of 0.0002 gwei results in a cost of approximately 0.006 cents for a typical transaction at an ETH price of $3000.
+The minimum base fee for Base Mainnet is 500,000 wei (0.0005 gwei). This value may be periodically adjusted as we gather data on how it affects the chain. For reference, a minimum base fee of 0.0005 gwei results in a cost of approximately 0.015 cents for a typical transaction at an ETH price of $3000.
 
 ### Benefits
 
@@ -42,7 +42,7 @@ The minimum base fee for Base Mainnet was initially set to 200,000 wei (0.0002 g
 
 | Network      | Minimum Base Fee |
 |--------------|------------------|
-| Base Mainnet | 200,000 wei (0.0002 gwei) |
+| Base Mainnet | 500,000 wei (0.0005 gwei) |
 | Base Sepolia | 200,000 wei (0.0002 gwei) |
 
 See the [Configuration Changelog](/base-chain/network-information/configuration-changelog) for a history of changes to the minimum base fee and other network parameters.


### PR DESCRIPTION
Update documentation to reflect the minimum base fee increase from 200,000 wei to 500,000 wei on Base Mainnet.