### PR TITLE
feat(docs): Add "Transactional Farcaster Frames" Cookbook Entry

### DIFF
--- a/docs/cookbook/transactional-frames-guide.md
+++ b/docs/cookbook/transactional-frames-guide.md
@@ -3,7 +3,7 @@
 title: "Building Transactional Farcaster Frames"
 slug: /cookbook/farcaster/transactional-frames
 description: A comprehensive guide to building interactive Frames that execute on-chain transactions (Minting NFTs) directly from the Farcaster feed.
-authors: [your-github-username]
+authors: [jadonamite]
 tags: [farcaster, frames, onchainkit, nextjs, nft, minting]
 ---
 


### PR DESCRIPTION
## Overview
This PR adds a comprehensive guide to building Transactional Frames on Base, enabling users to mint NFTs directly from their social feed.

## Changes
- **New File:** `apps/base-docs/docs/cookbook/farcaster/transactional-frames.md`
- **Architecture:** Explained the difference between `fc:frame:button` logic (POST requests) and standard redirects.
- **Implementation:** Provided full code for a Next.js implementation using `OnchainKit` and `Viem`:
    - **Metadata:** Setting up the `tx` button action.
    - **API Route:** Handling the signed POST request and returning encoded calldata.
    - **Success State:** Updating the Frame UI after the transaction is submitted.

## Why
Frames are the primary growth driver on Base right now. This guide fills a gap in the documentation by moving beyond "Read-Only" frames to "Write-Action" frames, which are essential for ecosystem apps.