### PR TITLE
add FAQ entry for Flashblocks index exceeding 10

### DIFF
--- a/docs/base-chain/flashblocks/faq.mdx
+++ b/docs/base-chain/flashblocks/faq.mdx
@@ -28,7 +28,7 @@ For a comprehensive introduction to how Flashblocks work, see the [Flashblocks O
   <Accordion title="Why is my transaction having trouble getting included?">
     Transactions with large gas limits (> ~18.75M gas, which is 1/10 of the ~187.5M block limit) may have longer inclusion times. This is because the builder allocates gas cumulatively—each Flashblock `j` can use up to `j/10` of the total block gas limit. Large transactions can be included once enough cumulative capacity exists.
 
-    See [Gas & Transaction Sizing](/base-chain/flashblocks/app-integration#gas--transaction-sizing) for the full breakdown.
+    See [Gas & Transaction Sizing](/base-chain/flashblocks/app-integration#gas-&-transaction-sizing) for the full breakdown.
   </Accordion>
 
   <Accordion title="How do I ensure my transaction is in the first Flashblock?">


### PR DESCRIPTION
**What changed? Why?**
Add FAQ entry: Flashblock index can exceed 10 (expected behavior)
- Adds a new accordion to the WebSocket section of the Flashblocks FAQ explaining that indices above 10 are valid and not a bug. Covers the two root causes (sequencer delay and timing drift), and provides actionable implementation guidance
- Also fixes two stale anchor links (#gas-allocation → app-integration#gas--transaction-sizing, #rpc-api-reference → Flashblocks API Reference).

**Notes to reviewers**

**How has it been tested?**
Locally