### PR TITLE
docs: add audience notes to get-started pages

### DIFF
--- a/docs/get-started/ai-prompting.mdx
+++ b/docs/get-started/ai-prompting.mdx
@@ -4,6 +4,10 @@ title: Use AI-powered IDEs
 description: How to use AI-powered IDEs to generate code for OnchainKit.
 ---
 
+<Note>
+**Who is this for?** Developers who want to use AI tools like Cursor, Claude, or GitHub Copilot for onchain development.
+</Note>
+
 import AiPowered from "/snippets/ai-powered.mdx";
 
 <AiPowered/>

--- a/docs/get-started/base-mentorship-program.mdx
+++ b/docs/get-started/base-mentorship-program.mdx
@@ -3,6 +3,10 @@ title: Base Mentorship Program
 description: Connect with experienced builders and industry leaders to accelerate your journey on Base
 ---
 
+<Note>
+**Who is this for?** Builders looking for guidance from experienced founders, operators, and investors in the Base ecosystem.
+</Note>
+
 ## Program Purpose
 
 The Base Mentorship Program connects builders with top operators and investors who have been there before, sharing lessons learned, making introductions, and helping you avoid costly mistakes. Mentors work closely with the Base team to ensure their advice is actionable and aligned with your stage and goals.

--- a/docs/get-started/build-app.mdx
+++ b/docs/get-started/build-app.mdx
@@ -3,6 +3,10 @@ title: Build an App
 description: A guide to building a next.js app on Base using OnchainKit
 ---
 
+<Note>
+**Who is this for?** Frontend developers familiar with React/Next.js who want to build their first onchain application.
+</Note>
+
 Welcome to the Base quickstart guide! In this walkthrough, we'll create a simple onchain app from start to finish. Whether you're a seasoned developer or just starting out, this guide has got you covered.
 
 ## What You'll Achieve

--- a/docs/get-started/deploy-smart-contracts.mdx
+++ b/docs/get-started/deploy-smart-contracts.mdx
@@ -3,6 +3,10 @@ title: 'Deploy Smart Contracts'
 description: A guide to help you get started with deploying your smart contracts on Base.
 ---
 
+<Note>
+**Who is this for?** Developers with basic Solidity knowledge who want to deploy their first smart contract on Base.
+</Note>
+
 Welcome to the Base deployment quickstart guide! This comprehensive walkthrough will help you set up your environment and deploy smart contracts on Base. Whether you're a seasoned developer or just starting out, this guide has got you covered.
 
 ## What You'll Achieve

--- a/docs/get-started/get-funded.mdx
+++ b/docs/get-started/get-funded.mdx
@@ -3,6 +3,10 @@ title: 'Get Funded'
 description: "The Base ecosystem offers multiple funding pathways designed specifically for builders at every stage—from weekend experiments to full-scale ventures."
 ---
 
+<Note>
+**Who is this for?** Builders seeking funding for their Base projects, from hobbyists to aspiring founders.
+</Note>
+
 ## Funding Pathways
 
 Whether you're just starting to experiment or ready to become a full-time founder, Base provides structured funding opportunities that grow with your ambitions. Each pathway is designed for different stages of your builder journey, with clear progression paths between programs.

--- a/docs/get-started/launch-token.mdx
+++ b/docs/get-started/launch-token.mdx
@@ -2,6 +2,9 @@
 title: 'Launch a Token'
 ---
 
+<Note>
+**Who is this for?** Creators and developers who want to launch their own token on Base, from no-code solutions to custom implementations.
+</Note>
 
 Launching a token on Base can be accomplished through multiple approaches, from no-code platforms to custom smart contract development. This guide helps you choose the right method and provides implementation details for both approaches.
 


### PR DESCRIPTION
## Summary
Added "Who is this for?" notes at the top of key get-started pages to help readers quickly identify if the content matches their needs and experience level.

## Changes
Added audience notes to 6 pages in the get-started section:

| Page | Target Audience |
|------|-----------------|
| deploy-smart-contracts.mdx | Developers with basic Solidity knowledge |
| build-app.mdx | Frontend developers familiar with React/Next.js |
| launch-token.mdx | Creators and developers launching tokens |
| get-funded.mdx | Builders seeking funding |
| ai-prompting.mdx | Developers using AI tools |
| base-mentorship-program.mdx | Builders seeking mentorship |

## Example
```mdx
<Note>
**Who is this for?** Developers with basic Solidity knowledge who want to deploy their first smart contract on Base.
</Note>
```

Fixes #806