### PR TITLE
fix(run-a-base-node): update stale base-org/node links to base/node

### DIFF
--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -3,7 +3,7 @@ title: Run a Node
 description: A tutorial that teaches how to set up and run a Base Node.
 ---
 
-This tutorial will walk you through setting up your own [Base Node](https://github.com/base-org/node).
+This tutorial will walk you through setting up your own [Base Node](https://github.com/base/node).
 
 ## Objectives
 
@@ -66,7 +66,7 @@ You'll need your own L1 RPC URL. This can be one that you run yourself, or via a
 
 ## Running a Node
 
-1. Clone the [repo](https://github.com/base-org/node).
+1. Clone the [repo](https://github.com/base/node).
 2. Ensure you have an Ethereum L1 full node RPC available (not Base), and set `OP_NODE_L1_ETH_RPC` & `OP_NODE_L1_BEACON` (in the `.env.*` file if using `docker-compose`). If running your own L1 node, it needs to be synced before Base will be able to fully sync.
 3. Uncomment the line relevant to your network (`.env.sepolia`, or `.env.mainnet`) under the 2 `env_file` keys in `docker-compose.yml`.
 4. Run `docker compose up`. Confirm you get a response from:

--- a/docs/base-chain/node-operators/troubleshooting.mdx
+++ b/docs/base-chain/node-operators/troubleshooting.mdx
@@ -124,4 +124,4 @@ Refer to the [Snapshots](/base-chain/node-operators/snapshots) guide for the cor
 If you’ve followed this guide and are still encountering issues, seek help from the community:
 
 - **Discord**: Join the [Base Discord](https://discord.gg/buildonbase) and post in the `🛠｜node-operators` channel, providing details about your setup, the issue, and relevant logs.  
-- **GitHub**: Check the [Base Node repository issues](https://github.com/base-org/node/issues) or open a new one if you suspect a bug.  
+- **GitHub**: Check the [Base Node repository issues](https://github.com/base/node/issues) or open a new one if you suspect a bug.  

--- a/docs/get-started/launch-token.mdx
+++ b/docs/get-started/launch-token.mdx
@@ -428,7 +428,7 @@ Remember to always prioritize security, transparency, and community value when d
   <Card title="Base Twitter" icon="twitter" href="https://twitter.com/base">
     Follow Base updates
   </Card>
-  <Card title="Base GitHub" icon="github" href="https://github.com/base-org">
+  <Card title="Base GitHub" icon="github" href="https://github.com/base">
     Contribute to Base development
   </Card>
 </CardGroup>


### PR DESCRIPTION
Fixes #1294

## Summary

Updated stale `base-org` repository links across three files:

- `run-a-base-node.mdx` — 2 links updated to `base/node`
- `troubleshooting.mdx` — 1 link updated to `base/node`
- `launch-token.mdx` — 1 link updated to archived `base-org` org → `base`