### PR TITLE
docs: fix broken links across multiple pages

### DIFF
--- a/docs/base-account/framework-integrations/rainbowkit.mdx
+++ b/docs/base-account/framework-integrations/rainbowkit.mdx
@@ -400,7 +400,7 @@ Now that you have RainbowKit configured with Base Account, you can:
     Learn more about RainbowKit and its features
   </Card>
   
-  <Card title="Explore Wagmi Docs" icon="hook" href="https://wagmi.sh/react/hooks">
+  <Card title="Explore Wagmi Docs" icon="hook" href="https://wagmi.sh/react/api/hooks">
     Learn more about wagmi and its features
   </Card>
   <Card title="Join the Base Community" icon="code" href="https://discord.com/invite/buildonbase">

--- a/docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx
+++ b/docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx
@@ -7,7 +7,7 @@ Below are some popular wallet libraries and what we know of their plans for day 
 
 | Name                                                                               | Support |
 | ---------------------------------------------------------------------------------- | ------- |
-| [Dynamic](https://docs.dynamic.xyz/wallets/advanced-wallets/coinbase-smart-wallet) | ✅      |
+| [Dynamic](https://docs.dynamic.xyz) | ✅      |
 | [Privy](https://docs.privy.io/guide/react/recipes/misc/coinbase-smart-wallets)     | ✅      |
 | [ThirdWeb](http://portal.thirdweb.com/connect)                                     | ✅      |
 | [ConnectKit](https://docs.family.co/connectkit)                                    | ✅      |

--- a/docs/base-account/quickstart/mobile-integration.mdx
+++ b/docs/base-account/quickstart/mobile-integration.mdx
@@ -49,7 +49,7 @@ yarn add @mobile-wallet-protocol/client@latest
 
 ### Install peer dependencies
 
-The Mobile Wallet Protocol Client library requires the [Expo WebBrowser](https://docs.expo.dev/versions/latest/sdk/webbrowser/) and [Async Storage](https://react-native-async-storage.github.io/async-storage/docs/install) packages to be installed.
+The Mobile Wallet Protocol Client library requires the [Expo WebBrowser](https://docs.expo.dev/versions/latest/sdk/webbrowser/) and [Async Storage](https://github.com/react-native-async-storage/async-storage#getting-started) packages to be installed.
 Follow the instructions on the respective pages for any additional setup.
 
 <CodeGroup>

--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -77,7 +77,7 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 
 **Unneeded contract addresses**
 
-Certain contracts are mandatory according to the [OP Stack SDK](https://stack.optimism.io/docs/build/sdk/#unneeded-contract-addresses), despite not being utilized. For such contracts, you can simply assign the zero address:
+Certain contracts are mandatory according to the [OP Stack SDK](https://docs.optimism.io/app-developers/tools), despite not being utilized. For such contracts, you can simply assign the zero address:
 
 - `StateCommitmentChain`
 - `CanonicalTransactionChain`

--- a/docs/get-started/data-indexers.mdx
+++ b/docs/get-started/data-indexers.mdx
@@ -9,12 +9,12 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 
 [Allium](https://www.allium.so/) is an Enterprise Data Platform that serves accurate, fast, and simple blockchain data. Currently serving 15 blockchains and over 100+ schemas, Allium offers near real-time Base data for infrastructure needs and enriched Base data (NFT, DEX, Decoded, Wallet360) for research and analytics.
 
-Allium supports data delivery to multiple [destinations](https://docs.allium.so/integrations/overview), including Snowflake, Bigquery, Databricks, and AWS S3.
+Allium supports data delivery to multiple [destinations](https://docs.allium.so/), including Snowflake, Bigquery, Databricks, and AWS S3.
 
 Documentation:
 
-- [Real-time](https://docs.allium.so/real-time-data/base)
-- [Batch-enriched](https://docs.allium.so/data-tables/base)
+- [Real-time](https://docs.allium.so/)
+- [Batch-enriched](https://docs.allium.so/)
 
 To get started, contact Allium [here](https://www.allium.so/contact).
 
@@ -33,19 +33,19 @@ References:
 
 ## Covalent
 
-[Covalent](https://www.covalenthq.com/?utm_source=base&utm_medium=partner-docs) is a hosted blockchain data solution providing access to historical and current on-chain data for [100+ supported blockchains](https://www.covalenthq.com/docs/networks/?utm_source=base&utm_medium=partner-docs), including [Base](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs).
+[Covalent](https://www.covalenthq.com/?utm_source=base&utm_medium=partner-docs) is a hosted blockchain data solution providing access to historical and current on-chain data for [100+ supported blockchains](https://www.covalenthq.com/docs/introduction), including [Base](https://www.covalenthq.com/docs/introduction).
 
 Covalent maintains a full archival copy of every supported blockchain, meaning every balance, transaction, log event, and NFT asset data is available from the genesis block. This data is available via:
 
-1. [Unified API](https://www.covalenthq.com/docs/unified-api/?utm_source=base&utm_medium=partner-docs) - Incorporate blockchain data into your app with a familiar REST API
-2. [Increment](https://www.covalenthq.com/docs/increment/?utm_source=base&utm_medium=partner-docs) - Create and embed custom charts with no-code analytics
+1. [Unified API](https://www.covalenthq.com/docs/introduction) - Incorporate blockchain data into your app with a familiar REST API
+2. [Increment](https://www.covalenthq.com/docs/introduction) - Create and embed custom charts with no-code analytics
 
-To get started, [sign up](https://www.covalenthq.com/platform/?utm_source=base&utm_medium=partner-docs) and visit the [developer documentation](https://www.covalenthq.com/docs/?utm_source=base&utm_medium=partner-docs).
+To get started, [sign up](https://www.covalenthq.com/platform/?utm_source=base&utm_medium=partner-docs) and visit the [developer documentation](https://www.covalenthq.com/docs/introduction).
 
 <HeaderNoToc title="Supported Networks"/>
 
-- [Base Mainnet](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs)
-- [Base Sepolia](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs) (Testnet)
+- [Base Mainnet](https://www.covalenthq.com/docs/introduction)
+- [Base Sepolia](https://www.covalenthq.com/docs/introduction) (Testnet)
 
 
 
@@ -113,21 +113,6 @@ To get started with Moralis, you can [sign up for an account](https://moralis.io
 
 - Base Mainnet
 - Base Sepolia (Testnet)
-
-
-
-## Nexandria
-
-[Nexandria](https://www.nexandria.com/?utm_source=base-docs&utm_medium=partner-docs) API offers access to complete historical on-chain data at blazing speeds, arbitrary granularity (as low as block-level) and at viable unit economics (think web2 level costs). Our technology lets you generate subgraphs on the fly, unlocking unique endpoints like a statement of all the balance transfers for all the tokens, or a list of all the neighbors of an address with all the historical interaction details or a portfolio balance graph covering all the tokens across arbitrary time/block ranges.
-
-References:
-
-- [API Documentation](https://docs.nexandria.com/)
-- [Sign-up](https://www.nexandria.com/api)
-
-<HeaderNoToc title="Supported Networks"/>
-
-- Base Mainnet
 
 
 


### PR DESCRIPTION
## Description

Ran a scan across all 266 doc pages and found ~20 broken external links. This PR fixes the ones with clear replacements:

**Fixed links:**
- `wagmi.sh/react/hooks` → `wagmi.sh/react/api/hooks` (page was moved)
- `stack.optimism.io/docs/build/sdk/` → `docs.optimism.io/app-developers/tools` (old domain deprecated)
- `docs.dynamic.xyz` broken deep link → root docs page
- `react-native-async-storage` docs site → GitHub repo readme (docs site is down)
- Multiple `covalenthq.com/docs/*` subpages → `docs/introduction` (site restructured)
- `docs.allium.so` subpages → root docs page (pages restructured)

**Removed:**
- Nexandria section from data-indexers.mdx — the entire site and API are dead (all URLs return 404)

## Files changed

- `docs/base-account/framework-integrations/rainbowkit.mdx`
- `docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx`
- `docs/base-account/quickstart/mobile-integration.mdx`
- `docs/base-chain/network-information/base-contracts.mdx`
- `docs/get-started/data-indexers.mdx`
