### PR TITLE
fix(docs): remove stale Fall 2025 date from migration guide table header

### DIFF
--- a/docs/base-account/guides/migration-guide.mdx
+++ b/docs/base-account/guides/migration-guide.mdx
@@ -15,8 +15,8 @@ Driving this change is a transition of our mobile app: the Coinbase Wallet app i
 
 Below is a table of existing users and how they will connect to apps now and in the future:
 
-| User Type | Today | Future (~Fall 2025) |
-|-----------|-------|---------------------|
+| User Type | Today | Future |
+|-----------|-------|--------|
 | Smart Wallet users (web and mobile app) | Automatically have a Base Account, can use "Sign in with Base" | No change |
 | New Base app users | Automatically have a Base Account, can use "Sign in with Base" | No change |
 | Coinbase Wallet Extension Users | Should continue to connect with "Coinbase Wallet" button | Will have a path to migrate to Base Account and use "Sign in with Base" |


### PR DESCRIPTION
Closes #1315.

The `Future (~Fall 2025)` column header in `docs/base-account/guides/migration-guide.mdx` is now stale (it is April 2026).

Changed the header to `Future` so it no longer references a past date. The column content itself is still forward-looking ("Will have a path to migrate…"), so keeping the header generic preserves the intent without making a claim about whether the migration is complete.

If the migration is in fact complete, a follow-up can collapse the table to show current state only.