### PR TITLE
fix bridge page link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1469,7 +1469,7 @@
     },
     {
       "source": "/chain/bridge-an-l1-token-to-base",
-      "destination": "/base-chain/quickstart/bridge-token"
+      "destination": "/base-chain/network-information/bridges"
     },
     {
       "source": "/chain/bridges-mainnet",

--- a/docs/get-started/base.mdx
+++ b/docs/get-started/base.mdx
@@ -21,7 +21,7 @@ mode: "wide"
     ### Tokens
     [Launch a Token](/get-started/launch-token)
     [Bridge from Solana](/base-chain/quickstart/base-solana-bridge)
-    [Bridge from Ethereum](/base-chain/quickstart/bridge-token)
+    [Bridge from Ethereum](/base-chain/network-information/bridges)
   </div>
 </div>
 


### PR DESCRIPTION
**What changed? Why?**
- `get-started/base.mdx` - Updated the "Bridge from Ethereum" homepage link to `/base-chain/network-information/bridges`.
- `docs.json` - Updated redirect to point to `/base-chain/network-information/bridges` instead of the non-existent `/base-chain/quickstart/bridge-token` page.

**Notes to reviewers**

**How has it been tested?**
Locally