### PR TITLE
Document dataSuffix for Base Pay attribution

### DIFF
--- a/docs/base-account/guides/accept-payments.mdx
+++ b/docs/base-account/guides/accept-payments.mdx
@@ -313,6 +313,27 @@ See full props and theming options in the [Button Reference](/base-account/refer
 If you intend on using the BasePayButton, please follow the [Brand Guidelines](/base-account/reference/ui-elements/brand-guidelines) to ensure consistency across your application.
 </Warning>
 
+## Attribution (dataSuffix)
+
+Pass a `dataSuffix` to attribute payments to your app via [Builder Codes](/base-chain/builder-codes/builder-codes). The suffix is appended to the transaction calldata and must be a `0x`-prefixed hex string with no fixed length requirement.
+
+```ts Payment with Attribution (dataSuffix)
+import { pay } from '@base-org/account';
+
+// Replace with your app's ERC-8021 data suffix from Builder Codes.
+const DATA_SUFFIX = '0x07626173656170700080218021802180218021802180218021';
+
+const payment = await pay({
+  amount: '10.50',
+  to: '0xRecipient',
+  dataSuffix: DATA_SUFFIX,
+});
+```
+
+<Tip>
+If your suffix is not a valid `0x`-prefixed hex string, `pay()` will throw a validation error before submitting the transaction.
+</Tip>
+
 ## Test on Base Sepolia
 
 1. Get test USDC from the <a href="https://faucet.circle.com" target="_blank">Circle Faucet</a> (select "Base Sepolia").  

--- a/docs/base-account/reference/base-pay/pay.mdx
+++ b/docs/base-account/reference/base-pay/pay.mdx
@@ -23,6 +23,10 @@ Ethereum address to send USDC to (must start with 0x).
 **Pattern:** `^0x[0-9a-fA-F]{40}$`
 </ParamField>
 
+<ParamField body="dataSuffix" type="`0x${string}`">
+Optional attribution data suffix to append to the transaction calldata. Must be a `0x`-prefixed hex string (e.g., `"0xabc123"`). Use this to pass [Builder Codes](/base-chain/builder-codes/builder-codes) or other onchain attribution identifiers. No fixed length requirement.
+</ParamField>
+
 <ParamField body="testnet" type="boolean">
 Set to true to use Base Sepolia testnet instead of mainnet. Default: false
 </ParamField>
@@ -91,6 +95,24 @@ try {
     amount: "10.50",
     to: "0x1234567890123456789012345678901234567890",
     testnet: false
+  });
+  console.log(`Payment sent! Transaction ID: ${payment.id}`);
+} catch (error) {
+  console.error(`Payment failed: ${error.message}`);
+}
+```
+
+```typescript Payment with Attribution (dataSuffix)
+import { pay } from '@base-org/account';
+
+// Replace with your app's ERC-8021 data suffix from Builder Codes.
+const DATA_SUFFIX = "0x07626173656170700080218021802180218021802180218021";
+
+try {
+  const payment = await pay({
+    amount: "10.50",
+    to: "0x1234567890123456789012345678901234567890",
+    dataSuffix: DATA_SUFFIX,
   });
   console.log(`Payment sent! Transaction ID: ${payment.id}`);
 } catch (error) {

--- a/docs/base-account/reference/core/createBaseAccount.mdx
+++ b/docs/base-account/reference/core/createBaseAccount.mdx
@@ -40,11 +40,11 @@ Attribution configuration for Smart Wallet transactions.
 
 <Expandable title="Attribution properties">
 <ParamField body="auto" type="boolean">
-When true, Smart Wallet will generate a 16 byte hex string from the app's origin.
+When true, Smart Wallet will generate a deterministic hex suffix from the app's origin.
 </ParamField>
 
 <ParamField body="dataSuffix" type="`0x${string}`">
-Custom 16 byte hex string appended to initCode and executeBatch calldata. Cannot be used with `auto: true`.
+Custom `0x`-prefixed hex string appended to initCode and executeBatch calldata. Cannot be used with `auto: true`.
 </ParamField>
 </Expandable>
 </ParamField>


### PR DESCRIPTION
## What changed? Why?

Document the `dataSuffix` parameter for Base Pay attribution via Builder Codes:

- **accept-payments.mdx**: Added "Attribution (dataSuffix)" section with usage example and tip about validation
- **pay.mdx**: Documented `dataSuffix` param in API reference and added example for payment with attribution
- **createBaseAccount.mdx**: Updated attribution config docs—replaced "16 byte hex string" with "deterministic hex suffix" and "Custom `0x`-prefixed hex string" to reflect no fixed length requirement

## How was this tested?

Docs-only change. MDX linter run on changed files (repo has no unit tests for content).

## How can reviewers manually test these changes?

1. Run `mintlify dev` and verify the Accept Payments guide, pay reference, and createBaseAccount reference render correctly
2. Confirm code examples and links to Builder Codes work

## Demo/screenshots

