### PR TITLE
Remove beta label from eth_subscribe

### DIFF
--- a/docs/base-chain/flashblocks/faq.mdx
+++ b/docs/base-chain/flashblocks/faq.mdx
@@ -139,7 +139,7 @@ For a comprehensive introduction to how Flashblocks work, see the [Flashblocks O
     | `eth_simulateV1` | Use `pending` tag |
     | `eth_estimateGas` | Use `pending` tag |
     | `eth_getLogs` | Use `pending` for `toBlock` |
-    | `eth_subscribe` | Stream Flashblock data in real-time (Beta) |
+    | `eth_subscribe` | Stream Flashblock data in real-time |
     | `base_transactionStatus` | Check if transaction is in mempool (Beta) |
 
     See the [Flashblocks API Reference](/base-chain/flashblocks/api-reference) for full method details and examples.


### PR DESCRIPTION
## Summary
- Remove the "(Beta)" designation from `eth_subscribe` in the Flashblocks FAQ table, as WebSocket subscriptions are no longer experimental.