### PR TITLE
Fix encoded colons in anchor hrefs

### DIFF
--- a/docs/get-started/get-funded.mdx
+++ b/docs/get-started/get-funded.mdx
@@ -8,19 +8,19 @@ description: "The Base ecosystem offers multiple funding pathways designed speci
 Whether you're just starting to experiment or ready to become a full-time founder, Base provides structured funding opportunities that grow with your ambitions. Each pathway is designed for different stages of your builder journey, with clear progression paths between programs.
 
 <CardGroup cols={2}>
-<Card title="Weekly Rewards" icon="calendar" href="#weekly-rewards%3A-start-building-today">
+<Card title="Weekly Rewards" icon="calendar" href="#weekly-rewards-start-building-today">
   2 ETH in weekly rewards for prototypes and experiments through Talent Protocol.
 </Card>
 
-<Card title="Builder Grants" icon="bolt" href="#builder-grants%3A-live-on-base">
+<Card title="Builder Grants" icon="bolt" href="#builder-grants-live-on-base">
   Fast, retroactive grants ranging from 1-5 ETH. Perfect for shipped projects ready to scale.
 </Card>
 
-<Card title="OP Retro Funding" icon="trophy" href="#op-retro-funding%3A-long-term-impact">
+<Card title="OP Retro Funding" icon="trophy" href="#op-retro-funding-long-term-impact">
   Get rewarded for creating public goods that benefit the entire Base ecosystem.
 </Card>
 
-<Card title="Base Batches" icon="rocket" href="#base-batches%3A-the-founder-track">
+<Card title="Base Batches" icon="rocket" href="#base-batches-the-founder-track">
   Comprehensive founder program with mentorship, resources, and significant funding opportunities.
 </Card>
 </CardGroup>


### PR DESCRIPTION
**What changed? Why?**

Fixed broken anchor links in `docs/get-started/get-funded.mdx`. The four `Card` hrefs used URL-encoded colons (`%3A`) in the fragment identifiers (e.g. `#weekly-rewards%3A-start-building-today`). Mintlify strips colons when auto-generating heading anchor IDs, so these links never resolved. Replaced `%3A` with `-` to match the actual generated anchors.

**Notes to reviewers**

Only the four `href` attributes in the `CardGroup` at the top of the page were changed, no content or structure was modified.

**How has it been tested?**

Verified manually by comparing the heading text to Mintlify's anchor generation rules (lowercase, spaces → hyphens, special characters stripped). Can be confirmed locally with `mintlify dev` by clicking each card and checking it scrolls to the correct section. 
