### PR TITLE
docs: Update EIP-1559 Denominator to 125

### DIFF
--- a/docs/base-chain/network-information/configuration-changelog.mdx
+++ b/docs/base-chain/network-information/configuration-changelog.mdx
@@ -10,6 +10,7 @@ This page tracks configuration changes to the Base networks, including updates t
 
 | Date | Change | Documentation |
 |------|--------|---------------|
+| February 4, 2026 | Increased EIP-1559 Denominator to 125 | [EIP-1559 Fee Parameters](/base-chain/network-information/network-fees#eip-1559-fee-parameters) |
 | February 2, 2026 | Increased Minimum Base Fee to 2,000,000 wei | [Minimum Base Fee](/base-chain/network-information/network-fees#minimum-base-fee) |
 | January 22, 2026 | Increased Minimum Base Fee to 1,000,000 wei | [Minimum Base Fee](/base-chain/network-information/network-fees#minimum-base-fee) |
 | December 18, 2025 | Increased Minimum Base Fee to 500,000 wei | [Minimum Base Fee](/base-chain/network-information/network-fees#minimum-base-fee) |

--- a/docs/base-chain/network-information/network-fees.mdx
+++ b/docs/base-chain/network-information/network-fees.mdx
@@ -30,7 +30,7 @@ documentation](https://docs.optimism.io/stack/transactions/fees).
 
 As part of the [Jovian upgrade], Base introduced a minimum base fee. This feature sets a floor for the L2 base fee, preventing it from dropping to extremely low levels during periods of low network activity.
 
-The minimum base fee for Base Mainnet is 2,000,000 wei (0.002 gwei). This value may be periodically adjusted as we gather data on how it affects the chain. For reference, a minimum base fee of 0.002 gwei results in a cost of approximately $0.001 for a typical 200,000 gas transaction at an ETH price of $2500.
+The minimum base fee for Base Mainnet is 2,000,000 wei (0.002 gwei). This value may be periodically adjusted as we gather data on how it affects the chain. For reference, a minimum base fee of 0.002 gwei results in a cost of approximately \$0.001 for a typical 200,000 gas transaction at an ETH price of \$2500.
 
 ### Benefits
 
@@ -46,5 +46,36 @@ The minimum base fee for Base Mainnet is 2,000,000 wei (0.002 gwei). This value 
 | Base Sepolia | 200,000 wei (0.0002 gwei) |
 
 See the [Configuration Changelog](/base-chain/network-information/configuration-changelog) for a history of changes to the minimum base fee and other network parameters.
+
+## EIP-1559 Fee Parameters
+
+Base uses the OP Stack's implementation of EIP-1559, which controls how the L2 base fee adjusts in response to network demand. Two key parameters govern this behavior:
+
+### Elasticity Multiplier
+
+The **Elasticity Multiplier** determines the maximum gas capacity of a block relative to the target gas usage. With an elasticity of 6, blocks can contain up to 6× the target gas, allowing the network to absorb sudden demand spikes.
+
+### Base Fee Change Denominator
+
+The **Base Fee Change Denominator** controls how quickly the base fee adjusts. A larger denominator means slower, more gradual fee changes. With a denominator of 125, the base fee changes more smoothly compared to lower values.
+
+### Maximum Rate of Change
+
+The maximum rate of base fee change per block is calculated as:
+
+**Max increase per block = (Elasticity - 1) / Denominator**
+
+With the current parameters (Elasticity = 6, Denominator = 125):
+- Maximum increase per block: (6 - 1) / 125 = **4%**
+- Minimum time to double the base fee: 18 blocks × 2 seconds = **36 seconds**
+
+This gradual adjustment helps prevent extreme fee volatility during traffic spikes while still allowing the network to respond to sustained demand.
+
+### Current Configuration
+
+| Network      | Elasticity | Denominator | Max Change/Block |
+|--------------|------------|-------------|------------------|
+| Base Mainnet | 6          | 125         | 4%               |
+| Base Sepolia | 6          | 50          | 10%              |
 
 [Jovian upgrade]: https://docs.optimism.io/notices/upgrade-17

--- a/docs/base-chain/node-operators/performance-tuning.mdx
+++ b/docs/base-chain/node-operators/performance-tuning.mdx
@@ -12,13 +12,13 @@ Running a performant Base node requires adequate hardware. We recommend the foll
 1. A modern multi-core CPU with good single-core performance.  
 2. At least 32 GB RAM (64 GB recommended).  
 3. A locally attached NVMe SSD drive. RAID 0 configurations can improve performance.  
-4. Sufficient storage capacity calculated as:  
+4. Sufficient storage capacity calculated as:
 
   ```
-  (2 \* [current chain size](https://base.org/stats) + [snapshot size](https://basechaindata.vercel.app) + 20% buffer)
+  (2 × [current chain size] + [snapshot size] + 20% buffer)
   ```
 
-  This accounts for chain data growth and snapshot restoration space.
+  This accounts for chain data growth and snapshot restoration space. Refer to [Base Stats](https://base.org/stats) for current chain size and [Base Chain Data](https://basechaindata.vercel.app) for snapshot size. 
 
 <Note>
 If utilizing Amazon Elastic Block Store (EBS), io2 Block Express volumes are recommended to ensure sufficient disk read speeds, preventing latency issues during initial sync. However, **locally attached NVMe SSDs are strongly recommended over networked storage for optimal performance.**


### PR DESCRIPTION
**What changed? Why?**
* Add config changelog entry for the recent EIP-1559 denominator increase
* Add section under Network Fees to explain how EIP-1559 parameters work
* Escape dollar signs under network fees section
* Fix formatting of the suggested storage size formula

**Notes to reviewers**

**How has it been tested?**
Manually reviewed in local dev env