### PR TITLE
fix: replace deprecated docker-compose with docker compose v2 in node setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,6 @@ The core team will review opened PRs. The SLA is 2 weeks, generally on a first-c
 ## Storybook for UI components
 
 See `storybook/README.md` for details on local Storybook and component docs.
+## Additional Note
+
+When building on Base, always ensure that you are using the correct RPC endpoint for the intended network (mainnet or testnet). Misconfiguration can lead to failed transactions or unexpected behavior.

--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -3,7 +3,7 @@ title: Run a Node
 description: A tutorial that teaches how to set up and run a Base Node.
 ---
 
-This tutorial will walk you through setting up your own [Base Node](https://github.com/base-org/node).
+This tutorial will walk you through setting up your own [Base Node](https://github.com/base/node).
 
 ## Objectives
 
@@ -66,9 +66,9 @@ You'll need your own L1 RPC URL. This can be one that you run yourself, or via a
 
 ## Running a Node
 
-1. Clone the [repo](https://github.com/base-org/node).
-2. Ensure you have an Ethereum L1 full node RPC available (not Base), and set `OP_NODE_L1_ETH_RPC` & `OP_NODE_L1_BEACON` (in the `.env.*` file if using `docker-compose`). If running your own L1 node, it needs to be synced before Base will be able to fully sync.
-3. Uncomment the line relevant to your network (`.env.sepolia`, or `.env.mainnet`) under the 2 `env_file` keys in `docker-compose.yml`.
+1. Clone the [repo](https://github.com/base/node).
+2. Ensure you have an Ethereum L1 full node RPC available (not Base), and set `OP_NODE_L1_ETH_RPC` & `OP_NODE_L1_BEACON` (in the `.env.*` file if using `docker compose`). If running your own L1 node, it needs to be synced before Base will be able to fully sync.
+3. Uncomment the line relevant to your network (`.env.sepolia`, or `.env.mainnet`) under the 2 `env_file` keys in `docker-compose.yml` (Docker Compose v2).
 4. Run `docker compose up`. Confirm you get a response from:
 
 ```bash Terminal
@@ -112,7 +112,7 @@ Once your node is synced, you can enable Flashblocks to serve 200ms preconfirmat
 To enable Flashblocks, start your node with the following environment variables:
 
 ```sh
-NODE_TYPE=base CLIENT=reth RETH_FB_WEBSOCKET_URL="wss://mainnet.flashblocks.base.org/ws" docker-compose up
+NODE_TYPE=base CLIENT=reth RETH_FB_WEBSOCKET_URL="wss://mainnet.flashblocks.base.org/ws" docker compose up
 ```
 
 | Variable | Description | Values |


### PR DESCRIPTION
﻿## Summary

Updates `run-a-base-node.mdx` to replace deprecated `docker-compose` (Compose v1) syntax with `docker compose` (Compose v2), and fixes a stale repository link.

## Changes

### docker-compose → docker compose (v2)

Docker Compose v1 (`docker-compose`) was deprecated in July 2023 and removed in Docker Desktop 4.33. The [base/node](https://github.com/base/node) repository README already uses `docker compose` (v2) exclusively — the docs should match to avoid confusion for node operators.

Affected lines in `run-a-base-node.mdx`:
- Step 2: `using docker-compose` → `using docker compose`
- Step 3: `docker-compose.yml` reference updated
- Flashblocks section: `docker-compose up` → `docker compose up`

### Stale repo link

- `github.com/base-org/node` → `github.com/base/node`

## References

- Docker Compose v1 deprecation: https://docs.docker.com/compose/releases/migrate/
- base/node README (uses docker compose v2): https://github.com/base/node
