### PR TITLE
docs: add Stork oracle

### DIFF
--- a/docs/base-chain/tools/oracles.mdx
+++ b/docs/base-chain/tools/oracles.mdx
@@ -145,6 +145,17 @@ See [this guide](https://docs.redstone.finance/) to learn how to use the RedSton
 
 - Base Mainnet
 
+## Stork
+
+[Stork](https://stork.network) is an ultra-low-latency oracle, built for the most demanding use cases in DeFi. Stork powers systems across the spectrum of onchain finance.
+
+See the [Stork docs](https://docs.stork.network) to learn how to integrate Stork [price feeds](https://data.stork.network).
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+- Base Sepolia (Testnet)
+
 ## Supra
 
 [Supra](https://supraoracles.com) provides VRF and decentralized oracle price feeds that can be used for onchain and offchain use-cases such as spot and perpetual DEXes, lending protocols, and payments protocols. Supra’s oracle chain and consensus algorithm makes it one of the fastest-to-finality oracle providers, with layer-1 security guarantees. The pull oracle has a sub-second response time. Aside from speed and security, Supra’s rotating node architecture gathers data from 40+ data sources and applies a robust calculation methodology to get the most accurate value. The node provenance on the data dashboard also provides a fully transparent historical audit trail. Supra’s Distributed Oracle Agreement (DORA) paper was accepted into ICDCS 2023, the oldest distributed systems conference.


### PR DESCRIPTION

**What changed? Why?**

Added information about Stork oracle and its integration. Stork supports Base and is used by a variety of Base projects, but was missing from this page. 

**Notes to reviewers**

**How has it been tested?**
