### PR TITLE
Update data-indexers.mdx, adding Zerion API

### DIFF
--- a/docs/base-chain/tools/data-indexers.mdx
+++ b/docs/base-chain/tools/data-indexers.mdx
@@ -231,5 +231,27 @@ sign up [here](https://app.spaceandtime.ai/)
 - Arbitrum
 - Base 
 
+
+
+## Zerion API
+
+[Zerion API](https://zerion.io/api/base) is an enterprise-grade wallet data API that provides token balances, DeFi positions, NFTs, and transaction history on Base, other major EVM chains, and Solana. It covers over 8,000 DeFi protocols and delivers sub-second responses through a unified schema, so teams don't need to build or maintain their own indexers.
+
+Zerion API supports:
+
+- **Token balances and prices:** Real-time interpreted portfolio data with built-in conversions to USD and major currencies.
+- **DeFi positions:** LP, staking, lending, and other protocol positions decoded and normalized.
+- **Transaction history:** Human-readable, enriched transaction feeds ready for UIs or exports.
+- **NFT holdings:** Full NFT portfolio data including metadata and floor prices.
+
+To get started, visit the [developer documentation](https://developers.zerion.io/) or create free API keys on the [Zerion API for Base](https://zerion.io/api/base) page.
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+
+See all [supported chains](https://developers.zerion.io/reference/supported-blockchains).
+
 <PolicyBanner />
+
 


### PR DESCRIPTION
Added Zerion API with description and links

**What changed? Why?**

Zerion API, which supports Base, was missing https://developers.zerion.io/reference/authentication 

**Notes to reviewers**

The list now includes Zerion API.

**How has it been tested?**

Checked that Base is in the list of supported chains: https://developers.zerion.io/reference/supported-blockchains 
Made test calls to fetch token balances and transaction history on Base. 