### PR TITLE
fix: correct params typing for Next.js handlers and pages

### DIFF
--- a/docs/mini-apps/technical-guides/dynamic-embeds.mdx
+++ b/docs/mini-apps/technical-guides/dynamic-embeds.mdx
@@ -38,9 +38,9 @@ export const dynamic = "force-dynamic";
 
 export async function GET(
   request: Request,
-  { params }: { params: Promise<{ username: string }> }
+  { params }: { params: { username: string } }
 ) {
-  const { username } = await params;
+  const { username } = params;
 
   return new ImageResponse(
     (
@@ -85,10 +85,10 @@ import { minikitConfig } from "../../../minikit.config";
 import { Metadata } from "next";
 
 export async function generateMetadata(
-  { params }: { params: Promise<{ username: string }> }
+  { params }: { params: { username: string } }
 ): Promise<Metadata> {
   try {
-    const { username } = await params;
+    const { username } = params;
     
     return {
       title: minikitConfig.miniapp.name,
@@ -125,9 +125,9 @@ export async function generateMetadata(
 }
 
 export default async function SharePage(
-  { params }: { params: Promise<{ username: string }> }
+  { params }: { params: { username: string } }
 ) {
-  const { username } = await params;
+  const { username } = params;
 
   return (
     <div>


### PR DESCRIPTION
**What changed? Why?**
Fixed the type of `params` in dynamic embed examples to match Next.js App Router behavior.   Replaced `Promise<{ username: string }>` with `{ username: string }` and removed `await params` in GET handler, generateMetadata, and SharePage.  

This change ensures the code works as expected when copied into a real Next.js project. The correction was confirmed by referencing Next.js documentation for route handlers, page components, and generateMetadata, where `params` is always a plain object.


**How has it been tested?**
References: [`generateMetadata`](https://nextjs.org/docs/app/api-reference/functions/generate-metadata), [`route handlers`](https://nextjs.org/docs/app/building-your-application/routing/route-handlers#route-handler-parameters)
