### PR TITLE
fix(docs): update broken Preview tool link from /preview to /apps/preview

### DIFF
--- a/docs/apps/core-concepts/manifest.mdx
+++ b/docs/apps/core-concepts/manifest.mdx
@@ -50,7 +50,7 @@ Set `"noindex": true` for development or staging environments to prevent search 
 1. Create the manifest file in your project at `/public/.well-known/farcaster.json`. It needs to be accessible at `https://your-domain.com/.well-known/farcaster.json`
 2. Update the [required](#accountassociation) and [optional](#display-information) fields in the `miniapp` object
 3. Ensure all changes are live so that the Manifest file is available at your app's url
-4. Navigate to the Base Build [Account association tool](https://www.base.dev/preview?tab=account)
+4. Navigate to the Base Build [Account association tool](https://base.dev/apps/preview?tab=account)
 5. Paste your domain in the App URL field (ex: sample-url.vercel.app) and click "Submit"
 6. Click on the "Verify" button that appears and sign the manifest with your wallet to generate the `accountAssociation` fields
 7. Copy the generated `accountAssociation` fields (header, payload, and signature) and paste them into your manifest file, replacing the empty values in the `accountAssociation` object

--- a/docs/apps/featured-guidelines/overview.mdx
+++ b/docs/apps/featured-guidelines/overview.mdx
@@ -8,7 +8,7 @@ Your app must meet all product, design, and technical guidelines outlined below.
 
 
 <Note>
-  To submit your app for featured placement, first verify your mini app in the [Base Build dashboard](https://base.dev/), then fill out the [submission form](https://docs.google.com/forms/d/e/1FAIpQLSeZiB3fmMS7oxBKrWsoaew2LFxGpktnAtPAmJaNZv5TOCXIZg/viewform).
+  To submit your app for featured placement, first verify your mini app in the [Base Build dashboard](https://base.dev/) and apply for featured placement through the dashboard.
 </Note>
 
 

--- a/docs/apps/featured-guidelines/technical-guidelines.mdx
+++ b/docs/apps/featured-guidelines/technical-guidelines.mdx
@@ -18,7 +18,7 @@ Metadata includes your manifest and embed metadata. Complete, valid metadata is 
 - Implement [embed metadata](/mini-apps/core-concepts/embeds-and-previews#implementation)
 
 <Note>
-  Validate your manifest using our preview tools at <a href="https://base.dev/preview">base.dev/preview</a>.
+  Validate your manifest using our preview tools at <a href="https://base.dev/apps/preview">base.dev/preview</a>.
 </Note>
 
 ## In-app Authentication

--- a/docs/apps/quickstart/create-new-app.mdx
+++ b/docs/apps/quickstart/create-new-app.mdx
@@ -80,7 +80,7 @@ Now that you have a public domain for your application, you are ready to associa
     1. Ensure all changes are live by pushing changes to the `main` branch.
     <Tip>Ensure that Vercel's **Deployment Protection** is off by going to the Vercel dashboard for your project and navigating to Settings -> Deployment Protection and toggling "Vercel Authentication" to off and click save. </Tip>
 
-    2. Navigate to the Base Build [Account association tool](https://www.base.dev/preview?tab=account). 
+    2. Navigate to the Base Build [Account association tool](https://base.dev/apps/preview?tab=account). 
     3. Paste your domain in the `App URL` field (ex: sample-url.vercel.app) and click "Submit"
 
     <img 
@@ -116,7 +116,7 @@ Push all changes to the `main` branch. Vercel will automatically deploy the chan
 </Step>
 
 <Step title="Preview Your App">
-  Go to [base.dev/preview](https://base.dev/preview) to validate your app.
+  Go to [base.dev/preview](https://base.dev/apps/preview) to validate your app.
   1. Add your app URL to view the embeds and click the launch button to verify the app launches as expected. 
   2. Use the "Account association" tab to verify the association credentials were created correctly.
   3. Use the "Metadata" tab to see the metadata added from the manifest and identify any missing fields.

--- a/docs/apps/quickstart/migrate-existing-apps.mdx
+++ b/docs/apps/quickstart/migrate-existing-apps.mdx
@@ -140,7 +140,7 @@ The `accountAssociation` fields in the manifest are used to verify ownership of 
 
 
     1. Ensure all changes are live so that the Manifest file is available at your app's url.
-    2. Navigate to the Base Build [Account association tool](https://www.base.dev/preview?tab=account). 
+    2. Navigate to the Base Build [Account association tool](https://base.dev/apps/preview?tab=account). 
     3. Paste your domain in the `App URL` field (ex: sample-url.vercel.app) and click "Submit"
     4. Click on the "Verify" button that appears and follow the instructions to generate the `accountAssociation` fields.
     5. Copy the `accountAssociation` fields and paste them into the manifest file you added in the previous step.
@@ -213,7 +213,7 @@ The `accountAssociation` fields in the manifest are used to verify ownership of 
 </Step>
 
 <Step title="Preview Your App">
-  Use the Base Build [Preview tool](https://www.base.dev/preview) to validate your app.
+  Use the Base Build [Preview tool](https://base.dev/apps/preview) to validate your app.
   1. Add your app URL to view the embeds and click the launch button to verify the app launches as expected. 
   2. Use the "Account association" tab to verify the association credentials were created correctly.
   3. Use the "Metadata" to see the metadata added from the manifest and identify any missing fields.

--- a/docs/apps/technical-guides/neynar-notifications.mdx
+++ b/docs/apps/technical-guides/neynar-notifications.mdx
@@ -68,7 +68,7 @@ Caching: The Base App might have your mini app manifest cached. To make sure all
 </Warning>
 
 <Tip>
-Test your Mini App in [Base Build](https://base.dev/preview) using the Preview tool. Once signed in, paste your app's URL in the `App URL` field and click the `Submit` button.
+Test your Mini App in [Base Build](https://base.dev/apps/preview) using the Preview tool. Once signed in, paste your app's URL in the `App URL` field and click the `Submit` button.
 </Tip>
 
 </Step>

--- a/docs/apps/troubleshooting/common-issues.mdx
+++ b/docs/apps/troubleshooting/common-issues.mdx
@@ -29,7 +29,7 @@ your-domain.com/
 Use Base Build's built-in Preview Tool for foundational debugging.
 
 <Card title="Preview Tool" img="/images/base-build/preview-tool-overview.png">
-Start debugging your app using the [Preview tool](https://base.dev/preview)
+Start debugging your app using the [Preview tool](https://base.dev/apps/preview)
 </Card>
 
 The **Preview tool** will help you:  
@@ -59,7 +59,7 @@ The Preview tool has three main components:
 
 ## Quick Diagnostic Workflow
 
-<Tip>The best way to validate your app works is by using Base Build's built-in [Preview tool](https://base.dev/preview)</Tip>
+<Tip>The best way to validate your app works is by using Base Build's built-in [Preview tool](https://base.dev/apps/preview)</Tip>
 
 - Not appearing in search? → App Discovery & Indexing Issues
 - Not rendering as an embed? → Embed Rendering Issues
@@ -234,7 +234,7 @@ Basic functionality and discovery/sharing checklists: confirm load, images, wall
 
 ## Getting Additional Help
 
-- [Base Build Preview Tool](https://base.dev/preview)  
+- [Base Build Preview Tool](https://base.dev/apps/preview)  
 - JSONLint  
 - [Eruda](https://github.com/liriliri/eruda)  
 - Base Discord — #minikit channel

--- a/docs/apps/troubleshooting/testing.mdx
+++ b/docs/apps/troubleshooting/testing.mdx
@@ -8,7 +8,7 @@ Testing your mini app before launch ensures it functions correctly, displays pro
 
 ## Base Build Preview Tool
 
-Preview and debug your mini app to ensure it displays correctly in the Base App using the [Preview Tool.](https://www.base.dev/preview)
+Preview and debug your mini app to ensure it displays correctly in the Base App using the [Preview Tool.](https://base.dev/apps/preview)
 
 <Info>
 Your browser's console won't show Base-specific logs. Base.dev console provides logs specific to how your mini app works within the Base app, including user context and Base app-specific functionality. 
@@ -27,7 +27,7 @@ Your browser's console won't show Base-specific logs. Base.dev console provides 
 
 ### Steps
 
-1. Navigate to [Base.dev/preview](https://www.base.dev/preview) 
+1. Navigate to [Base.dev/preview](https://base.dev/apps/preview) 
 2. Log in using your Base app account
 3. Paste your app's url in the field
 4. Click `Submit`

--- a/docs/base-chain/network-information/bridges.mdx
+++ b/docs/base-chain/network-information/bridges.mdx
@@ -49,7 +49,7 @@ code to withdraw the assets.
 
 ### For Token Issuers
 
-If you have an ERC-20 token deployed on Ethereum and want to enable bridging to Base, see our guide on [Bridging an L1 Token to Base](/base-chain/quickstart/bridge-token). This covers deploying your token on Base using the standard bridge contracts and getting it listed on the Superchain token list.
+If you have an ERC-20 token deployed on Ethereum and want to enable bridging to Base, see our guide on [Bridging an L1 Token to Base](https://docs.optimism.io/builders/app-developers/bridging/standard-bridge). This covers deploying your token on Base using the standard bridge contracts and getting it listed on the Superchain token list.
 
 ---
 


### PR DESCRIPTION
While going through the troubleshooting docs I noticed the Preview tool links were returning 404. Traced it back to a URL change the tool moved from /preview to /apps/preview on base.dev.

Closes #1306.

Tested both:
- base.dev/preview → redirects to dashboard.base.org/preview → 404
- base.dev/apps/preview → redirects to dashboard.base.org/apps/preview → 200

Found 12 occurrences across 7 files and updated them all.