### PR TITLE
docs: standardize Discord links to direct invite URL

### DIFF
--- a/docs/cookbook/launch-tokens.mdx
+++ b/docs/cookbook/launch-tokens.mdx
@@ -422,7 +422,7 @@ Remember to always prioritize security, transparency, and community value when d
 ### Community
 
 <CardGroup cols={3}>
-  <Card title="Base Discord" icon="discord" href="https://base.org/discord">
+  <Card title="Base Discord" icon="discord" href="https://discord.com/invite/buildonbase">
     Join the Base community
   </Card>
   <Card title="Base Twitter" icon="twitter" href="https://twitter.com/base">

--- a/docs/get-started/launch-token.mdx
+++ b/docs/get-started/launch-token.mdx
@@ -422,7 +422,7 @@ Remember to always prioritize security, transparency, and community value when d
 ### Community
 
 <CardGroup cols={3}>
-  <Card title="Base Discord" icon="discord" href="https://base.org/discord">
+  <Card title="Base Discord" icon="discord" href="https://discord.com/invite/buildonbase">
     Join the Base community
   </Card>
   <Card title="Base Twitter" icon="twitter" href="https://twitter.com/base">


### PR DESCRIPTION
## What
Updated Discord links throughout the documentation to point directly to the invite URL (`discord.com/invite/buildonbase`) instead of the `base.org/discord` redirect.

## Why
Using the direct invite URL is faster, more reliable, and consistent with other parts of the documentation. It avoids potential issues with redirect chains.

## Changes
- Updated Discord link in [launch-tokens.mdx](cci:7://file:///C:/Users/Dell/.gemini/antigravity/scratch/base-docs/docs/cookbook/launch-tokens.mdx:0:0-0:0)
- Updated Discord link in [get-started/launch-token.mdx](cci:7://file:///C:/Users/Dell/.gemini/antigravity/scratch/base-docs/docs/get-started/launch-token.mdx:0:0-0:0)

## Testing
- [x] Verified link `https://discord.com/invite/buildonbase` is valid and active
- [x] Confirmed pages render correctly with new links