### PR TITLE
Adding CDP Embedded Wallets to user onboarding page

### DIFF
--- a/docs/base-chain/tools/onboarding.mdx
+++ b/docs/base-chain/tools/onboarding.mdx
@@ -10,7 +10,7 @@ description: Documentation for various ways to onboard users in your apps on Bas
 
 [Coinbase Developer Platform](https://docs.cdp.coinbase.com) (CDP) offers enterprise-grade crypto infrastructure across wallets, payments, trading, and more. [CDP Embedded Wallets](https://docs.cdp.coinbase.com/embedded-wallets/welcome) provide a complete embedded wallet solution, enabling users to create and manage wallets with email, SMS, Google, Apple, or X sign-in; no extensions or seed phrases required. Users maintain full self-custody with the ability to export keys anytime.
 
-CDP Embedded Wallets support both EVM networks (Base, Ethereum, Arbitrum, Polygon, Optimism, and more) and Solana, with built-in transaction signing, smart account support for gasless transactions, and wagmi/Solana Wallet Standard integrations.
+CDP Embedded Wallets supports EVM chains like Base and non-EVM chains, with built-in transaction signing, smart account support for gasless transactions, and integrations with popular developer tooling.
 
 Get started with the [React quickstart](https://docs.cdp.coinbase.com/embedded-wallets/quickstart) or explore the [SDK reference](https://docs.cdp.coinbase.com/sdks/cdp-sdks-v2/frontend).
 


### PR DESCRIPTION
**What changed? Why?**
Added CDP Embedded Wallets to the user onboarding page, as another option for builders looking for wallet solutions on Base chain.

**Notes to reviewers**

**How has it been tested?**
Reviewed locally.