### PR TITLE
docs(base-account): drop .mdx extension from signInWithEthereum link

### DIFF
--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 


### PR DESCRIPTION
## Summary

\`docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx:193\` links to \`/base-account/reference/core/capabilities/signInWithEthereum.mdx\`. Mintlify routes are published without the \`.mdx\` suffix, so the link 404s.

Removed the extension so the link resolves to \`/base-account/reference/core/capabilities/signInWithEthereum\`.

Closes #1311

## Testing

Docs-only change. Verified:
- docs.base.org/base-account/reference/core/capabilities/signInWithEthereum resolves;
- the same-directory sibling \`capabilities/signInWithEthereum.mdx\` exists in-repo.