### PR TITLE
docs: add runnable example to Code examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,19 @@ The Base documentation is organized into established sections (for example: `get
 - For alternatives, use `<Tabs>` / `<Tab>`.
 - For API docs, use `<ParamField>`, `<ResponseField>`, and request/response examples.
 
+
 ### Code examples
 
 - Provide complete, runnable examples with realistic data.
 - Include proper error handling and edge cases.
 - Specify language and filename when helpful.
 - Show expected output or verification steps.
+
+**Example:**
+
+```bash
+cd docs
+mint dev
 
 ## Third-party guides policy
 


### PR DESCRIPTION
Added a runnable example to the "Code examples" section in the review checklist.

This makes the guidelines more helpful and consistent for new Base contributors, as the section was telling people to provide good examples without showing one itself.