### PR TITLE
docs: update Builder Rewards link to Talent App dashboard

### DIFF
--- a/docs/get-started/base.mdx
+++ b/docs/get-started/base.mdx
@@ -47,7 +47,7 @@ mode: "wide"
   <div className="resources-row">
     <div>
       <h4>Funding</h4>
-      <span className="resource-link"><Icon icon="trophy" size={14} /> <a href="https://www.builderscore.xyz/">Builder Rewards</a></span>
+      <span className="resource-link"><Icon icon="trophy" size={14} /> <a href="https://talent.app/~/dashboard">Builder Rewards</a></span>
       <span className="resource-link"><Icon icon="hand-holding-dollar" size={14} /> <a href="https://paragraph.com/@grants.base.eth/calling-based-builders">Grants</a></span>
       <span className="resource-link"><Icon icon="rocket" size={14} /> <a href="https://www.basebatches.xyz/">Base Batches</a></span>
       <span className="resource-link"><Icon icon="clock-rotate-left" size={14} /> <a href="https://atlas.optimism.io/">Retroactive Funding</a></span>


### PR DESCRIPTION
### Summary
Updated the Builder Rewards link on the landing page as the previous domain (builderscore.xyz) is no longer in use for the rewards program.

### Changes
- Changed Builder Rewards URL from https://www.builderscore.xyz/ to https://talent.app/~/dashboard to reflect the latest platform migration.

### Impact
Ensures builders can correctly navigate to the active rewards dashboard and participate in the ecosystem incentives.

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
