### PR TITLE
fix: remove extra space before comma in Privacy Policy

### DIFF
--- a/docs/privacy-policy.mdx
+++ b/docs/privacy-policy.mdx
@@ -11,7 +11,7 @@ Last updated: July 1, 2025
 
 ---
 
-At Base (referred to here as “**we**”, “**us**” or “**our**”), we respect and protect the privacy of those users and developers (“**you**” and “**your**” or “**Users**” and “**Developers**”, as relevant) who explore and use Base (“**Base**”) through the Base protocol or any other applications, tools ,and features we operate or through Base programmes (collectively, the “**Services**”).
+At Base (referred to here as “**we**”, “**us**” or “**our**”), we respect and protect the privacy of those users and developers (“**you**” and “**your**” or “**Users**” and “**Developers**”, as relevant) who explore and use Base (“**Base**”) through the Base protocol or any other applications, tools, and features we operate or through Base programmes (collectively, the “**Services**”).
 
 This Privacy Policy describes how we collect, use, and disclose personal information when you use our Services, which include the services offered on our website [https://base.org](https://base.org/) (“**Site**”). This Privacy Policy does not apply to any processing which Base carries out as a processor on behalf of those Users and Developers who explore and use Base. Please note that we do not control websites, applications, or services operated by third parties, and we are not responsible for their actions. We encourage you to review the privacy policies of the other websites, decentralised applications, and services you use to access or interact with our Services.
 


### PR DESCRIPTION
## Summary
Fixed grammatical error in Privacy Policy page.

**Before:** `applications, tools ,and features`
**After:** `applications, tools, and features`

## Files Changed
- `docs/privacy-policy.mdx` (line 14)

Closes #785