### PR TITLE
fix: remove broken submission form link in featured guidelines

### DIFF
--- a/docs/mini-apps/featured-guidelines/overview.mdx
+++ b/docs/mini-apps/featured-guidelines/overview.mdx
@@ -8,7 +8,7 @@ Your app must meet all product, design, and technical guidelines outlined below.
 
 
 <Note>
-  To submit your app for featured placement, first verify your mini app in the [Base Build dashboard](https://base.dev/), then fill out the [submission form](https://docs.google.com/forms/d/e/1FAIpQLSeZiB3fmMS7oxBKrWsoaew2LFxGpktnAtPAmJaNZv5TOCXIZg/viewform).
+  To submit your app for featured placement, first verify your mini app in the [Base Build dashboard](https://base.dev/) and apply for featured placement through the dashboard.
 </Note>
 
 


### PR DESCRIPTION
## Problem
The submission form link on the Mini Apps featured guidelines page points to a Google Drive document that returns an error: 'Sorry, this document is not published.'

## Fix
Removed the broken Google Drive link and updated the note to direct users to the Base Build dashboard directly.

Closes #1182