### PR TITLE
fix(docs): update broken /apps/introduction/overview link

### DIFF
--- a/docs/base-account/guides/verify-social-accounts.mdx
+++ b/docs/base-account/guides/verify-social-accounts.mdx
@@ -432,7 +432,7 @@ function redirectToVerifyMiniApp(provider: string) {
 }
 ```
 
-After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps/introduction/overview) for broader app structure and lifecycle guidance.
+After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps) for broader app structure and lifecycle guidance.
 
 </Step>
 </Steps>


### PR DESCRIPTION
## Summary
Fixes #1308

Updates broken apps overview link in the verify-social-accounts guide.

## Changes
- **File:** `docs/base-account/guides/verify-social-accounts.mdx`
- **Line 435:** Updated apps link to working URL

## Details
The link `/apps/introduction/overview` returns 404 because that page has `hidden: true` in its frontmatter. Updated to `/apps` which is the publicly accessible apps overview page.

**Before:** `/apps/introduction/overview` → 404  
**After:** `/apps` → ✅

## Testing
- [x] Verified new link returns 200
- [x] Confirmed /apps page serves as apps overview