### PR TITLE
docs: add RPC endpoint clarification to prevent misconfiguration

### DIFF
--- a/docs/get-started/build-app.mdx
+++ b/docs/get-started/build-app.mdx
@@ -544,3 +544,4 @@ Base is a fast, low-cost Ethereum L2 built to bring the next billion users oncha
 - **Batch read calls** — reduce RPC round trips by batching reads via viem's `multicall`.
 - **Optimistic updates** — update the UI before confirmation using TanStack Query's `onMutate` callback.
 - **Wagmi setup reference** — review the full [Wagmi setup guide](/base-account/framework-integrations/wagmi/setup) for additional configuration options.
+> ⚠️ **Important:** Ensure you are using the correct RPC endpoint for Base (mainnet vs testnet). Incorrect configuration may result in failed transactions or unexpected behavior during development.


### PR DESCRIPTION
Adds a clarification note in the build app guide to help developers avoid common RPC misconfiguration issues when building on Base.

Improves developer onboarding and reduces setup errors.
