### PR TITLE
feat: add pruned snapshot URL

### DIFF
--- a/docs/base-chain/node-operators/snapshots.mdx
+++ b/docs/base-chain/node-operators/snapshots.mdx
@@ -31,12 +31,12 @@ These steps assume you are in the cloned `node` directory (the one containing `d
 
     | Network  | Client | Snapshot Type | Download Command (`wget …`)                                                                                       |
     | -------- | ------ | ------------- | ----------------------------------------------------------------------------------------------------------------- |
-    | Testnet  | Reth   | Archive (recommended)| `wget https://sepolia-reth-archive-snapshots.base.org/$(curl https://sepolia-reth-archive-snapshots.base.org/latest)` |
-    | Testnet  | Reth   | Pruned               | `wget https://sepolia-reth-pruned-snapshots.base.org/$(curl https://sepolia-reth-pruned-snapshots.base.org/latest)` |                 |
-    | Testnet  | Geth   | Full                 | `wget https://sepolia-full-snapshots.base.org/$(curl https://sepolia-full-snapshots.base.org/latest)`             |
-    | Mainnet  | Reth   | Archive (recommended)| `wget https://mainnet-reth-archive-snapshots.base.org/$(curl https://mainnet-reth-archive-snapshots.base.org/latest)` |
-    | Mainnet  | Reth   | Pruned               | `wget https://mainnet-reth-pruned-snapshots.base.org/$(curl https://mainnet-reth-pruned-snapshots.base.org/latest)` |                 |
-    | Mainnet  | Geth   | Full                 | `wget https://mainnet-full-snapshots.base.org/$(curl https://mainnet-full-snapshots.base.org/latest)`             |
+    | Testnet  | Reth   | Archive (recommended)| `wget -c https://sepolia-reth-archive-snapshots.base.org/$(curl https://sepolia-reth-archive-snapshots.base.org/latest)` |
+    | Testnet  | Reth   | Pruned               | `wget -c https://sepolia-reth-pruned-snapshots.base.org/$(curl https://sepolia-reth-pruned-snapshots.base.org/latest)` |                 |
+    | Testnet  | Geth   | Full                 | `wget -c https://sepolia-full-snapshots.base.org/$(curl https://sepolia-full-snapshots.base.org/latest)`             |
+    | Mainnet  | Reth   | Archive (recommended)| `wget -c https://mainnet-reth-archive-snapshots.base.org/$(curl https://mainnet-reth-archive-snapshots.base.org/latest)` |
+    | Mainnet  | Reth   | Pruned               | `wget -c https://mainnet-reth-pruned-snapshots.base.org/$(curl https://mainnet-reth-pruned-snapshots.base.org/latest)` |                 |
+    | Mainnet  | Geth   | Full                 | `wget -c https://mainnet-full-snapshots.base.org/$(curl https://mainnet-full-snapshots.base.org/latest)`             |
 
     <Note>
     Ensure you have enough free disk space to download the snapshot archive (`.tar.gz` / `.tar.zst` file) _and_ extract its contents. The extracted data will be significantly larger than the archive.


### PR DESCRIPTION
**What changed? Why?**

Add URLs for `base-pruned-reth` snapshots for Base Sepolia and Base Mainnet.

Note:
- The pruned snapshots come with 31 days of pruning distance (~1,339,200 blocks), see: https://github.com/base/node/pull/682

**Notes to reviewers**

**How has it been tested?**

For both Base Sepolia/Mainnet, I was able to:
- Pull the snapshot tar
- Untar the file
- Spin up docker containers for the node
- Sync the node to tip

The test was performed on a GCP VM
