### PR TITLE
docs: position agents on homepage

### DIFF
--- a/docs/get-started/base.mdx
+++ b/docs/get-started/base.mdx
@@ -12,10 +12,10 @@ mode: "wide"
     [Integrate Base Accounts](/base-account/quickstart/web)
   </div>
   <div className="use-cases-links">
-    ### Apps
-    [Create a Mini App](/mini-apps/quickstart/create-new-miniapp)
-    [Sponsor Transactions](/base-account/improve-ux/sponsor-gas/paymasters)
-    [Accept Recurring Payments](/base-account/guides/accept-recurring-payments)
+    ### Agents
+    [Build an AI Agent](/ai-agents/index)
+    [Give Your Agent a Wallet](/ai-agents/core-concepts/wallets)
+    [Register Your Agent](/ai-agents/core-concepts/identity-verification-auth)
   </div>
   <div className="use-cases-links">
     ### Tokens


### PR DESCRIPTION
**What changed? Why?**
- **Homepage**: Replace "Apps" use-case section with "Agents" on the docs homepage (`get-started/base.mdx`), linking to Build an AI Agent, Give Your Agent a Wallet, and Register Your Agent — positioning Base as agent-first alongside Payments and Tokens

**Notes to reviewers**

**How has it been tested?**
Locally