### PR TITLE
Fix broken Search and Discovery link in embeds-and-previews

### DIFF
--- a/docs/mini-apps/core-concepts/embeds-and-previews.mdx
+++ b/docs/mini-apps/core-concepts/embeds-and-previews.mdx
@@ -135,7 +135,7 @@ Splash screen background color. Must be hex color code. Defaults to manifest spl
 ## Related Concepts
 
 <CardGroup cols={2}>
-<Card title="Search and Discovery" href="/mini-apps/technical-guides/search-and-discovery">
+<Card title="Search and Discovery" href="/mini-apps/core-concepts/manifest#discovery-&-search">
   Learn how your manifest powers search indexing and category placement in the Base app discovery features.
 </Card>
 


### PR DESCRIPTION
Updated the Related Concepts link from the non-existent `/mini-apps/technical-guides/search-and-discovery` to the correct `/mini-apps/core-concepts/manifest#discovery-&-search`

**What changed? Why?**

The Search and Discovery card in the Related Concepts section of `docs/mini-apps/core-concepts/embeds-and-previews.mdx` had a broken `href` pointing to a route that does not exist. Updated it to point to the correct anchor in the manifest page.

**Notes to reviewers**

Single line change in the Related Concepts section at the bottom of the file.

**How has it been tested?**

Verified the correct URL resolves: https://docs.base.org/mini-apps/core-concepts/manifest#discovery-&-search
