### PR TITLE
fix(docs): replace broken appLogoUrl example (base.org/logo.png returns 404)

### DIFF
--- a/docs/base-account/improve-ux/batch-transactions.mdx
+++ b/docs/base-account/improve-ux/batch-transactions.mdx
@@ -48,7 +48,7 @@ import { createBaseAccountSDK } from "@base-org/account";
 
 const sdk = createBaseAccountSDK({
   appName: "Base Account SDK Demo",
-  appLogoUrl: "https://base.org/logo.png",
+  appLogoUrl: "https://avatars.githubusercontent.com/u/108554348?s=200",
 });
 
 const provider = sdk.getProvider();
@@ -66,7 +66,7 @@ import { numberToHex, parseEther } from "viem";
 
 const sdk = createBaseAccountSDK({
   appName: "Batch Transaction Demo",
-  appLogoUrl: "https://base.org/logo.png",
+  appLogoUrl: "https://avatars.githubusercontent.com/u/108554348?s=200",
 });
 
 const provider = sdk.getProvider();
@@ -165,7 +165,7 @@ const NFT_CONTRACT_ADDRESS = "0x82039e7C37D7aAc98D0F4d0A762F4E0d8c8DC273";
 async function approveAndTransfer() {
   const sdk = createBaseAccountSDK({
     appName: "ERC-20 Batch Demo",
-    appLogoUrl: "https://base.org/logo.png",
+    appLogoUrl: "https://avatars.githubusercontent.com/u/108554348?s=200",
   });
 
   const provider = sdk.getProvider();

--- a/docs/base-account/improve-ux/spend-permissions.mdx
+++ b/docs/base-account/improve-ux/spend-permissions.mdx
@@ -44,7 +44,7 @@ import { base } from "viem/chains";
 
 const sdk = createBaseAccountSDK({
   appName: 'Base Account SDK Demo',
-  appLogoUrl: 'https://base.org/logo.png',
+  appLogoUrl: 'https://avatars.githubusercontent.com/u/108554348?s=200',
   appChainIds: [base.id],
 });
 
@@ -201,7 +201,7 @@ import { base } from "viem/chains";
 
 const sdk = createBaseAccountSDK({
   appName: 'Base Account SDK Demo',
-  appLogoUrl: 'https://base.org/logo.png',
+  appLogoUrl: 'https://avatars.githubusercontent.com/u/108554348?s=200',
   appChainIds: [base.id],
 });
 

--- a/docs/base-account/improve-ux/sponsor-gas/paymasters.mdx
+++ b/docs/base-account/improve-ux/sponsor-gas/paymasters.mdx
@@ -108,7 +108,7 @@ the [Coinbase Developer Platform documentation](https://docs.cdp.coinbase.com/pa
 
   const sdk = createBaseAccountSDK({
     appName: 'Paymaster Demo',
-    appLogoUrl: 'https://base.org/logo.png',
+    appLogoUrl: 'https://avatars.githubusercontent.com/u/108554348?s=200',
     appChainIds: [base.constants.CHAIN_IDS.baseSepolia], // or base.constants.CHAIN_IDS.base for mainnet
   });
 
@@ -148,7 +148,7 @@ the [Coinbase Developer Platform documentation](https://docs.cdp.coinbase.com/pa
   async function sendSponsoredTransaction() {
     const sdk = createBaseAccountSDK({
       appName: 'Paymaster Demo',
-      appLogoUrl: 'https://base.org/logo.png',
+      appLogoUrl: 'https://avatars.githubusercontent.com/u/108554348?s=200',
       appChainIds: [base.constants.CHAIN_IDS.baseSepolia],
     });
 
@@ -213,7 +213,7 @@ the [Coinbase Developer Platform documentation](https://docs.cdp.coinbase.com/pa
   async function sendMultipleSponsoredTransactions() {
     const sdk = createBaseAccountSDK({
       appName: 'Paymaster Demo',
-      appLogoUrl: 'https://base.org/logo.png',
+      appLogoUrl: 'https://avatars.githubusercontent.com/u/108554348?s=200',
       appChainIds: [base.constants.CHAIN_IDS.baseSepolia],
     });
 
@@ -264,7 +264,7 @@ the [Coinbase Developer Platform documentation](https://docs.cdp.coinbase.com/pa
   async function checkPaymasterSupport() {
     const sdk = createBaseAccountSDK({
       appName: 'Paymaster Demo',
-      appLogoUrl: 'https://base.org/logo.png',
+      appLogoUrl: 'https://avatars.githubusercontent.com/u/108554348?s=200',
       appChainIds: [base.constants.CHAIN_IDS.baseSepolia],
     });
 

--- a/docs/base-account/improve-ux/sub-accounts.mdx
+++ b/docs/base-account/improve-ux/sub-accounts.mdx
@@ -104,7 +104,7 @@ import { base } from 'viem/chains';
 // Initialize SDK with Sub Account configuration
 const sdk = createBaseAccountSDK({
   appName: 'Base Account SDK Demo',
-  appLogoUrl: 'https://base.org/logo.png',
+  appLogoUrl: 'https://avatars.githubusercontent.com/u/108554348?s=200',
   appChainIds: [base.id],
 });
 
@@ -339,7 +339,7 @@ If your users' Sub Accounts will be funded manually, you can disable Auto Spend 
 ```tsx page.tsx
 const sdk = createBaseAccountSDK({
   appName: 'Base Account SDK Demo',
-  appLogoUrl: 'https://base.org/logo.png',
+  appLogoUrl: 'https://avatars.githubusercontent.com/u/108554348?s=200',
   appChainIds: [base.id],
   subAccounts: {
     funding: 'manual', // Disable auto spend permissions

--- a/docs/base-account/quickstart/web-react.mdx
+++ b/docs/base-account/quickstart/web-react.mdx
@@ -82,7 +82,7 @@ export default function Home() {
   const sdk = createBaseAccountSDK(
     {
       appName: 'Base Account Quick-start',
-      appLogoUrl: 'https://base.org/logo.png',
+      appLogoUrl: 'https://avatars.githubusercontent.com/u/108554348?s=200',
     }
   );
 

--- a/docs/base-account/quickstart/web.mdx
+++ b/docs/base-account/quickstart/web.mdx
@@ -98,7 +98,7 @@ This guide uses the CDN approach for simplicity.
       const provider = window
         .createBaseAccountSDK({
           appName: "Base Account Quick-start",
-          appLogoUrl: "https://base.org/logo.png",
+          appLogoUrl: "https://avatars.githubusercontent.com/u/108554348?s=200",
         })
         .getProvider();
       const statusDiv = document.getElementById("status");


### PR DESCRIPTION
Was going through the SDK code examples and noticed base.org/logo.png is used as the appLogoUrl in multiple places. Tested it and it returns 404. Anyone copying these examples will see a broken image in their app popup. Searched across the docs and found it in 6 files. Replaced with the Base GitHub avatar URL which returns 200. Affected files are paymasters.mdx, spend-permissions.mdx, sub accounts.mdx, batch-transactions.mdx, web.mdx and web-react.mdx.