### PR TITLE
fix(docs): remove .mdx extension from signInWithEthereum link in wallet_connect reference

### DIFF
--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 


### PR DESCRIPTION
Was looking at the wallet connect reference page and noticed the signInWithEthereum capability link was broken. The link had a .mdx extension at the end which Mintlify does not handle as a valid path so it returns 404. Removed the extension and the link works fine now. The file itself exists at docs/base account/reference/core/capabilities/signInWithEthereum.mdx but the URL should not include the extension. Single line change on line 193 of wallet connect.mdx.