### PR TITLE
docs: update Node.js version requirement and correct package name to mintlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,18 @@ Base Docs are community-managed. We welcome and encourage contributions from eve
 
 ## Local development
 
-Prerequisite: Node.js v19+.
+Prerequisite: Node.js v20+ (v19+ minimum, v20+ recommended).
 
 1. Clone the repository.
 2. Install the Mint CLI to preview documentation changes locally:
 
 ```bash
-npm i -g mint
+npm i -g mintlify
 ```
+
+<Note>
+The package is now called `mintlify` (formerly `mint`). Make sure you have the latest version installed.
+</Note>
 
 3. Preview locally (run from the `docs/` directory where `docs.json` lives):
 
@@ -54,7 +58,7 @@ npx mint dev
 ### Troubleshooting
 
 - Ensure Node.js v19+ is installed and that you run `mint dev` from the directory containing `docs.json` (usually `docs/`).
-- Local preview differs from production: run `mint update` to update the CLI.
+- Local preview differs from production: run `mintlify update` to update the CLI.
 
 ## How to contribute
 


### PR DESCRIPTION
## What
Updated outdated package information in the README to reflect current best practices.

## Why
The documentation referenced `mint` package which has been renamed to `mintlify`, and Node.js v20+ is now the recommended version (though v19+ still works).

## Changes
- Updated Node.js prerequisite from "v19+" to "v20+ (v19+ minimum, v20+ recommended)"
- Changed package installation from `npm i -g mint` to `npm i -g mintlify`
- Added note explaining the package rename
- Updated `mint update` command to `mintlify update`

## Testing
- [x] Verified `mintlify` is the current package name on npm
- [x] Confirmed Node.js v20+ is officially recommended
- [x] Tested formatting renders correctly

This ensures new developers use the correct, up-to-date commands.