### PR TITLE
docs: improve RPC guidance visibility in concepts guide

### DIFF
--- a/docs/get-started/concepts.mdx
+++ b/docs/get-started/concepts.mdx
@@ -10,4 +10,4 @@ Key concept overview:
 - Smart Contracts
 - Wallets
 - Nodes
-...
+> ⚠️ Important: Always ensure your RPC endpoint and network configuration are correct (Base mainnet vs testnet). Misconfiguration can lead to failed transactions or unexpected behavior.


### PR DESCRIPTION
Improves RPC usage guidance by surfacing an important configuration note earlier in the concepts guide.

This helps developers avoid common misconfiguration issues when working with Base.

Closes #1286