### PR TITLE
docs: add `eth_getTransactionReceipt` indexing error code

### DIFF
--- a/docs/base-account/reference/core/provider-rpc-methods/eth_getTransactionReceipt.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/eth_getTransactionReceipt.mdx
@@ -117,10 +117,11 @@ Either 1 (success) or 0 (failure).
 
 ## Error Handling
 
-| Code   | Message                        | Description |
-| ------ | ------------------------------ | ----------- |
-| -32602 | Invalid transaction hash       | The provided transaction hash is invalid |
-| 4100   | Requested method not supported | The method is not supported by the wallet |
+| Code   | Message                          | Description |
+| ------ | -------------------------------- | ----------- |
+| -32000 | Transaction indexing is in progress | The node is still indexing transactions and the receipt is not yet available |
+| -32602 | Invalid transaction hash         | The provided transaction hash is invalid |
+| 4100   | Requested method not supported   | The method is not supported by the wallet |
 
 <Info>
 Transaction receipts are only available for mined transactions. Pending transactions will return null.


### PR DESCRIPTION
**What changed? Why?**
[eth_getTransactionReceipt](https://docs.base.org/base-account/reference/core/provider-rpc-methods/eth_getTransactionReceipt#error-handling) error handling table has a missing error code; the `-32000` error indicates that the node is still indexing transactions, which can occur when querying for receipts during node startup or syncing.

```json
{"jsonrpc":"2.0","id":13,"error":{"code":-32000,"message":"transaction indexing is in progress","data":"transaction indexing is in progress"}}
```

**Notes to reviewers**

**How has it been tested?**
Locally