### PR TITLE
Remove Bridge Token Page from docs.json

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -97,7 +97,6 @@
               "base-chain/quickstart/why-base",
               "base-chain/quickstart/deploy-on-base",
               "base-chain/quickstart/connecting-to-base",
-              "base-chain/quickstart/bridge-token",
               "base-chain/quickstart/base-solana-bridge"
             ]
           },


### PR DESCRIPTION
**What changed? Why?**

Remove Bridge Token page from docs.json
