### PR TITLE
Fix incorrect params typing

### DIFF
--- a/docs/mini-apps/technical-guides/dynamic-embeds.mdx
+++ b/docs/mini-apps/technical-guides/dynamic-embeds.mdx
@@ -38,9 +38,9 @@ export const dynamic = "force-dynamic";
 
 export async function GET(
   request: Request,
-  { params }: { params: Promise<{ username: string }> }
+  { params }: { params: { username: string } }
 ) {
-  const { username } = await params;
+  const { username } = params;
 
   return new ImageResponse(
     (
@@ -85,10 +85,10 @@ import { minikitConfig } from "../../../minikit.config";
 import { Metadata } from "next";
 
 export async function generateMetadata(
-  { params }: { params: Promise<{ username: string }> }
+  { params }: { params: { username: string } }
 ): Promise<Metadata> {
   try {
-    const { username } = await params;
+    const { username } = params;
     
     return {
       title: minikitConfig.miniapp.name,
@@ -125,9 +125,9 @@ export async function generateMetadata(
 }
 
 export default async function SharePage(
-  { params }: { params: Promise<{ username: string }> }
+  { params }: { params: { username: string } }
 ) {
-  const { username } = await params;
+  const { username } = params;
 
   return (
     <div>


### PR DESCRIPTION
**What changed? Why?**
Fixed incorrect TypeScript typing of `params` in the [**Generate Dynamic Embed Images**](https://github.com/base/docs/blob/master/docs/mini-apps/technical-guides/dynamic-embeds.mdx) guide. 

Originally, `params` was typed as a `Promise<{ username: string }>` and accessed using `await params`, which does not match the Next.js App Router API. In Next.js App Router:

- `params` is always a synchronous object
- is not a Promise
- its type is `{ username: string }` in these examples

The incorrect typing caused TypeScript errors (`TS2741: Property 'username' is missing in type 'Promise<{ username: string; }>' but required in type '{ username: string; }'`) in the API route, `generateMetadata`, and page components.  

All examples have now been updated to:

- type `params` correctly as `{ username: string }`
- remove `await`
- access values directly via `params.username`

This ensures the examples compile cleanly in TypeScript and align with the Next.js App Router contract.

***

**Notes to reviewers**

N/A

***

**How has it been tested?**

**Verified that TypeScript compilation passes with no errors (`tsc --noEmit`)**
