### PR TITLE
feat(docs): Add "High-Performance Indexing" Guide (Graph vs. Goldsky)

### DIFF
--- a/docs/cookbook/data/high-performance-indexing.md
+++ b/docs/cookbook/data/high-performance-indexing.md
@@ -3,7 +3,7 @@
 title: "High-Performance Indexing: The Graph vs. Goldsky"
 slug: /cookbook/data/high-performance-indexing
 description: A comparative guide to indexing strategies on Base. Learn when to use The Graph (Subgraphs) vs. Goldsky (Real-time Pipelines) and how to deploy a custom subgraph.
-authors: [your-github-username]
+authors: [Jadonamite]
 tags: [data, indexing, subgraphs, goldsky, the-graph, graphql]
 ---
 


### PR DESCRIPTION
## Description
This PR adds a guide on indexing strategies for Base, focusing on The Graph and Goldsky.

## Changes
- **New File:** `apps/base-docs/docs/cookbook/data/high-performance-indexing.md`
- **Comparison:** Detailed analysis of Linear Indexing (The Graph) vs. Parallel Indexing (Goldsky) to help developers choose the right tool for latency-sensitive apps.
- **Tutorial:** Step-by-step code for initializing, mapping, and deploying a custom subgraph to the Base network.
- **Schema Design:** Example of an Account/Transfer entity relationship model for tracking ERC-20 balances.

## Why
Standard RPC methods (`eth_getLogs`) are insufficient for production applications. This guide provides the path for developers to migrate to proper indexing solutions, which improves dApp performance and reliability on Base.