### PR TITLE
docs: add networking section with reth discv5 port callout

### DIFF
--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -43,6 +43,19 @@ If utilizing Amazon Elastic Block Store (EBS), ensure timing buffered disk reads
 </Note>
 
 
+### Networking
+
+Ensure the following ports are accessible (not blocked by firewall) for peer discovery and sync:
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| `30303` | TCP/UDP | P2P Discovery (discv4) & RLPx |
+| `9222` | TCP/UDP | Reth Discovery v5 (discv5) |
+
+<Note>
+Port `9222` is critical for Reth peer discovery. If this port is blocked, your node may have difficulty finding peers and syncing.
+</Note>
+
 ### Docker
 
 This tutorial assumes you are familiar with [Docker](https://www.docker.com/) and have it running on your machine.

--- a/docs/base-chain/node-operators/troubleshooting.mdx
+++ b/docs/base-chain/node-operators/troubleshooting.mdx
@@ -107,7 +107,7 @@ Refer to the [Snapshots](/base-chain/node-operators/snapshots) guide for the cor
     - **Check**: Are the `--http.addr` and `--ws.addr` flags set to `0.0.0.0` in the client config/entrypoint to allow external connections (within the Docker network)?
 
 - **Issue**: Node has low peer count.  
-    - **Check**: P2P port (default `30303`) accessibility. Is it blocked by a firewall on the host or network?  
+    - **Check**: P2P port accessibility. Ensure `30303` (TCP/UDP) and `9222` (TCP/UDP for Reth discv5) are not blocked by a firewall on the host or network.  
     - **Check**: Node logs for P2P errors.  
     - **Action**: If behind NAT, configure the `--nat=extip:<your-ip>` flag via `ADDITIONAL_ARGS` in the `.env` file (see [Advanced Configuration](/base-chain/node-operators/run-a-base-node#improving-peer-connectivity)).
 


### PR DESCRIPTION
**What changed? Why?**
The [Base node docs](https://docs.base.org/base-chain/node-operators/troubleshooting#networking-/-connectivity-issues) do not mention the [Reth Discovery v5 Port (discv5)](https://reth.rs/run/faq/ports/) which is necessary to allow for peer discovery. This PR adds networking section with a callout highlighting `port 9222` as the default that is referenced in the Base node configs:
- [docker-compose.yml](https://github.com/base/node/blob/main/docker-compose.yml)
- [.env.mainnet](https://github.com/base/node/blob/main/.env.mainnet)
- [.env.sepolia](https://github.com/base/node/blob/main/.env.sepolia)

**Notes to reviewers**

**How has it been tested?**
Locally