### PR TITLE
docs(apps): add Builder Code attribution to migration quickstart config

### DIFF
--- a/docs/apps/quickstart/migrate-to-standard-web-app.mdx
+++ b/docs/apps/quickstart/migrate-to-standard-web-app.mdx
@@ -44,15 +44,21 @@ Your app uses the Farcaster SDK. The migration replaces Farcaster-specific auth,
   Install wagmi, viem, and React Query if you don't have them already:
 
   ```bash Terminal
-  npm install wagmi viem @tanstack/react-query @base-org/account
+  npm install wagmi viem ox @tanstack/react-query @base-org/account
   ```
 
   Create a wagmi config for Base and wrap your app with `WagmiProvider` and `QueryClientProvider`:
 
-  ```tsx config.ts lines expandable wrap
+  ```tsx config.ts lines expandable wrap highlight={4,6-9,24}
   import { http, createConfig, createStorage, cookieStorage } from 'wagmi';
   import { base } from 'wagmi/chains';
   import { baseAccount, injected } from 'wagmi/connectors';
+  import { Attribution } from 'ox/erc8021';
+
+  // Get your Builder Code from base.dev > Settings > Builder Code
+  const DATA_SUFFIX = Attribution.toDataSuffix({
+    codes: ['YOUR-BUILDER-CODE'],
+  });
 
   export const config = createConfig({
     chains: [base],
@@ -67,6 +73,7 @@ Your app uses the Farcaster SDK. The migration replaces Farcaster-specific auth,
     transports: {
       [base.id]: http(),
     },
+    dataSuffix: DATA_SUFFIX,
   });
 
   declare module 'wagmi' {
@@ -173,7 +180,7 @@ Your app uses the Farcaster SDK. The migration replaces Farcaster-specific auth,
 </Step>
 
 <Step title="Register on Base.dev">
-  If you haven't registered yet, create a project at [Base.dev](https://www.base.dev) and complete your app metadata: name, icon, tagline, description, screenshots, category, primary URL, and [builder code](/apps/builder-codes/builder-codes). Already registered apps do not need to re-register or update metadata.
+  If you haven't registered yet, create a project at [Base.dev](https://www.base.dev) and complete your app metadata: name, icon, tagline, description, screenshots, category, primary URL, and [builder code](/apps/builder-codes/builder-codes). Already registered apps do not need to re-register or update metadata. To attribute transactions from web users outside the Base App browser, also add your Builder Code as a `dataSuffix` to your wagmi config. See [Builder Codes for App Developers](/apps/builder-codes/app-developers).
 </Step>
 </Steps>
 


### PR DESCRIPTION
## Summary

- Adds `ox` to the `npm install` command in Step 1 of the "I'm converting an app" migration path
- Updates the `config.ts` code block to import `Attribution` from `ox/erc8021`, derive a `DATA_SUFFIX` constant, and pass it as `dataSuffix` to `createConfig` — matching the pattern documented in [Builder Codes for App Developers](/apps/builder-codes/app-developers)
- Appends a sentence to Step 5 (Register on Base.dev) pointing web-traffic users to the Builder Codes guide for transaction attribution outside the Base App browser

## Test plan

- [ ] Verify the `npm install` line includes `ox` between `viem` and `@tanstack/react-query`
- [ ] Verify the `config.ts` code block compiles: `Attribution.toDataSuffix` is a valid export from `ox/erc8021` (requires viem ≥ 2.45.0 per the Builder Codes guide)
- [ ] Verify `highlight={4,6-9,24}` correctly marks the new import, `DATA_SUFFIX` constant, and `dataSuffix` field
- [ ] Verify the `lines`, `expandable`, and `wrap` fence flags are intact
- [ ] Verify Step 5 in the "My app has no Farcaster SDK" tab is unchanged
- [ ] Verify no other sections of the file were modified