### PR TITLE
docs: improve documentation formatting

### DIFF
--- a/docs/snippets/learning-objectives.mdx
+++ b/docs/snippets/learning-objectives.mdx
@@ -19,7 +19,7 @@
 
 - Install and create a new Hardhat project with Typescript support
 - Describe the organization and folder structure of a Hardhat project
-- List the use and properties of hardhat.config.ts
+- List the use and properties of `hardhat.config.ts`
 
 ### [Testing with Hardhat and Typechain](/learn/hardhat/hardhat-testing/hardhat-testing-sbs)
 
@@ -35,8 +35,8 @@
 
 ### [Deploying Smart Contracts](/learn/hardhat/hardhat-deploy/hardhat-deploy-sbs)
 
-- Deploy a smart contract to the Base Sepolia Testnet with hardhat-deploy
-- Deploy a smart contract to the Sepolia Testnet with hardhat-deploy
+- Deploy a smart contract to the Base Sepolia Testnet with `hardhat-deploy`
+- Deploy a smart contract to the Sepolia Testnet with `hardhat-deploy`
 - Use BaseScan to view a deployed smart contract
 
 ### [Verifying Smart Contracts](/learn/hardhat/hardhat-verify/hardhat-verify-sbs)
@@ -53,11 +53,11 @@
 ### ['Introduction to Remix'](/learn/introduction-to-solidity/introduction-to-remix)
 
 - List the features, pros, and cons of using Remix as an IDE
-- Deploy and test the Storage.sol demo contract in Remix
+- Deploy and test the `Storage.sol` demo contract in Remix
 
 ### [Deployment in Remix](/learn/introduction-to-solidity/deployment-in-remix)
 
-- Deploy and test the Storage.sol demo contract in Remix
+- Deploy and test the `Storage.sol` demo contract in Remix
 
 ### [Hello World](/learn/contracts-and-basic-functions/hello-world-step-by-step)
 
@@ -121,8 +121,8 @@
 
 ### [Function Visibility and State Mutability](/learn/advanced-functions/function-visibility)
 
-- Categorize functions as public, private, internal, or external based on their usage
-- Describe how pure and view functions are different than functions that modify storage
+- Categorize functions as `public`, `private`, `internal`, or `external` based on their usage
+- Describe how `pure` and `view` functions are different than functions that modify storage
 
 ### [Function Modifiers](/learn/advanced-functions/function-modifiers)
 
@@ -145,7 +145,7 @@
 
 ### [Abstract Contracts](/learn/inheritance/abstract-contracts-sbs)
 
-- Use the virtual, override, and abstract keywords to create and use an abstract contract
+- Use the `virtual`, `override`, and `abstract` keywords to create and use an abstract contract
 
 ### [Imports](/learn/imports/imports-sbs)
 
@@ -173,9 +173,9 @@
 
 ### [Address and Payable in Solidity](/learn/address-and-payable/address-and-payable)
 
-- Differentiate between address and address payable types in Solidity
+- Differentiate between `address` and `address payable` types in Solidity
 - Determine when to use each type appropriately in contract development
-- Employ address payable to send Ether and interact with payable functions
+- Employ `address payable` to send Ether and interact with payable functions
 
 ### [Minimal Token](/learn/token-development/minimal-tokens/minimal-token-sbs)
 


### PR DESCRIPTION
**What changed? Why?**
Updated documentation formatting to consistently highlight Solidity keywords, commands, and filenames using markdown conventions. This improves readability, scannability, and keeps the docs aligned with common technical writing standards.

**How has it been tested?**
Not applicable. This change only affects documentation and does not impact code, behavior, or functionality.