### PR TITLE
fix: replace broken bridge-token link with Optimism standard bridge docs

### DIFF
--- a/docs/apps/featured-guidelines/overview.mdx
+++ b/docs/apps/featured-guidelines/overview.mdx
@@ -8,7 +8,7 @@ Your app must meet all product, design, and technical guidelines outlined below.
 
 
 <Note>
-  To submit your app for featured placement, first verify your mini app in the [Base Build dashboard](https://base.dev/), then fill out the [submission form](https://docs.google.com/forms/d/e/1FAIpQLSeZiB3fmMS7oxBKrWsoaew2LFxGpktnAtPAmJaNZv5TOCXIZg/viewform).
+  To submit your app for featured placement, first verify your mini app in the [Base Build dashboard](https://base.dev/) and apply for featured placement through the dashboard.
 </Note>
 
 

--- a/docs/base-chain/network-information/bridges.mdx
+++ b/docs/base-chain/network-information/bridges.mdx
@@ -49,7 +49,7 @@ code to withdraw the assets.
 
 ### For Token Issuers
 
-If you have an ERC-20 token deployed on Ethereum and want to enable bridging to Base, see our guide on [Bridging an L1 Token to Base](/base-chain/quickstart/bridge-token). This covers deploying your token on Base using the standard bridge contracts and getting it listed on the Superchain token list.
+If you have an ERC-20 token deployed on Ethereum and want to enable bridging to Base, see our guide on [Bridging an L1 Token to Base](https://docs.optimism.io/builders/app-developers/bridging/standard-bridge). This covers deploying your token on Base using the standard bridge contracts and getting it listed on the Superchain token list.
 
 ---
 


### PR DESCRIPTION
## Problem
The link [Bridging an L1 Token to Base](/base-chain/quickstart/bridge-token) in `bridges.mdx` points to a page that does not exist, causing a 404 error reported in #1159.

A redirect exists in `docs.json` pointing this path to `/base-chain/network-information/bridges` (the same page), which creates a self-referencing loop.

## Fix
Replaced the broken internal link with the official Optimism standard bridge documentation at `https://docs.optimism.io/builders/app-developers/bridging/standard-bridge`, which covers the exact topic (deploying ERC-20 tokens on Base using standard bridge contracts).

Closes #1159