### PR TITLE
docs: fix `transactionStatus` response objects and update node-reth repo name

### DIFF
--- a/docs/base-chain/flashblocks/apps.mdx
+++ b/docs/base-chain/flashblocks/apps.mdx
@@ -263,13 +263,13 @@ Check whether a transaction is present in the mempool:
 curl https://sepolia-preconf.base.org -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"base_transactionStatus","params":["0x..."],"id":1}'
 ```
 
-**Transaction Found**
+**Transaction Known**
 ```
 {
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "status": "Found"
+    "status": "Known"
   }
 }
 ```


### PR DESCRIPTION
**What changed? Why?**
Fixed the response objects for `base_transactionStatus` to be congruent with the enum variants in [rpc.rs](https://github.com/base/base/blob/main/crates/client/txpool/src/rpc.rs#L15-L22).
Additionally, node-reth is mentioned, so replaced that with the new repo name ([base/base](https://github.com/base/base/)).

**Notes to reviewers**

**How has it been tested?**
Locally