### PR TITLE
Update link for Builder Rewards Program

### DIFF
--- a/docs/get-started/get-funded.mdx
+++ b/docs/get-started/get-funded.mdx
@@ -57,7 +57,7 @@ Whether you're just starting to experiment or ready to become a full-time founde
 
 The Builder Rewards Program distributes 2 ETH weekly to active builders—perfect for experimentation and learning.
 
-[Join Builder Rewards Program](https://www.builderscore.xyz/)
+[Join Builder Rewards Program](https://talent.app/~/dashboard)
 
 ### How It Works
 1. Build anything on Base (prototypes welcome)


### PR DESCRIPTION
- Replaced the deprecated builderscore.xyz URL with the new Talent App dashboard (talent.app/~/dashboard).
- Ensures builders can access the active rewards program and track their contributions.

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
