### PR TITLE
Format function name

### DIFF
--- a/docs/onchainkit/mint/nft-mint-card.mdx
+++ b/docs/onchainkit/mint/nft-mint-card.mdx
@@ -218,7 +218,7 @@ export default function NFTComponent() {
 
 ## Compatibility
 
-The mint component uses a custom buildMintTransaction implementation which supports Coinbase mints as well as [`these supported platforms on reservoir`](https://docs.reservoir.tools/docs/minting#platform-support). If your contract is not supported, please follow the [`bring your own data instructions`](#bring-your-own-data) below.
+The mint component uses a custom `buildMintTransaction` implementation which supports Coinbase mints as well as [`these supported platforms on reservoir`](https://docs.reservoir.tools/docs/minting#platform-support). If your contract is not supported, please follow the [`bring your own data instructions`](#bring-your-own-data) below.
 
 ## Advanced Usage
 


### PR DESCRIPTION
Added backticks because `buildMintTransaction` is a function name.