### PR TITLE
docs: update deprecated Goerli reference to Sepolia

### DIFF
--- a/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-biconomy.mdx
+++ b/docs/learn/onchain-app-development/account-abstraction/account-abstraction-on-base-using-biconomy.mdx
@@ -159,7 +159,7 @@ To get testnet ETH, see the [prerequisites](#prerequisites).
 To deploy the smart contract to the Base Sepolia testnet, run the following command:
 
 ```bash
-forge create ./src/Counter.sol:Counter --rpc-url https://Sepolia.base.org --account deployer
+forge create ./src/Counter.sol:Counter --rpc-url https://sepolia.base.org --account deployer
 ```
 
 When prompted, enter the password that you set earlier, when you imported your wallet's private key.
@@ -217,7 +217,7 @@ Set up and fund the paymaster's gas tank by completing the following steps:
 1. From the dashboard, select the **Bundlers** tab
 
 <Info>
-At the time of writing this tutorial, the Bundler service is still under development, however a **Bundler URL** is provided for testing out UserOperations on test networks. You can specify the chain ID **84531** to use the Bundler URL on **Base Sepolia** testnet.
+At the time of writing this tutorial, the Bundler service is still under development, however a **Bundler URL** is provided for testing out UserOperations on test networks. You can specify the chain ID **84532** to use the Bundler URL on **Base Sepolia** testnet.
 </Info>
 
 ## Setting up the frontend


### PR DESCRIPTION
### Description
I noticed the "Account Abstraction using Biconomy" tutorial still contained multiple references to the deprecated "Base Goerli" network.

### Fix
- Updated all instances of "Base Goerli" to "Base Sepolia".
- Updated RPC URLs and network selection instructions throughout the tutorial.

### Context
Goerli is deprecated, so these instructions were outdated for new users.