### PR TITLE
docs: add beginner guidance and prerequisites to Get Started page

### DIFF
--- a/docs/get-started/base.mdx
+++ b/docs/get-started/base.mdx
@@ -4,6 +4,30 @@ description: "The #1 Ethereum Layer 2, incubated by Coinbase"
 mode: "wide"
 ---
 
+## New to Base? Start here
+
+Base is an Ethereum Layer 2 network built for speed, low fees, and developer simplicity. Whether you're building payments, AI agents, or onchain apps, this page helps you find the right starting point.
+
+### Prerequisites
+
+Before you start building, make sure you have:
+
+- A basic understanding of how Ethereum and smart contracts work
+- [Node.js](https://nodejs.org/) (v18 or later) installed
+- A wallet such as [Coinbase Wallet](https://www.coinbase.com/wallet) or [MetaMask](https://metamask.io/)
+- Some testnet ETH on Base Sepolia — get some free from the [Optimism Superchain Faucet](https://app.optimism.io/faucet)
+
+### Recommended workflow
+
+If you're new to Base, follow this path:
+
+1. **Understand the network** — Read [Why Base](/base-chain/quickstart/why-base) to learn what makes Base different
+2. **Deploy your first contract** — Follow the [Deploy Smart Contracts](/get-started/deploy-smart-contracts) guide
+3. **Connect a wallet** — Integrate [Base Account](/base-account/quickstart/web) for authentication and payments
+4. **Go live** — Use the [Build an App](/get-started/build-app) guide to ship your project
+
+---
+
 <div className="use-cases">
   <div className="use-cases-links">
     ### Payments
@@ -59,3 +83,4 @@ mode: "wide"
     </div>
   </div>
 </div>
+


### PR DESCRIPTION
## Summary

Addresses #966

The current Get Started page lists navigation links but doesn't guide new developers on what to do first, what tools they need, or why they should choose each section.

## Changes

- Added a **'New to Base? Start here'** intro section explaining what Base is in plain terms
- Added a **Prerequisites** section listing required tools (Node.js, wallet, testnet ETH)
- Added a **Recommended workflow** with a clear 4-step path for new developers

## Before / After

**Before:** Page jumped straight into use-case links with no context for beginners.

**After:** New developers have a clear starting point, know what to install, and understand the recommended path before diving into specific sections.

## Testing

No code changes — documentation only. Verified markdown renders correctly.