### PR TITLE
docs: fix typo and standardize mentorship program social links

### DIFF
--- a/docs/get-started/base-mentorship-program.mdx
+++ b/docs/get-started/base-mentorship-program.mdx
@@ -23,7 +23,7 @@ Base Mentors are experienced founders, operators, and subject matter experts acr
 | Anthony Bassili | [Coinbase Asset Management](https://x.com/SmartestBeta) |
 | Antonio García Martínez | [Spindl (acq. Coinbase)](https://x.com/antoniogm) |
 | Conor Grogan | [Coinbase](https://x.com/jconorgrogan) |
-| Conner Swenberg | [Station Labs (acq. Coinbase)](http://x.com/ilikesymmetry) |
+| Conner Swenberg | [Station Labs (acq. Coinbase)](https://x.com/ilikesymmetry) |
 | Dariush Aghai | [Study Hall Creative](https://studyhall.design/about) |
 | David Espinel | [Social Graph Ventures](https://www.socialgraph.vc/team) |
 | Elena Nadolinski | [Iron Fish (acq. Coinbase)](https://x.com/leanthebean) |
@@ -48,4 +48,4 @@ Base Mentors are experienced founders, operators, and subject matter experts acr
 | Simone "Limone" Staffa | [Builders Garden](https://www.builders.garden/#mission) |
 | Winnie Lau | [Strobe Ventures](https://www.strobe.fund/team/winnie-lau) |
 
-**Program Disclaimer**: *The Base Mentorship Program is an educational/networking initiative only. Participation does not constitute investment advice, a recommendation, an offer or solicitation to buy/sell any security, or an endorsement by Base/Coinbase of any project, token, or investment. Base does not arrange, negotiate, or receive compensation for investments and is not acting as a broker, dealer, or finder. Mentors participate in a personal capacity. If a mentor later chooses to invest in a project, any discussion must occur independently of this program and without Base involvement.* 
+**Program Disclaimer**: *The Base Mentorship Program is an educational/networking initiative only. Participation does not constitute investment advice, a recommendation, an offer or solicitation to buy/sell any security, or an endorsement by Base/Coinbase of any project, token, or investment. Base does not arrange, negotiate, or receive compensation for investments and is not acting as a broker, dealer, or finder. Mentors participate in a personal capacity. If a mentor later chooses to invest in a project, any discussion must occur independently of this program and without Base involvement.*


### PR DESCRIPTION
Corrected a spelling error in the Program Purpose section ("depoisited" fixed to "deposited").

Standardized social media links by ensuring https protocol and consistent x.com formatting for all mentors.

Improved overall document consistency for the Base Mentorship page.

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
