### PR TITLE
docs(base-account): fix broken /apps/introduction/overview link -> /apps

### DIFF
--- a/docs/base-account/guides/verify-social-accounts.mdx
+++ b/docs/base-account/guides/verify-social-accounts.mdx
@@ -432,7 +432,7 @@ function redirectToVerifyMiniApp(provider: string) {
 }
 ```
 
-After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps/introduction/overview) for broader app structure and lifecycle guidance.
+After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps) for broader app structure and lifecycle guidance.
 
 </Step>
 </Steps>


### PR DESCRIPTION
## Summary

\`docs/base-account/guides/verify-social-accounts.mdx:435\` links to \`/apps/introduction/overview\`. That page has \`hidden: true\` in its frontmatter and is not publicly accessible, so the link 404s. Point it at the parent \`/apps\` section, which is live, per the issue.

Closes #1308

## Testing

Docs-only change.