### PR TITLE
docs: fix missing space in build-app quickstart

### DIFF
--- a/docs/get-started/build-app.mdx
+++ b/docs/get-started/build-app.mdx
@@ -91,7 +91,7 @@ Base is a fast, low-cost, builder-friendly Ethereum L2 built to bring the next b
   BASE_SEPOLIA_RPC_URL="https://sepolia.base.org"
   ```
 
-  -Load your environment variables
+  - Load your environment variables
 
   ```bash Terminal
   source .env


### PR DESCRIPTION
What changed? Why?
Fixed a minor formatting issue where a hyphen was missing a space before "Load your environment variables" in the bullet list (line 94).

Before: `-Load your environment variables`
After: `- Load your environment variables`

Notes to reviewers
Typo/formatting fix only.

How has it been tested?
Verified the markdown list renders correctly.