### PR TITLE
docs: update ws response examples for `v0.4.0`

### DIFF
--- a/docs/base-chain/flashblocks/node-providers.mdx
+++ b/docs/base-chain/flashblocks/node-providers.mdx
@@ -87,20 +87,7 @@ To minimize the amount of data sent to nodes, each Flashblock only includes the 
     // ... other diff fields ...
   },
   "metadata": {
-    "block_number": 22585577,
-    "new_account_balances": {
-      "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "0x0",
-      // ... other balances ...
-    },
-    "receipts": {
-      "0x07d7f06b06fea714c1d1d446efa2790c6970aa74ee006186a32b5b7dd8ca2d82": {
-        "Deposit": {
-          "status": "0x1",
-          "depositNonce": "0x158a0ea"
-          // ... other receipt fields ...
-        }
-      }
-    }
+    "block_number": 22585577
   }
 }
 ```
@@ -121,20 +108,7 @@ To minimize the amount of data sent to nodes, each Flashblock only includes the 
     // ... other diff fields ...
   },
   "metadata": {
-    "block_number": 22585577,
-    "new_account_balances": {
-      "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "0x0",
-      "0x4200000000000000000000000000000000000015": "0x1234"
-      // ... other balances ...
-    },
-    "receipts": {
-      "0x07d7f06b06fea714c1d1d446efa2790c6970aa74ee006186a32b5b7dd8ca2d82": {
-        "status": "0x1",
-        "gasUsed": "0x1234f",
-        "logs": []
-        // ... other receipt fields ...
-      }
-    }
+    "block_number": 22585577
   }
 }
 ```


### PR DESCRIPTION
**What changed? Why?**
This PR removes the `receipts` and `new_account_balances` from the `metadata` object examples per base/base#466 (builder no longer tracks these fields).

**Notes to reviewers**

**How has it been tested?**
Locally