### PR TITLE
fix: update outdated Solidity pragma versions to 0.8.20

### DIFF
--- a/docs/learn/contracts-and-basic-functions/hello-world-step-by-step.mdx
+++ b/docs/learn/contracts-and-basic-functions/hello-world-step-by-step.mdx
@@ -47,7 +47,7 @@ If you don't want to give a license, you can put `UNLICENSED`. Common open sourc
 Below the license identifier, you need to specify which [version] of Solidity the compiler should use to compile your code. If by the time you read this, the version has advanced, you should try to use the most current version. Doing so may cause you to run into unexpected errors, but it's great practice for working in real-world conditions!
 
 ```Solidity
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 ```
 
 Finally, add a `contract` called `HelloWorld`. You should end up with:
@@ -55,7 +55,7 @@ Finally, add a `contract` called `HelloWorld`. You should end up with:
 ```Solidity
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 contract HelloWorld {
 
@@ -168,7 +168,7 @@ Deploy and test your contract. You should get a _decoded output_ with:
 ```solidity
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 contract HelloWorld {
 

--- a/docs/learn/hardhat/hardhat-forking/hardhat-forking.mdx
+++ b/docs/learn/hardhat/hardhat-forking/hardhat-forking.mdx
@@ -49,7 +49,7 @@ Those won't be covered in this guide, however it's recommended to explore them a
 The BalanceReader contract is created as follows:
 
 ```tsx
-pragma solidity 0.8.9;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/docs/learn/mappings/mappings-sbs.mdx
+++ b/docs/learn/mappings/mappings-sbs.mdx
@@ -171,7 +171,7 @@ You should end up with a contract similar to this:
 <Accordion title="Reveal code">
 
 ```solidity
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 contract Mappings {
     mapping (address => uint) public favoriteNumbers;


### PR DESCRIPTION
## Summary
Updated outdated Solidity pragma statements in tutorial code examples to version 0.8.20.

## Changes
| File | Old Version | New Version |
|------|-------------|-------------|
| `docs/learn/contracts-and-basic-functions/hello-world-step-by-step.mdx` | 0.8.17 | 0.8.20 |
| `docs/learn/hardhat/hardhat-forking/hardhat-forking.mdx` | 0.8.9 | 0.8.20 |
| `docs/learn/mappings/mappings-sbs.mdx` | 0.8.17 | 0.8.20 |

## Why 0.8.20?
- Includes important compiler optimizations
- Better security features
- Aligns with current best practices
- Still widely supported by tooling (Hardhat, Foundry, Remix)

Closes #815