### PR TITLE
[i18n] Spanish translation — AI Agents section

### DIFF
--- a/docs/es/ai-agents/core-concepts/agent-apps.mdx
+++ b/docs/es/ai-agents/core-concepts/agent-apps.mdx
@@ -1,0 +1,75 @@
+---
+title: "Aplicaciones de Agentes"
+description: "Construye servicios diseñados para agentes y haz que tu aplicación sea descubrible"
+---
+
+import { GithubRepoCard } from "/snippets/GithubRepoCard.mdx";
+
+Una aplicación de agentes es un servicio construido con agentes de IA como el usuario principal. En lugar de renderizar una interfaz visual para que los humanos hagan clic, una aplicación de agentes expone endpoints estructurados que los agentes pueden descubrir, entender y llamar programáticamente.
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/-y0ZJ-0z7Ow?si=YtmXlwM_3m8Gm0WE"
+  title="Building agent apps on Base"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+## Cómo los agentes descubren tu aplicación
+
+Los agentes encuentran tu servicio a través de un archivo `SKILL.md` alojado en una ruta de URL bien conocida: `/.well-known/SKILL.md`. Si has trabajado con desarrollo web, este patrón puede ser familiar:
+
+- Apple usa `/.well-known/apple-app-site-association` para enlaces universales
+- Las autoridades de certificados SSL usan `/.well-known/acme-challenge/` para verificar la propiedad del dominio
+- OAuth usa `/.well-known/openid-configuration` para descubrimiento
+
+La convención `/.well-known/` es una forma estándar de alojar metadatos en una ubicación predecible. Para aplicaciones de agentes, tu archivo `SKILL.md` vive ahí para que cualquier agente pueda encontrarlo verificando `tudominio.com/.well-known/SKILL.md`.
+
+### Qué va en un SKILL.md
+
+Tu archivo `SKILL.md` describe qué hace tu aplicación, qué endpoints están disponibles y cómo usarlos. Aquí hay una plantilla conceptual:
+
+```markdown Title "SKILL.md template"
+# Nombre de Tu Aplicación
+
+## Descripción
+Qué hace tu aplicación, en lenguaje simple.
+
+## Endpoints
+
+### POST /api/action-name
+- **Descripción:** Qué hace este endpoint
+- **Entradas:** Qué parámetros espera
+- **Salida:** Qué devuelve
+- **Pago:** Si requiere pago x402 y el costo
+
+## Autenticación
+Cómo los agentes deben autenticarse (por ejemplo, SIWA, clave de API, x402).
+```
+
+Cuando un agente lee tu `SKILL.md`, entiende qué ofrece tu servicio y cómo interactuar con él, sin humanos en el medio.
+
+## Diseñando para usuarios agentes
+
+Los agentes no son humanos. No navegan, adivinan o interpretan señales visuales. Al construir una aplicación de agentes, sigue estas pautas:
+
+- **Documenta efectos secundarios**: si un endpoint transfiere fondos, modifica estado o desencadena acciones externas, dilo explícitamente en tu `SKILL.md`
+- **Devuelve JSON estructurado**: los agentes analizan JSON, no HTML. Cada endpoint debe devolver respuestas JSON bien estructuradas con nombres de campo consistentes
+- **Soporta x402 para acceso de pago**: si tu servicio cuesta dinero, implementa el [protocolo x402](/ai-agents/core-concepts/payments-and-transactions) para que los agentes puedan pagar por solicitud sin pre-registro
+- **Usa respuestas de error claras**: devuelve mensajes de error descriptivos con códigos de estado HTTP apropiados para que los agentes puedan manejar fallos elegantemente
+
+## Haciendo tu aplicación descubrible
+
+Aloja tu `SKILL.md` en `/.well-known/SKILL.md` y registra tu aplicación en el [registry ERC-8004](/ai-agents/core-concepts/identity-verification-auth). El mismo registry usado para identidad de agentes se usa para descubrimiento de aplicaciones. Una vez registrado, los agentes pueden consultar el registry, encontrar tu servicio y leer tu `SKILL.md` para entender cómo interactuar con él.
+
+<Warning>
+El Agent App Framework es experimental. Las APIs y convenciones pueden cambiar a medida que el estándar evoluciona.
+</Warning>
+
+<GithubRepoCard title="Agent App Framework" githubUrl="https://github.com/base/agent-apps-experimental" />
+
+## Continúa explorando
+
+<Card title="Volver al resumen" icon="arrow-left" href="/ai-agents/index">
+  Regresa al resumen de agentes de IA para un resumen de todos los componentes.
+</Card>

--- a/docs/es/ai-agents/core-concepts/agent-frameworks.mdx
+++ b/docs/es/ai-agents/core-concepts/agent-frameworks.mdx
@@ -1,0 +1,61 @@
+---
+title: "Frameworks"
+description: "Elige el framework adecuado para construir y ejecutar agentes de IA en Base"
+---
+
+Tu primera decisión al construir un agente de IA en Base es elegir un framework. Esto determina cómo escribes la lógica de tu agente, dónde se ejecuta y cuánta infraestructura gestionas tú mismo.
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/b5Wx2NAeY2E?si=r1FumIsbGt6nAt29"
+  title="Building agents on Base"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+## Comparando tus opciones
+
+| | BANKR | OpenClaw | Agent SDK |
+|---|---|---|---|
+| **Qué es** | Un API de agente gestionado, más plugins de skill y wallet para OpenClaw | Un asistente de IA personal de código abierto que se ejecuta en múltiples canales (Discord, Telegram, web) | Un conjunto de herramientas para desarrolladores para construir agentes personalizados con control total sobre comportamiento e integraciones |
+| **Lenguaje** | Cualquiera (REST API) para Agent API; TypeScript para plugins de OpenClaw | TypeScript | TypeScript / Python |
+| **Alojamiento** | Agent API es gestionado por BANKR; los plugins de OpenClaw se ejecutan en tu agente auto-hospedado | Auto-hospedado | Auto-hospedado |
+| **Mejor para** | Agent API para agregar capacidades onchain sin gestionar infraestructura; plugins de OpenClaw para agregar skills onchain a un agente auto-hospedado | Ejecutar un asistente multicanal con skills preconstruidos y soporte de plugins | Agentes de producción donde necesitas control total sobre lógica, integraciones y despliegue |
+
+## BANKR
+
+BANKR ofrece dos formas de trabajar con agentes en Base. El **BANKR Agent API** es un agente hospedado con el que interactúas a través de un REST API: envías prompts y recibes resultados, incluyendo la capacidad de ejecutar intercambios y verificar balances, sin construir o desplegar tu propio agente. Esta es la forma más rápida de agregar capacidades de agente onchain a una aplicación existente.
+
+BANKR también proporciona **skills y plugins de wallet para OpenClaw**. Si estás construyendo con OpenClaw, puedes instalar los paquetes de skill de BANKR para dar a tu agente auto-hospedado capacidades de wallet, intercambios de tokens y otras acciones onchain sin usar el API gestionado.
+
+Usa el BANKR Agent API cuando quieras capacidades de agente onchain sin gestionar infraestructura. Usa los plugins de OpenClaw de BANKR cuando quieras los skills onchain de BANKR dentro de tu propio agente auto-hospedado.
+
+[Comienza con BANKR Agent API →](https://docs.bankr.bot/getting-started/quick-start)
+
+[Explora los skills de BANKR para OpenClaw →](https://github.com/BankrBot/openclaw-skills)
+
+## OpenClaw
+
+OpenClaw es un asistente de IA de código abierto que se conecta a múltiples plataformas de mensajería de forma predeterminada. Viene con un sistema de plugins para agregar skills (acciones preconstruidas que tu agente puede realizar) y maneja la infraestructura para recibir mensajes, procesarlos y responder a través de canales.
+
+Usa OpenClaw cuando quieras ejecutar un agente conversacional a través de Discord, Telegram o web y extenderlo con plugins construidos por la comunidad.
+
+[Comienza con OpenClaw →](https://docs.openclaw.ai/start/getting-started)
+
+## Agent SDK
+
+El Agent SDK de Coinbase te da los bloques de construcción para crear agentes que pueden interactuar con <Tooltip tip="Protocolos y aplicaciones basados en blockchain, como exchanges descentralizados o plataformas de préstamos">servicios onchain</Tooltip>. Tú escribes la lógica del agente, defines sus herramientas y lo despliegas en tu propia infraestructura. Esta es la opción más flexible: controlas cada aspecto del comportamiento del agente, desde cómo procesa los prompts hasta qué servicios llama.
+
+Usa Agent SDK cuando estés construyendo un agente de producción y quieras control total sobre su arquitectura.
+
+[Comienza con Agent SDK →](https://docs.cdp.coinbase.com/agent-kit/welcome)
+
+<Tip>
+**Cómo elegir:** Usa el **BANKR Agent API** para llamar a un agente vía API sin construir uno, o agrega **los plugins de skill de BANKR** a un agente OpenClaw para capacidades onchain. Usa **OpenClaw** si necesitas un chatbot multicanal con plugins. Usa **Agent SDK** si quieres control total sobre lógica, integraciones y despliegue.
+</Tip>
+
+## Siguiente paso
+
+<Card title="Wallets" icon="arrow-right" href="/ai-agents/core-concepts/wallets">
+  Dale a tu agente la capacidad de mantener fondos y realizar pagos.
+</Card>

--- a/docs/es/ai-agents/core-concepts/identity-verification-auth.mdx
+++ b/docs/es/ai-agents/core-concepts/identity-verification-auth.mdx
@@ -1,0 +1,84 @@
+---
+title: "Identidad, Verificación y Autenticación"
+description: "Haz que tu agente sea descubrible y verificable para que otros agentes y servicios puedan confiar en él"
+---
+
+Cuando tu agente llama a un servicio, ¿cómo sabe ese servicio que es realmente tu agente y no un impostor? Cuando tu agente recibe una respuesta, ¿cómo sabe que la respuesta provino de un servicio legítimo? La identidad, verificación y autenticación resuelven estos problemas.
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/l387PXGnrgU?si=EM4IKT14ajFoYkNP"
+  title="Agent identity, verification, and auth"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+## Por qué la identidad importa
+
+En un mundo donde los agentes interactúan entre sí y con servicios de forma autónoma, la confianza es la base. Sin identidad:
+
+- Un servicio no puede verificar que una solicitud provino de un agente autorizado
+- Tu agente no puede verificar que una respuesta provino del servicio real (no un impostor malicioso)
+- Otros agentes no pueden descubrir qué hace tu agente o cómo interactuar con él
+
+Los estándares de identidad en Base resuelven los tres problemas: permiten que tu agente se registre en un directorio público, pruebe su identidad con cada solicitud y descubra otros agentes y servicios.
+
+## Registry: un directorio público para agentes
+
+Un registry es un directorio público donde los agentes y servicios publican su identidad. Cualquier participante puede consultar el registry para resolver el nombre de un agente a sus metadatos: qué hace, dónde viven sus endpoints y qué clave pública usa para firmar.
+
+En Base, esto se implementa a través del estándar **ERC-8004**. Cuando tu agente se registra, su entrada se almacena onchain, lo que significa que cualquiera puede verificarla sin depender de una autoridad central.
+
+Una entrada de registry típicamente incluye:
+
+- El nombre y descripción de tu agente
+- Los endpoints donde puede ser alcanzado
+- Un <Tooltip tip="Un par de claves criptográficas: la clave pública se comparte abiertamente (como una dirección de retorno) e identifica tu agente, mientras que la clave privada se mantiene secreta (como un sello de firma) y prueba que controlas la identidad">par de claves</Tooltip> que vincula la identidad del agente a sus credenciales criptográficas
+
+[Aprende más sobre Agent Registry (ERC-8004) →](https://www.8004.org/)
+
+## Verificación: probando identidad en runtime
+
+El registro le dice al mundo que tu agente existe. La verificación prueba que es realmente tu agente haciendo cada solicitud. Esto es manejado por el estándar **ERC-8128**.
+
+<Steps>
+  <Step title="Registra tu agente">
+    Tu agente registra su identidad y clave pública en el registry ERC-8004. Este es un paso de configuración único.
+  </Step>
+
+  <Step title="Firma cada solicitud">
+    Cuando tu agente llama a un servicio, firma la solicitud usando su clave privada. Esto crea una firma criptográfica única para esa solicitud específica.
+  </Step>
+
+  <Step title="El servicio verifica la firma">
+    El servicio busca la clave pública de tu agente desde el registry, luego verifica la firma. Si la firma coincide, el servicio sabe que la solicitud provino de tu agente registrado y no de un impostor.
+  </Step>
+</Steps>
+
+Esto funciona en ambas direcciones: tu agente también puede verificar que la respuesta de un servicio es auténtica verificando la firma del servicio contra el registry.
+
+[Aprende más sobre Agent Verification (ERC-8128) →](https://erc8128.slice.so/concepts/overview)
+
+## Sign In With Agent (SIWA)
+
+SIWA agrupa registry y verificación en un solo SDK, similar a cómo "Sign in with Google" agrupa OAuth y verificación de identidad en una integración. En lugar de conectar ERC-8004 y ERC-8128 por separado, integras SIWA y obtienes ambas capacidades de forma predeterminada.
+
+Con SIWA, tu agente puede:
+
+- **Registrar su identidad** en el directorio onchain
+- **Autenticarse en servicios** probando que es el agente registrado
+- **Firmar cada solicitud** para que los servicios puedan verificar autenticidad
+
+SIWA es la ruta más rápida para dar a tu agente una identidad verificable. Usa ERC-8004 y ERC-8128 directamente solo si necesitas un control más granular sobre el proceso de registro y verificación.
+
+[Aprende más en siwa.id →](https://siwa.id)
+
+<Tip>
+**Comienza con SIWA** para la ruta de integración más simple. Usa ERC-8004 y ERC-8128 directamente si necesitas control detallado sobre cómo tu agente se registra y cómo se realiza la verificación.
+</Tip>
+
+## Siguiente paso
+
+<Card title="Aplicaciones de agentes" icon="arrow-right" href="/ai-agents/core-concepts/agent-apps">
+  Construye servicios diseñados para agentes y haz que tu aplicación sea descubrible.
+</Card>

--- a/docs/es/ai-agents/core-concepts/payments-and-transactions.mdx
+++ b/docs/es/ai-agents/core-concepts/payments-and-transactions.mdx
@@ -1,0 +1,94 @@
+---
+title: "Pagos y Transacciones"
+description: "Cómo tu agente paga por servicios, recibe pagos y ejecuta acciones onchain"
+---
+
+Tu agente tiene un wallet. Ahora necesita usarlo. Esta página cubre dos conceptos clave: cómo tu agente paga por servicios automáticamente usando el protocolo x402, y cómo los skills definen las acciones que tu agente puede realizar.
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/b5Wx2NAeY2E?si=r1FumIsbGt6nAt29"
+  title="Payments and transactions for agents"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+## x402: pago por solicitud con stablecoins
+
+x402 permite que tu agente pague por solicitudes de API usando <Tooltip tip="Criptomonedas ancladas a un activo estable como el dólar estadounidense (por ejemplo, USDC). 1 USDC está diseñado para siempre equivaler a $1.">stablecoins</Tooltip> sin suscripciones o claves de API. Tu agente solicita un recurso, el servidor le dice el precio, tu agente paga y el servidor entrega los datos.
+
+El nombre proviene del código de estado HTTP `402 Payment Required`, que ha estado reservado en la especificación HTTP desde los años 1990 pero nunca fue ampliamente adoptado. x402 finalmente lo pone en uso.
+
+### Cómo funciona x402
+
+<Steps>
+  <Step title="Tu agente hace una solicitud">
+    Tu agente envía una solicitud HTTP estándar a un endpoint de API, igual que cualquier otra llamada de API.
+  </Step>
+
+  <Step title="El servidor responde con 402 Payment Required">
+    En lugar de devolver datos, el servidor responde con un código de estado `402` e incluye detalles de pago: cuánto cuesta, en qué stablecoin pagar y dónde enviar el pago.
+  </Step>
+
+  <Step title="Tu agente paga">
+    El wallet de tu agente construye y envía un pago onchain basado en las instrucciones del servidor. Esto sucede automáticamente, sin aprobación humana necesaria.
+  </Step>
+
+  <Step title="El servidor entrega los datos">
+    Una vez confirmado el pago, el servidor devuelve los datos solicitados. Todo el flujo toma segundos.
+  </Step>
+</Steps>
+
+Este modelo es poderoso para agentes porque no requiere una relación preexistente entre tu agente y el servicio. Cualquier agente con un wallet financiado puede pagar por cualquier API habilitada para x402 sobre la marcha.
+
+[Aprende más sobre x402 →](https://www.x402.org/)
+
+## Skills: acciones que tu agente puede realizar
+
+Los skills son definiciones de funciones tipadas que describen una acción que tu agente puede invocar. Cada skill especifica un nombre, entradas esperadas y tipo de retorno similar a un esquema de herramienta o función en cualquier integración de uso de herramientas de LLM. Tu agente analiza estas definiciones en runtime y las llama cuando son relevantes.
+
+Los skills cubren acciones como verificar el balance de un token, ejecutar un intercambio, enviar un pago o llamar a un <Tooltip tip="Un programa desplegado onchain que se ejecuta automáticamente cuando se cumplen las condiciones">smart contract</Tooltip>.
+
+### Cómo se ve un skill
+
+Una definición de skill incluye el nombre de la acción, una descripción de lo que hace, las entradas requeridas y la salida esperada. Aquí hay un ejemplo simplificado:
+
+```json Title "Conceptual skill definition"
+{
+  "skill": "check-balance",
+  "description": "Check the token balance of a wallet address",
+  "inputs": {
+    "wallet_address": "The address to check",
+    "token": "The token symbol (e.g., USDC, ETH)"
+  },
+  "output": "The current balance of the specified token"
+}
+```
+
+Tu agente lee esta definición, entiende qué entradas necesita proporcionar y llama al skill cuando es relevante para la tarea en cuestión.
+
+### Proveedores de skills
+
+<Tabs>
+  <Tab title="BANKR Skills">
+    **Qué son:** Skills preconstruidos para agentes ejecutándose en OpenClaw. Los skills de BANKR cubren acciones comunes como intercambios de tokens, verificaciones de balance e interacciones DeFi.
+
+    **Mejor para:** Agentes usando OpenClaw o BANKR que necesitan capacidades onchain listas para usar.
+
+    [Explora los skills de BANKR →](https://github.com/BankrBot/openclaw-skills)
+  </Tab>
+
+  <Tab title="CDP Skills">
+    **Qué son:** Skills proporcionados por la plataforma de desarrolladores de Coinbase. Los skills de CDP se integran con el Agentic Wallet y cubren gestión de wallet, operaciones de tokens e interacciones de protocolos.
+
+    **Mejor para:** Agentes usando Agent SDK con un CDP Agentic Wallet.
+
+    [Explora los skills de CDP →](https://docs.cdp.coinbase.com/agentic-wallet/skills/overview)
+  </Tab>
+</Tabs>
+
+## Siguiente paso
+
+<Card title="Identidad, verificación y autenticación" icon="arrow-right" href="/ai-agents/core-concepts/identity-verification-auth">
+  Haz que tu agente sea descubrible y verificable para que otros agentes y servicios puedan confiar en él.
+</Card>

--- a/docs/es/ai-agents/core-concepts/wallets.mdx
+++ b/docs/es/ai-agents/core-concepts/wallets.mdx
@@ -1,0 +1,63 @@
+---
+title: "Wallets"
+description: "Dale a tu agente la capacidad de mantener fondos, enviar pagos y firmar mensajes"
+---
+
+Un wallet onchain le da a tu agente la capacidad de mantener fondos, autorizar transacciones y firmar mensajes. Sin uno, tu agente puede leer datos pero no puede pagar por servicios, recibir pagos o probar su identidad.
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/G3yn8g4mf-s?si=jRsLzFPS_cui9-gF"
+  title="Agent wallets on Base"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+## Por qué tu agente necesita un wallet dedicado
+
+Un agente de IA *podría* generar su propio wallet creando una clave privada aleatoria a través de prompting, pero esto es inseguro. Aquí está el porqué:
+
+- La clave privada aparece en el contexto de conversación del agente, donde puede ser registrada, almacenada en caché o filtrada a través de middleware
+- Cualquier sistema con acceso al historial de prompts del agente podría extraer la clave
+- Si la clave se compromete, todos los fondos en el wallet se pierden permanentemente
+
+Los servicios de wallet dedicados resuelven esto gestionando claves en infraestructura segura que está separada del runtime de tu agente. Tu agente puede solicitar transacciones sin ver nunca la clave privada.
+
+## Opciones de wallet
+
+<Tabs>
+  <Tab title="BANKR Wallet">
+    **Qué es:** Un servicio de wallet diseñado para agentes ejecutándose en OpenClaw. BANKR gestiona las claves privadas y expone acciones de wallet como skills que tu agente puede llamar.
+
+    **Mejor para:** Agentes construidos con OpenClaw o BANKR que necesitan una integración rápida de wallet con skills preconstruidos.
+
+    **Cómo funciona:** Instala el skill de wallet de BANKR, y tu agente obtiene la capacidad de verificar balances, enviar tokens e interactuar con <Tooltip tip="Protocolos que proporcionan servicios financieros (préstamos, trading, etc.) a través de smart contracts en lugar de bancos tradicionales">protocolos DeFi</Tooltip>. Las claves son almacenadas y gestionadas por BANKR.
+
+    [Comienza →](https://github.com/BankrBot/openclaw-skills)
+  </Tab>
+
+  <Tab title="CDP Agentic Wallet">
+    **Qué es:** La infraestructura de wallet de Coinbase para agentes de IA. Proporciona gestión de wallet basada en API con seguridad de claves de nivel empresarial a través de la infraestructura de Coinbase.
+
+    **Mejor para:** Agentes construidos con Agent SDK que necesitan infraestructura de wallet lista para producción con seguridad respaldada por Coinbase.
+
+    **Cómo funciona:** Crea wallets a través del API de CDP. Tu agente solicita transacciones vía el API, y CDP maneja la firma y transmisión. Las claves son gestionadas en el enclave seguro de Coinbase, tu agente nunca las toca directamente.
+
+    [Comienza →](https://docs.cdp.coinbase.com/agentic-wallet/quickstart)
+  </Tab>
+</Tabs>
+
+## Lo que tu agente puede hacer con un wallet
+
+Una vez que tu agente tiene un wallet, puede:
+
+- **Mantener <Tooltip tip="Criptomonedas ancladas a un activo estable como el dólar estadounidense (por ejemplo, USDC). 1 USDC está diseñado para siempre equivaler a $1.">stablecoins</Tooltip>**: recibir y almacenar USDC u otros tokens
+- **Enviar y recibir pagos**: transferir fondos a otros wallets, pagar por acceso a API o recibir pagos por servicios
+- **Firmar mensajes**: probar criptográficamente que un mensaje o solicitud provino de tu agente (usado para verificación de identidad)
+- **Interactuar con protocolos**: llamar <Tooltip tip="Programas desplegados onchain que se ejecutan automáticamente cuando se cumplen las condiciones. Potencian todo, desde intercambios de tokens hasta préstamos.">smart contracts</Tooltip> para intercambiar tokens, proporcionar liquidez o usar otros servicios onchain
+
+## Siguiente paso
+
+<Card title="Pagos y transacciones" icon="arrow-right" href="/ai-agents/core-concepts/payments-and-transactions">
+  Aprende cómo tu agente paga por servicios y ejecuta acciones onchain.
+</Card>

--- a/docs/es/ai-agents/index.mdx
+++ b/docs/es/ai-agents/index.mdx
@@ -1,0 +1,45 @@
+---
+title: "Agentes de IA en Base"
+description: "Construye agentes de IA que pueden mantener fondos, realizar pagos, verificar identidad e interactuar con servicios en Base"
+---
+
+Base le da a tu agente de IA las herramientas para operar como un actor económico independiente: un wallet para mantener y gastar fondos, estándares de identidad para que otros agentes y servicios puedan confiar en él, un protocolo de pago para APIs de pago por solicitud, y una capa de descubrimiento para que los agentes puedan encontrarse entre sí.
+
+## Lo que puedes construir
+
+- **Un agente de trading** que monitorea condiciones del mercado y ejecuta intercambios de tokens automáticamente usando skills y un wallet financiado
+- **Un agente de pago** que paga por datos de API premium en nombre de tu aplicación usando el protocolo de pago por solicitud x402
+- **Un servicio descubrible** que otros agentes pueden encontrar, verificar y pagar para usar — sin integración humana requerida
+- **Un asistente multicanal** que gestiona un wallet, responde preguntas y ejecuta acciones onchain a través de Discord, Telegram o web
+
+## Cómo encajan las piezas
+
+1. **Elige un framework** — selecciona cómo construirás y ejecutarás tu agente (SDK auto-hospedado, asistente de código abierto, o API gestionado)
+2. **Agrega un wallet** — dale a tu agente la capacidad de mantener stablecoins, enviar pagos y firmar transacciones
+3. **Usa pagos y skills** — permite que tu agente pague por servicios a través de x402 y realice acciones onchain mediante skills preconstruidos
+4. **Establece identidad** — registra tu agente en un directorio público para que otros agentes y servicios puedan descubrirlo y verificarlo
+5. **Construye o conéctate a aplicaciones de agentes** — crea servicios diseñados para agentes, o conecta tu agente a los existentes
+
+## Conceptos fundamentales
+
+<CardGroup cols={2}>
+  <Card title="Frameworks" icon="cubes" href="/ai-agents/core-concepts/agent-frameworks">
+    Elige entre Agent SDK, OpenClaw y BANKR — cada uno ofrece un nivel diferente de control y alojamiento.
+  </Card>
+
+  <Card title="Wallets" icon="wallet" href="/ai-agents/core-concepts/wallets">
+    Tu agente necesita un wallet para mantener fondos y autorizar transacciones. Aprende por qué los wallets dedicados importan y qué opción se ajusta a tu configuración.
+  </Card>
+
+  <Card title="Pagos y transacciones" icon="bolt" href="/ai-agents/core-concepts/payments-and-transactions">
+    Cómo tu agente paga por acceso a APIs con stablecoins (x402) y realiza acciones onchain a través de skills.
+  </Card>
+
+  <Card title="Identidad y autenticación" icon="fingerprint" href="/ai-agents/core-concepts/identity-verification-auth">
+    Cómo tu agente prueba quién es, verifica otros agentes y se autentica en servicios.
+  </Card>
+
+  <Card title="Aplicaciones de agentes" icon="grid-2" href="/ai-agents/core-concepts/agent-apps">
+    Construye servicios con agentes como el usuario principal. Expone endpoints estructurados y haz que tu aplicación sea descubrible.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Motivation

Base Korea (@daehan_base) published a full Korean translation of the AI Agents docs, driven by community feedback that the lack of Korean docs was a barrier to getting started with agent development.

In response, @eric.base.eth (Lead DevRel at Base) publicly said:

> "Love this! Lets get it integrated to the core docs site"
> — https://x.com/i/status/2028869946311164081

This PR does the same for Spanish, following that same call to action.

Spanish is the second most spoken language in the world by native speakers, with a large and growing developer community across Latin America and Spain. The same barrier that existed for Korean developers exists for Spanish-speaking developers today.

## What this PR does

Adds a Spanish translation of the entire AI Agents section under `docs/es/ai-agents/`, mirroring the existing English file structure exactly.

## Files added
- `docs/es/ai-agents/index.mdx`
- `docs/es/ai-agents/core-concepts/agent-frameworks.mdx`
- `docs/es/ai-agents/core-concepts/wallets.mdx`
- `docs/es/ai-agents/core-concepts/payments-and-transactions.mdx`
- `docs/es/ai-agents/core-concepts/identity-verification-auth.mdx`
- `docs/es/ai-agents/core-concepts/agent-apps.mdx`

## Why docs.json is not modified

The current `docs.json` uses a flat `tabs` array with no `languages` key. Enabling Mintlify i18n requires replacing `tabs` with a `languages` structure that duplicates the entire navigation for each locale — a change that affects the whole site, not just AI Agents.

This PR intentionally scopes to content only and leaves the navigation decision to the Base team. If you want to activate the language switcher, the next step would be restructuring `docs.json` following:
https://www.mintlify.com/docs/guides/internationalization

## Translation approach
- Technical terms kept in English: wallet, token, SDK, API, x402, AgentKit, CDP, XMTP, onchain
- All code blocks preserved exactly as-is
- Professional developer documentation tone throughout