### PR TITLE
fix(docs): replace broken /apps/introduction/overview link with /apps

### DIFF
--- a/docs/base-account/guides/verify-social-accounts.mdx
+++ b/docs/base-account/guides/verify-social-accounts.mdx
@@ -432,7 +432,7 @@ function redirectToVerifyMiniApp(provider: string) {
 }
 ```
 
-After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps/introduction/overview) for broader app structure and lifecycle guidance.
+After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps) for broader app structure and lifecycle guidance.
 
 </Step>
 </Steps>


### PR DESCRIPTION
Was reading through the verify social accounts guide and noticed the link at the bottom points to /apps/introduction/overview. Clicked on it and got a 404. Looked into why and found that docs/apps/introduction/overview.mdx has hidden: true in its frontmatter so Mintlify never serves it publicly. The /apps path loads fine and is the right destination here. Changed line 435 in docs/base account/guides/verify social accounts.mdx.