### PR TITLE
fix: eth_subscribe usage - params array must be literal true

### DIFF
--- a/docs/base-chain/flashblocks/apps.mdx
+++ b/docs/base-chain/flashblocks/apps.mdx
@@ -228,7 +228,7 @@ Each subscription returns **one item per WebSocket message** and emits events ev
 
 Optional `full` parameter for enriched transaction and log data:
 ```json
-{"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["newFlashblockTransactions", {"full": true}]}
+{"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["newFlashblockTransactions", true]}
 ```
 
 ---


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
