### PR TITLE
docs: clarify RPC endpoint usage to prevent misconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,6 @@ The core team will review opened PRs. The SLA is 2 weeks, generally on a first-c
 ## Storybook for UI components
 
 See `storybook/README.md` for details on local Storybook and component docs.
+## Additional Note
+
+When building on Base, always ensure that you are using the correct RPC endpoint for the intended network (mainnet or testnet). Misconfiguration can lead to failed transactions or unexpected behavior.


### PR DESCRIPTION
Adds a small clarification note about using the correct RPC endpoint when building on Base to help prevent common configuration issues.