### PR TITLE
fix: correct sequence numbering (4 -> 3)

### DIFF
--- a/docs/base-chain/tools/tokens-in-wallet.mdx
+++ b/docs/base-chain/tools/tokens-in-wallet.mdx
@@ -85,7 +85,7 @@ By sharing a unique link to your token’s asset page, your community can easily
 
 ![][image2]
 
-**Step 4:** Share it with your community – either by posting it as an official link on your social accounts or as a CTA on your website. 
+**Step 3:** Share it with your community – either by posting it as an official link on your social accounts or as a CTA on your website. 
 
 ## Trending Swaps on Base
 


### PR DESCRIPTION
There was incorrect numbering in the “Custom trading links” section.