### PR TITLE
docs: update swap.mdx

### DIFF
--- a/docs/onchainkit/swap/swap.mdx
+++ b/docs/onchainkit/swap/swap.mdx
@@ -688,7 +688,7 @@ The components are designed to work together hierarchically. For each component,
 - `<SwapAmountInput />` - Set the [Token](/onchainkit/token/types#token) to swap and specify the input type (`from` or `to`).
 - `<SwapToggleButton />` - Optional component to toggle between input types.
 - `<SwapMessage />` - Optional component that displays a message related to the swap operation's current state.
-- `<SwapButton />` - Set the onSuccess and onError callbacks.
+- `<SwapButton />` - Set the `onSuccess` and `onError` callbacks.
 - `<SwapToast />` - Optional component to notify user of successful swap transaction.
 
 ## Props


### PR DESCRIPTION
**What changed? Why?**
Add backticks to `onSuccess` and `onError` since they are component props.
