### PR TITLE
Update minimum base fee to 5,000,000 wei

### DIFF
--- a/docs/base-chain/network-information/configuration-changelog.mdx
+++ b/docs/base-chain/network-information/configuration-changelog.mdx
@@ -28,6 +28,7 @@ This page tracks configuration changes to the Base networks, including updates t
 | Date | Change | Documentation |
 |------|--------|---------------|
 | February 19, 2026 | Increased Minimum Base Fee to 5,000,000 wei | [Minimum Base Fee](/base-chain/network-information/network-fees#minimum-base-fee) |
+| February 10, 2026 | Increased EIP-1559 Denominator to 125 | [EIP-1559 Fee Parameters](/base-chain/network-information/network-fees#eip-1559-fee-parameters) |
 | February 10, 2026 | Increased Minimum Base Fee to 2,000,000 wei | [Minimum Base Fee](/base-chain/network-information/network-fees#minimum-base-fee) |
 | November 20, 2025 | Enabled Minimum Base Fee (200,000 wei) | [Minimum Base Fee](/base-chain/network-information/network-fees#minimum-base-fee) |
 | September 3, 2025 | Enabled Per-Transaction Gas Maximum | [Per-Transaction Gas Maximum](/base-chain/network-information/block-building#per-transaction-gas-maximum) |

--- a/docs/base-chain/network-information/network-fees.mdx
+++ b/docs/base-chain/network-information/network-fees.mdx
@@ -76,6 +76,6 @@ This gradual adjustment helps prevent extreme fee volatility during traffic spik
 | Network      | Elasticity | Denominator | Max Change/Block |
 |--------------|------------|-------------|------------------|
 | Base Mainnet | 6          | 125         | 4%               |
-| Base Sepolia | 6          | 50          | 10%              |
+| Base Sepolia | 6          | 125         | 4%               |
 
 [Jovian upgrade]: https://docs.optimism.io/notices/upgrade-17


### PR DESCRIPTION
## Summary
- Update minimum base fee from 2,000,000 to 5,000,000 wei (0.005 gwei) on both Base Mainnet and Base Sepolia
- Update cost example in network fees docs
- Add changelog entries for the 5M minimum base fee on both networks

Also captures missing Feb 10 Sepolia parity changes:
- Update Sepolia EIP-1559 Denominator from 50 to 125 (matching Mainnet)
- Add changelog entries for Sepolia Denominator increase and 2M minimum base fee

## Context
- Contract deployment PR: https://github.com/base/contract-deployments/pull/595
- Previous docs PRs: #1100 (2M), #894 (1M), #740 (500K)