### PR TITLE
chore: add vscode, vim and windows files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,14 @@ next-env.d.ts
 
 .mintlify-latest
 /.idea/
+
+# Windows system files
+Thumbs.db
+Desktop.ini
+
+# VS Code settings
+.vscode/
+
+# Vim swap files
+*.swp
+*.swo


### PR DESCRIPTION
Updated `.gitignore` to include common development artifacts that were missing:
- `.vscode/` (VS Code workspace settings)
- `Thumbs.db` and `Desktop.ini` (Windows system files)
- `*.swp` and `*.swo` (Vim swap files)

This helps keep the repository clean from local environment noise.
