### PR TITLE
Fix minor typos and punctuation in deploy-smart-contracts guide

### DIFF
--- a/docs/get-started/deploy-smart-contracts.mdx
+++ b/docs/get-started/deploy-smart-contracts.mdx
@@ -43,7 +43,7 @@ This installs Foundry and updates it to the latest version.
 forge init
 ```
 
-Your Foundry project is now ready. You'll find an example contract in the `src` directory, which you can replace with your own contracts. For the purposes of this guide, we'll use the Counter contract provided in `/src/Counter.sol`
+Your Foundry project is now ready. You'll find an example contract in the `src` directory, which you can replace with your own contracts. For the purposes of this guide, we'll use the Counter contract provided in `/src/Counter.sol`.
 
 <Tip>
 Foundry provides a suite of tools for Ethereum application development, including Forge (for testing), Cast (for interacting with the chain), and Anvil (for setting up a local node). You can learn more about Foundry [here](https://book.getfoundry.sh/).
@@ -88,7 +88,7 @@ Base Sepolia is the test network for Base, which we will use for the rest of thi
 cast wallet import deployer --interactive
 ```
 
-2. When prompted enter your private key and a password.
+2. When prompted, enter your private key and a password.
 
 Your private key is stored in `~/.foundry/keystores` which is not tracked by git.
 
@@ -107,7 +107,7 @@ Now that your environment is set up, let's deploy your contracts to Base Sepolia
 forge create ./src/Counter.sol:Counter --rpc-url $BASE_SEPOLIA_RPC_URL --account deployer
 ```
 
-Note the format of the contract being deployed is `<contract-path>:<contract-name>`.
+Note that the format of the contract being deployed is `<contract-path>:<contract-name>`.
 
 2. After successful deployment, the transaction hash will be printed to the console output
 


### PR DESCRIPTION
- Add missing comma after "When prompted"
- Add missing period at end of sentence referencing Counter.sol
- Add missing "that" for grammatical correctness

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
