### PR TITLE
Fix formatting for Storage.sol in Remix tutorial

### DIFF
--- a/docs/learn/introduction-to-solidity/introduction-to-remix.mdx
+++ b/docs/learn/introduction-to-solidity/introduction-to-remix.mdx
@@ -14,7 +14,7 @@ In this lesson, you'll be introduced to an online Solidity IDE called Remix. You
 By the end of this lesson you should be able to:
 
 - List the features, pros, and cons of using Remix as an IDE
-- Deploy and test the Storage.sol demo contract in Remix
+- Deploy and test the `Storage.sol` demo contract in Remix
 
 ---
 


### PR DESCRIPTION
**What changed? Why?**
Added backticks for Storage.sol
This corresponds to the markdown style of the base documentation.