### PR TITLE
docs: align punctuation with documentation style

### DIFF
--- a/docs/onchainkit/token/token-row.mdx
+++ b/docs/onchainkit/token/token-row.mdx
@@ -6,7 +6,7 @@ The `TokenRow` component displays token information in a row format to be used i
 
 ## Usage
 
-Token with an image url
+Token with an image url:
 
 ```tsx
 // @noErrors: 1109 - Expression expected
@@ -36,7 +36,7 @@ const token = { ... };
   />
 </App> */}
 
-Token without an image url
+Token without an image url:
 
 ```tsx
 // @noErrors: 1109 - Expression expected
@@ -66,7 +66,7 @@ const token = { ... };
   />
 </App> */}
 
-Token with an amount
+Token with an amount:
 
 ```tsx
 // @noErrors: 1109 - Expression expected
@@ -110,7 +110,7 @@ const token = { ... };
   />
 </App> */}
 
-Variations with `hideImage` and `hideSymbol`
+Variations with `hideImage` and `hideSymbol`:
 
 ```tsx
 // @noErrors: 1109 - Expression expected


### PR DESCRIPTION
**What changed? Why?**
Adds missing colons in `onchainkit/token/token-row` before each block of code to bring punctuation in line with the existing style of all base documentation.

**Notes to reviewers**

**How has it been tested?**
