### PR TITLE
fix(docs): remove trailing comma from JSON response example in agent-builder-codes

### DIFF
--- a/docs/ai-agents/setup/agent-builder-codes.mdx
+++ b/docs/ai-agents/setup/agent-builder-codes.mdx
@@ -34,7 +34,7 @@ Response:
 ```json Response
 {
   "builderCode": "bc_a1b2c3d4",
-  "walletAddress": "0x...",
+  "walletAddress": "0x..."
 }
 ```
 


### PR DESCRIPTION
The response example in agent builder codes.mdx has a trailing comma after the last field which makes it invalid JSON. Verified against the actual API  the real response has no trailing comma.
Single character fix, line 37.