### PR TITLE
docs: add network configuration tip to concepts guide

### DIFF
--- a/docs/get-started/concepts.mdx
+++ b/docs/get-started/concepts.mdx
@@ -11,3 +11,4 @@ Key concept overview:
 - Wallets
 - Nodes
 ...
+> 💡 Tip: Double-check your network configuration when working with Base to avoid common issues related to RPC endpoints and chain IDs.


### PR DESCRIPTION
Adds a small tip in the concepts guide to help developers avoid common issues related to RPC endpoints and chain configuration when working with Base.