### PR TITLE
fix(docs): remove .mdx extension from signInWithEthereum link

### DIFF
--- a/docs/ai-agents/setup/agent-builder-codes.mdx
+++ b/docs/ai-agents/setup/agent-builder-codes.mdx
@@ -34,7 +34,7 @@ Response:
 ```json Response
 {
   "builderCode": "bc_a1b2c3d4",
-  "walletAddress": "0x...",
+  "walletAddress": "0x..."
 }
 ```
 

--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 


### PR DESCRIPTION
## Summary
Fixes #1311

Removes `.mdx` extension from signInWithEthereum link in wallet_connect reference documentation.

## Changes
- **File:** `docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx`
- **Line 193:** Removed `.mdx` extension from link path

## Details
The link to signInWithEthereum capability documentation incorrectly included the `.mdx` file extension, resulting in 404 errors when users clicked the link.

**Before:** `/base-account/reference/core/capabilities/signInWithEthereum.mdx` → 404  
**After:** `/base-account/reference/core/capabilities/signInWithEthereum` → ✅

## Testing
- [x] Verified link path is now correct
- [x] Checked no other .mdx extensions in links