### PR TITLE
fix: update broken faucet link in launch-token guide

### DIFF
--- a/docs/get-started/launch-token.mdx
+++ b/docs/get-started/launch-token.mdx
@@ -120,7 +120,7 @@ Before launching a custom developed token to production, always conduct security
     For detailed installation instructions, see the [Foundry documentation](https://book.getfoundry.sh/getting-started/installation).
   </Step>
   <Step title="Get Test ETH">
-    Obtain Base Sepolia ETH for testing from the [Base Faucet](https://docs.base.org/docs/tools/network-faucets)
+    Obtain Base Sepolia ETH for testing from the [Base Faucet](https://docs.base.org/base-chain/network-information/network-faucets)
   </Step>
   <Step title="Set Up Development Environment">
     Configure your wallet and development tools for Base testnet deployment


### PR DESCRIPTION
The faucet link in the Prerequisites section pointed to  /docs/tools/network-faucets which returns a 404. 
Updated to the correct URL: /base-chain/network-information/network-faucets

Fixes #[paste your issue number here]

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
