### PR TITLE
fix(docs): replace broken /apps/introduction/overview link with /apps

### DIFF
--- a/docs/apps/featured-guidelines/overview.mdx
+++ b/docs/apps/featured-guidelines/overview.mdx
@@ -8,7 +8,7 @@ Your app must meet all product, design, and technical guidelines outlined below.
 
 
 <Note>
-  To submit your app for featured placement, first verify your mini app in the [Base Build dashboard](https://base.dev/), then fill out the [submission form](https://docs.google.com/forms/d/e/1FAIpQLSeZiB3fmMS7oxBKrWsoaew2LFxGpktnAtPAmJaNZv5TOCXIZg/viewform).
+  To submit your app for featured placement, first verify your mini app in the [Base Build dashboard](https://base.dev/) and apply for featured placement through the dashboard.
 </Note>
 
 

--- a/docs/apps/troubleshooting/common-issues.mdx
+++ b/docs/apps/troubleshooting/common-issues.mdx
@@ -29,7 +29,7 @@ your-domain.com/
 Use Base Build's built-in Preview Tool for foundational debugging.
 
 <Card title="Preview Tool" img="/images/base-build/preview-tool-overview.png">
-Start debugging your app using the [Preview tool](https://base.dev/preview)
+Start debugging your app using the [Preview tool](https://base.dev/apps/preview)
 </Card>
 
 The **Preview tool** will help you:  
@@ -59,7 +59,7 @@ The Preview tool has three main components:
 
 ## Quick Diagnostic Workflow
 
-<Tip>The best way to validate your app works is by using Base Build's built-in [Preview tool](https://base.dev/preview)</Tip>
+<Tip>The best way to validate your app works is by using Base Build's built-in [Preview tool](https://base.dev/apps/preview)</Tip>
 
 - Not appearing in search? → App Discovery & Indexing Issues
 - Not rendering as an embed? → Embed Rendering Issues
@@ -234,7 +234,7 @@ Basic functionality and discovery/sharing checklists: confirm load, images, wall
 
 ## Getting Additional Help
 
-- [Base Build Preview Tool](https://base.dev/preview)  
+- [Base Build Preview Tool](https://base.dev/apps/preview)  
 - JSONLint  
 - [Eruda](https://github.com/liriliri/eruda)  
 - Base Discord — #minikit channel

--- a/docs/base-account/guides/verify-social-accounts.mdx
+++ b/docs/base-account/guides/verify-social-accounts.mdx
@@ -432,7 +432,7 @@ function redirectToVerifyMiniApp(provider: string) {
 }
 ```
 
-After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps/introduction/overview) for broader app structure and lifecycle guidance.
+After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps) for broader app structure and lifecycle guidance.
 
 </Step>
 </Steps>

--- a/docs/base-chain/network-information/bridges.mdx
+++ b/docs/base-chain/network-information/bridges.mdx
@@ -49,7 +49,7 @@ code to withdraw the assets.
 
 ### For Token Issuers
 
-If you have an ERC-20 token deployed on Ethereum and want to enable bridging to Base, see our guide on [Bridging an L1 Token to Base](/base-chain/quickstart/bridge-token). This covers deploying your token on Base using the standard bridge contracts and getting it listed on the Superchain token list.
+If you have an ERC-20 token deployed on Ethereum and want to enable bridging to Base, see our guide on [Bridging an L1 Token to Base](https://docs.optimism.io/builders/app-developers/bridging/standard-bridge). This covers deploying your token on Base using the standard bridge contracts and getting it listed on the Superchain token list.
 
 ---
 


### PR DESCRIPTION
Closes #1308.

The link to `/apps/introduction/overview` in verify-social-accounts guide returns 404 because the page has `hidden: true` in its frontmatter.

Replaced with `/apps` which returns 200.

**Affected file:** `docs/base-account/guides/verify-social-accounts.mdx` line 435