### PR TITLE
Fix: v1 refs changed to Azul

### DIFF
--- a/docs/base-chain/node-operators/base-v1-upgrade.mdx
+++ b/docs/base-chain/node-operators/base-v1-upgrade.mdx
@@ -1,15 +1,15 @@
 ---
-title: "Base V1 Upgrade"
-description: "Migrate your Base node to base-reth-node and base-consensus for V1."
+title: "Base Azul Upgrade"
+description: "Migrate your Base node to base-reth-node and base-consensus for Azul."
 ---
 
 <Warning>
-Base V1 is an upgrade that introduces Osaka features on Base and TEE/ZK proof systems. It requires migrating to Base-native clients.
+Base Azul is an upgrade that introduces Osaka features on Base and TEE/ZK proof systems. It requires migrating to Base-native clients.
 </Warning>
 
-Only `base-reth-node` (EL) and `base-consensus` (CL) support V1. **Nodes running `op-node`, `op-geth`, `op-reth`, `nethermind`, or `kona` will not support the network upgrade and must be migrated before activation.**
+Only `base-reth-node` (EL) and `base-consensus` (CL) support Azul. **Nodes running `op-node`, `op-geth`, `op-reth`, `nethermind`, or `kona` will not support the network upgrade and must be migrated before activation.**
 
-For full details on what's included, see the [V1 specification](https://specs.base.org/upgrades/v1/overview).
+For full details on what's included, see the [Azul specification](https://specs.base.org/upgrades/azul/overview).
 
 ## Activation Timeline
 


### PR DESCRIPTION
**What changed? Why?**
Changed the inline verbiage from v1 to Azul and fixed the link to our specs page.

**Notes to reviewers**
n/a

**How has it been tested?**
Locally
