### PR TITLE
docs: add old bridge page redirect

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1174,6 +1174,10 @@
   },
   "redirects": [
     {
+      "source": "/base-chain/quickstart/bridge-token",
+      "destination": "/base-chain/network-information/bridges"
+    },
+    {
       "source": "/base-chain/builder-codes/builder-codes-faq",
       "destination": "/base-chain/builder-codes/builder-codes"
     },


### PR DESCRIPTION
**What changed? Why?**
Adds a redirect from the now removed [bridge-token page](https://docs.base.org/base-chain/quickstart/bridge-token) to the [general bridges page](https://docs.base.org/base-chain/network-information/bridges) to prevent a 404.

**Notes to reviewers**

**How has it been tested?**
Locally