### PR TITLE
docs: remove internal TODO comments from public overview

### DIFF
--- a/docs/onchainkit/latest/getting-started/overview.mdx
+++ b/docs/onchainkit/latest/getting-started/overview.mdx
@@ -12,7 +12,7 @@ OnchainKit helps you build traditional onchain web apps, mini apps, and hybrid a
 
 If you're new to mini apps, they are supercharged web apps that get additional functionality such as automatic wallet connection, push notifications, and more. Check out the [Mini Apps documentation](/mini-apps/overview) for more information.
 
-{/* TODO: Create mini-apps/overview.mdx - comprehensive guide to mini apps */}
+
 
 ## Philosophy
 
@@ -58,4 +58,4 @@ Components with render prop support include `ConnectWallet`, `TransactionButton`
   These docs are LLM-friendly. Reference the [OnchainKit AI Prompting Guide](/onchainkit/guides/ai-prompting-guide) in your code editor to streamline builds and prompt smarter.
 </Check>
 
-{/* TODO: Create guides/ai-prompting-guide.mdx - comprehensive AI prompting guide for OnchainKit */}
+


### PR DESCRIPTION
## What
Removed internal TODO comments that were visible in the public source code of the documentation.

## Why
These comments (`Create mini-apps/overview.mdx`, `Create guides/ai-prompting-guide.mdx`) appear to be internal notes for the docs team and shouldn't be in the public release, as they can confuse contributors about whether those files exist.

## Changes
- Removed `{/* TODO: ... */}` comment from [overview.mdx](cci:7://file:///C:/Users/Dell/.gemini/antigravity/scratch/base-docs/docs/onchainkit/latest/getting-started/overview.mdx:0:0-0:0) (line 15)
- Removed `{/* TODO: ... */}` comment from [overview.mdx](cci:7://file:///C:/Users/Dell/.gemini/antigravity/scratch/base-docs/docs/onchainkit/latest/getting-started/overview.mdx:0:0-0:0) (line 61)

## Testing
- [x] Verified file renders correctly without the comments
- [x] Validated that no functional content was removed

This cleans up the source code for the "Getting Started" overview.