### PR TITLE
Fix hook backticks in docs

### DIFF
--- a/docs/onchainkit/signature/signature.mdx
+++ b/docs/onchainkit/signature/signature.mdx
@@ -4,7 +4,7 @@ sidebarTitle: <Signature />
 description: The `<Signature />` component supports signing EIP712 and personal_sign messages.
 ---
 
-The `<Signature />` components provide a wrapper around the useSignTypedData and useSignMessage wagmi hooks.
+The `<Signature />` components provide a wrapper around the `useSignTypedData` and `useSignMessage` wagmi hooks.
 These hooks handle EIP712 signatures and personal_sign messages, falling back to eth_sign.
 
 Before using them, ensure you've completed all [Getting Started steps](/onchainkit/getting-started).


### PR DESCRIPTION
**What changed? Why?**
Added missing backticks around hook names to ensure consistent formatting.

**Notes to reviewers**
In the Base documentation, hooks should be wrapped in backticks (hook).
This was missing in two places - the formatting has now been aligned with the rest of the documentation.

**How has it been tested?**
