### PR TITLE
chore: update cdp faucet info

### DIFF
--- a/docs/base-chain/tools/network-faucets.mdx
+++ b/docs/base-chain/tools/network-faucets.mdx
@@ -1,14 +1,14 @@
 ---
 title: 'Network Faucets'
-description: Documentation for Testnet Faucets for the Base network. Details how to obtain Base testnet ETH.
+description: Documentation for Testnet Faucets on the Base network.
 ---
 
 ## Coinbase Developer Platform
 
-The [Coinbase Developer Platform Faucet](https://portal.cdp.coinbase.com/products/faucet) provides free testnet ETH on Base Sepolia - one claim per 24 hours.
+The [Coinbase Developer Platform Faucet](https://portal.cdp.coinbase.com/products/faucet) provides free testnet ETH on Base Sepolia - up to 0.1 ETH per 24 hours. Also supports USDC, EURC, and cbBTC.
 
 <Note>
-Requests to Coinbase Developer Platform's Faucet are limited to one claim per 24 hours.
+CDP Faucet can be accessed via the [Portal UI](https://portal.cdp.coinbase.com/products/faucet) or [programmatically](https://docs.cdp.coinbase.com/faucets/introduction/quickstart) using the `@coinbase/cdp-sdk`. See the [CDP Faucet docs](https://docs.cdp.coinbase.com/faucets/introduction/welcome#evm-compatible) for claim limits and supported assets.
 </Note>
 
 


### PR DESCRIPTION
**What changed? Why?**
This PR updates the CDP section of the [Network Faucet](https://docs.base.org/base-chain/tools/network-faucets#coinbase-developer-platform) page with supported assets as well as correctly states the total ETH claimable within 24hrs.

**Notes to reviewers**

**How has it been tested?**
Locally