### PR TITLE
fix(docs): remove trailing comma from JSON response example

### DIFF
--- a/docs/ai-agents/setup/agent-builder-codes.mdx
+++ b/docs/ai-agents/setup/agent-builder-codes.mdx
@@ -34,7 +34,7 @@ Response:
 ```json Response
 {
   "builderCode": "bc_a1b2c3d4",
-  "walletAddress": "0x...",
+  "walletAddress": "0x..."
 }
 ```
 


### PR DESCRIPTION
Fixes #1313

The JSON response example in agent-builder-codes.mdx contained a trailing comma after the last property, which is invalid JSON. This fix removes the comma to ensure the example shows valid JSON.

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
