### PR TITLE
docs: clarify Mini App import and Farcaster manifest usage

### DIFF
--- a/docs/mini-apps/introduction/overview.mdx
+++ b/docs/mini-apps/introduction/overview.mdx
@@ -2,7 +2,12 @@
 hidden: true
 title: "Why Mini Apps"
 description: "Discover how Mini Apps eliminate  friction and leverage social distribution to create instantly engaging, viral experiences that traditional apps can't match."
----
+---> 💡 **When do you need Mini App import and Farcaster manifest?**  
+>
+> Use Mini App import when integrating your app into the Base ecosystem.  
+> A Farcaster manifest is only required if your Mini App needs to be discoverable or shared within Farcaster clients.  
+>
+> If you're building a standalone app without social distribution, you may not need a Farcaster manifest.
 
 The next evolution of digital experiences extends beyond app stores into social feeds and direct messages. Mini Apps are lightweight, social-native apps that launch instantly when you tap them: no downloads, no friction, just immediate engagement. While the Base App provides the discoverability through social distribution and featured listings, Mini Apps deliver the frictionless experience that makes instant trial and viral sharing possible.
 


### PR DESCRIPTION
Adds clarification on when Mini App import and Farcaster manifest are required.

Helps developers understand when each is needed and reduces confusion.

Closes #1286
