### PR TITLE
update Base docs for V1 upgrade

### DIFF
--- a/docs/base-chain/flashblocks/api-reference.mdx
+++ b/docs/base-chain/flashblocks/api-reference.mdx
@@ -436,7 +436,7 @@ Block differences/updates for this Flashblock. See [Diff Object](#diff-object).
 </ParamField>
 
 <ParamField path="metadata" type="Metadata">
-Additional data including balance updates and transaction receipts. **Not stable — may change without notice.** See [Metadata Object](#metadata-object).
+Additional metadata for this Flashblock. **Not stable — may change without notice.** See [Metadata Object](#metadata-object).
 </ParamField>
 </Card>
 
@@ -474,38 +474,18 @@ Contains the block state changes for this specific Flashblock. Present in every 
 ### Metadata Object
 
 <Warning>
-**The `metadata` object is not stable.** 
+**The `metadata` object is not stable.**
 
 Fields may be added, modified, or removed without prior notice. Do not build production dependencies on it — use the [`diff`](#diff-object) object or query finalized block data via RPC instead.
 </Warning>
 
+<Note>
+The `new_account_balances` and `receipts` fields were removed in the [V1 upgrade](https://specs.base.org/upgrades/v1/exec-engine#remove-account-balances--receipts). Only `block_number` and `access_list` remain. If your integration previously read receipts from metadata, switch to [`eth_getTransactionReceipt`](/base-chain/reference/json-rpc-api#eth_gettransactionreceipt) against a Flashblocks-aware endpoint.
+</Note>
+
 <Card>
 <ParamField path="block_number" type="number">Block number as a decimal integer.</ParamField>
-<ParamField path="new_account_balances" type="object">Map of addresses to their updated ETH balances (hex). Only includes accounts whose balances changed in this Flashblock.</ParamField>
-<ParamField path="receipts" type="object">Map of transaction hashes to their [Receipt](#receipt-object) objects.</ParamField>
-</Card>
-
-### Receipt Object
-
-Transaction execution result. 
-
-Check which `type` is present to determine the transaction type: `Legacy`, `Access List`, `EIP-1559`, `Custom/Experimental (Deposit)`
-
-<Card>
-<ParamField path="type" type="string">Transaction type: `0x0` Legacy, `0x1` Access List, `0x2` EIP-1559, `0x7e` Deposit (L1→L2).</ParamField>
-<ParamField path="status" type="string">Transaction status: `0x1` for success, `0x0` for failure.</ParamField>
-<ParamField path="cumulativeGasUsed" type="string">Total gas used in the block up to and including this transaction (hex).</ParamField>
-<ParamField path="logs" type="Log[]">Array of event logs emitted by the transaction. See [Log Object](#log-object).</ParamField>
-<ParamField path="logsBloom" type="string">Bloom filter for the logs in this receipt.</ParamField>
-<ParamField path="transactionIndex" type="string">Index of the transaction within the block (hex).</ParamField>
-</Card>
-
-### Log Object
-
-<Card>
-<ParamField path="address" type="string">Contract address that emitted the event.</ParamField>
-<ParamField path="topics" type="string[]">Array of indexed event parameters. The first topic is typically the event signature hash.</ParamField>
-<ParamField path="data" type="string">ABI-encoded non-indexed event parameters.</ParamField>
+<ParamField path="access_list" type="object | null">Reserved for future use. Always `null` in V1.</ParamField>
 </Card>
 
 ### Complete Examples
@@ -533,19 +513,7 @@ Check which `type` is present to determine the transaction type: `Legacy`, `Acce
   },
   "metadata": {
     "block_number": 22585577,
-    "new_account_balances": {
-      "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "0x0"
-    },
-    "receipts": {
-      "0x07d7f06b06fea714c1d1d446efa2790c6970aa74ee006186a32b5b7dd8ca2d82": {
-        "type": "0x7e",
-        "status": "0x1",
-        "cumulativeGasUsed": "0xab3f",
-        "logs": [],
-        "logsBloom": "0x00000000...",
-        "transactionIndex": "0x0"
-      }
-    }
+    "access_list": null
   }
 }
 ```
@@ -565,19 +533,7 @@ Check which `type` is present to determine the transaction type: `Legacy`, `Acce
   },
   "metadata": {
     "block_number": 22585577,
-    "new_account_balances": {
-      "0x4200000000000000000000000000000000000015": "0x1234"
-    },
-    "receipts": {
-      "0x7c69632dc315f13a...": {
-        "type": "0x2",
-        "status": "0x1",
-        "cumulativeGasUsed": "0x1234f",
-        "logs": [],
-        "logsBloom": "0x00000000...",
-        "transactionIndex": "0x1"
-      }
-    }
+    "access_list": null
   }
 }
 ```

--- a/docs/base-chain/network-information/block-building.mdx
+++ b/docs/base-chain/network-information/block-building.mdx
@@ -56,7 +56,7 @@ For a comprehensive technical deep dive into Flashblocks architecture, see the [
 
 Base enforces a per-transaction gas maximum of **25,000,000 gas**. Transactions that specify a gas limit above this value are **rejected by the mempool before inclusion**. `eth_sendTransaction` or `eth_sendRawTransaction` will return a JSON-RPC error (for example: `exceeds maximum per-transaction gas limit`). This cap does **not** change the block gas limit or the block validity conditions.
 
-Fusaka's [EIP 7825](https://eips.ethereum.org/EIPS/eip-7825) **will** change the block validity conditions and enforce a lower per-transaction gas maximum of 16,777,216 gas (2^24). We expect this protocol change to be adopted in all OP Stack chains around January 2026.
+As of the [V1 upgrade](https://specs.base.org/upgrades/v1/exec-engine#transaction-gas-limit-cap) ([EIP-7825](https://eips.ethereum.org/EIPS/eip-7825)), the protocol-level cap is **16,777,216 gas (2^24)**, enforced at the block validity level in addition to the mempool.
 
 Bundler operators for smart contract wallets must configure their systems to limit the bundle size to fit within this cap.
 

--- a/docs/base-chain/network-information/diffs-ethereum-base.mdx
+++ b/docs/base-chain/network-information/diffs-ethereum-base.mdx
@@ -3,7 +3,7 @@ title: "Differences between Ethereum and Base"
 sidebarTitle: 'Differences: Ethereum & Base'
 ---
 
-Base is built to be as compatible as possible to Etherum, and there are very few differences when it comes to building on Base versus Ethereum.
+Base is built to be as compatible as possible to Ethereum, and there are very few differences when it comes to building on Base versus Ethereum.
 
 However, there are still some minor discrepancies between the behavior of Base and Ethereum that you should be aware of when building apps on top of Base.
 
@@ -16,3 +16,5 @@ These minor differences include:
 - [Address aliasing](https://docs.optimism.io/stack/differences#address-aliasing)
 - [Transaction costs](https://docs.optimism.io/stack/differences#transaction-fees)
 - [Chain Finality](https://docs.optimism.io/stack/differences#chain-finality)
+
+For a complete formal specification of Base's protocol, including upgrade history and EVM deviations, see the [Base Protocol Specifications](https://specs.base.org).

--- a/docs/base-chain/reference/json-rpc-api.mdx
+++ b/docs/base-chain/reference/json-rpc-api.mdx
@@ -1543,6 +1543,63 @@ This method takes no parameters.
 ```
 </CodeGroup>
 
+### eth_config
+
+Returns the chain's configuration parameters such as fork activation timestamps. Introduced in [EIP-7910](https://eips.ethereum.org/EIPS/eip-7910) as part of the [V1 upgrade](https://specs.base.org/upgrades/v1/exec-engine#eth_config-rpc-method).
+
+**Parameters**
+
+This method takes no parameters.
+
+**Returns**
+
+<ResponseField name="result" type="object">
+  An object containing chain configuration parameters. Fields vary by client version; fork activation timestamps are always present.
+
+  <Expandable title="Config object fields">
+    <ResponseField name="chainId" type="string">
+      Chain ID as a hexadecimal string.
+    </ResponseField>
+    <ResponseField name="forks" type="object">
+      Map of fork names to their activation timestamps (or block numbers for pre-merge forks). A value of `0` indicates the fork is active from genesis.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<CodeGroup>
+```json Request
+{
+  "jsonrpc": "2.0",
+  "method": "eth_config",
+  "params": [],
+  "id": 1
+}
+```
+
+```json Response
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "chainId": "0x2105",
+    "forks": {
+      "homestead": 0,
+      "byzantium": 0,
+      "constantinople": 0,
+      "istanbul": 0,
+      "london": 0,
+      "canyon": 1704992401,
+      "delta": 1708560000,
+      "ecotone": 1710374401,
+      "fjord": 1720627201,
+      "granite": 1726070401,
+      "holocene": 1736445601
+    }
+  }
+}
+```
+</CodeGroup>
+
 ### web3_clientVersion
 
 Returns a string identifying the node client software and version.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,37 +11,7 @@
   "contextual": {
     "options": [
       "copy",
-      "view",
-      
-      "assistant",
-      {
-        "title": "Chat with Claude about this page",
-        "description": "Ask Claude about this page",
-        "icon": "https://img.icons8.com/ios-glyphs/30/claude-ai.png",
-        "href": {
-          "base": "https://claude.ai/new",
-          "query": [
-            {
-              "key": "q",
-              "value": "Read from $path so I can ask questions about it."
-            }
-          ]
-        }
-      },
-      {
-        "title": "Chat with ChatGPT about this page",
-        "description": "Ask ChatGPT about this page",
-        "icon": "OpenAI",
-        "href": {
-          "base": "https://chatgpt.com/",
-          "query": [
-            {
-              "key": "q",
-              "value": "Read from $path so I can ask questions about it."
-            }
-          ]
-        }
-      }
+      "view"
     ]
   },
   "api": {
@@ -203,6 +173,11 @@
         ],
         "global": {
           "anchors": [
+            {
+              "anchor": "Protocol Specs",
+              "href": "https://specs.base.org",
+              "icon": "file-lines"
+            },
             {
               "anchor": "GitHub",
               "href": "https://github.com/base",


### PR DESCRIPTION
**What changed? Why?**
Documents the Base V1 upgrade:
- Flashblocks metadata: Removed `new_account_balances` and `receipts` from the `FlashblocksMetadata` schema; added migration note to use `eth_getTransactionReceipt` against a Flashblocks endpoint. Updated JSON examples.
- `eth_config` method: Added documentation for the new `eth_config` JSON-RPC method ([EIP-7910](https://github.com/base/base/blob/main/docs/specs/pages/upgrades/v1/exec-engine.md#eth_config-rpc-method)).
- Per-tx gas cap: Updated block building docs to reflect the V1 / [EIP-7825](https://github.com/base/base/blob/main/docs/specs/pages/upgrades/v1/exec-engine.md#transaction-gas-limit-cap) protocol-level cap of 16,777,216 gas.
- specs.base.org: Added as a global navigation anchor and linked from relevant pages.

Related: https://github.com/base/base/pull/1346

**Notes to reviewers**

**How has it been tested?**
Locally