### PR TITLE
Fix outdated reference to archived learn-docs repository

### DIFF
--- a/docs/get-started/learning-resources.mdx
+++ b/docs/get-started/learning-resources.mdx
@@ -3,11 +3,13 @@ title: "Learning Resources"
 description: "Find educational content for learning Solidity, Ethereum, and blockchain development"
 ---
 
-## Archived Content
+## Previous Learn Content
 
-All previous Learn content, including Solidity tutorials, Ethereum basics, and blockchain development guides, is now available at:
+All previous Learn content, including Solidity tutorials, Ethereum basics, and blockchain development guides, was previously hosted at
 
-**[github.com/base/learn-docs](https://github.com/base/learn-docs)**
+[github.com/base/learn-docs](https://github.com/base/learn-docs).
+
+Note that this repository is now archived and no longer maintained.
 
 ## Coming Soon
 


### PR DESCRIPTION
## Summary
The `base/learn-docs` repository is now deprecated and archived, 
but the learning-resources page still referenced it as an active resource.

## Changes
- Updated section heading from "Archived Content" to "Previous Learn Content"
- Updated description to clarify the repository is archived and no longer maintained

## Type of Change
- [x] Documentation fix