### PR TITLE
ci: add setup-node with caching to chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,6 +17,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: storybook/yarn.lock
+          
       - name: Install dependencies
         run: cd storybook && yarn install
       - uses: chromaui/action@3378c92d26c32353e53166beac732e2edc14213c # latest


### PR DESCRIPTION
This PR improves the stability and performance of the Chromatic workflow by explicitly setting up the Node.js environment.

Changes:
- Added `actions/setup-node@v4`.
- Pinned `node-version` to 20 (LTS) to ensure deterministic builds and avoid potential breakages from implicit `ubuntu-latest` updates.
- Enabled `yarn` dependency caching. Since dependencies are installed in the `storybook` subdirectory, `cache-dependency-path` is configured to point to `storybook/yarn.lock`.

This reduces CI execution time on subsequent runs and hardens the build environment.
