### PR TITLE
Update docs top navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,7 +95,7 @@
         }
       },
       {
-        "tab": "Base Chain",
+        "tab": "Chain",
         "groups": [
           {
             "group": "Quickstart",
@@ -242,7 +242,7 @@
         }
       },
       {
-        "tab": "Base Account",
+        "tab": "Account",
         "groups": [
           {
             "group": "Introduction",
@@ -478,7 +478,36 @@
         }
       },
       {
-        "tab": "AI Agents",
+        "tab": "Apps",
+        "groups": [
+          {
+            "group": "Quickstart",
+            "pages": [
+              "apps/quickstart/migrate-to-standard-web-app",
+              "get-started/build-app"
+            ]
+          },
+          {
+            "group": "Growth",
+            "pages": ["apps/growth/rewards"]
+          },
+          {
+            "group": "Notifications",
+            "pages": ["apps/technical-guides/base-notifications"]
+          },
+          {
+            "group": "Builder Codes",
+            "pages": [
+              "apps/builder-codes/builder-codes",
+              "apps/builder-codes/app-developers",
+              "apps/builder-codes/wallet-developers",
+              "apps/builder-codes/agent-developers"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Agents",
         "groups": [
           {
             "group": "Overview",
@@ -541,44 +570,6 @@
                 ]
               }
             ]
-          }
-        ]
-      },
-      {
-        "tab": "Apps",
-        "groups": [
-          {
-            "group": "Quickstart",
-            "pages": [
-              "apps/quickstart/migrate-to-standard-web-app",
-              "get-started/build-app"
-            ]
-          },
-          {
-            "group": "Growth",
-            "pages": ["apps/growth/rewards"]
-          },
-          {
-            "group": "Notifications",
-            "pages": ["apps/technical-guides/base-notifications"]
-          },
-          {
-            "group": "Builder Codes",
-            "pages": [
-              "apps/builder-codes/builder-codes",
-              "apps/builder-codes/app-developers",
-              "apps/builder-codes/wallet-developers",
-              "apps/builder-codes/agent-developers"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "OnchainKit",
-        "groups": [
-          {
-            "group": "Getting Started",
-            "pages": ["onchainkit/migrate-from-onchainkit"]
           }
         ]
       }

--- a/docs/get-started/base.mdx
+++ b/docs/get-started/base.mdx
@@ -28,7 +28,7 @@ mode: "wide"
 ### Products
 
 <CardGroup cols={4}>
-  <Card title="Base" icon="link" href="/base-chain/quickstart/why-base">
+  <Card title="Chain" icon="link" href="/base-chain/quickstart/why-base">
     Network, nodes, and infrastructure
   </Card>
   <Card title="Account" icon="wallet" href="/base-account/overview/what-is-base-account">

--- a/docs/get-started/base.mdx
+++ b/docs/get-started/base.mdx
@@ -28,13 +28,13 @@ mode: "wide"
 ### Products
 
 <CardGroup cols={4}>
-  <Card title="Base Chain" icon="link" href="/base-chain/quickstart/why-base">
+  <Card title="Base" icon="link" href="/base-chain/quickstart/why-base">
     Network, nodes, and infrastructure
   </Card>
-  <Card title="Base Account" icon="wallet" href="/base-account/overview/what-is-base-account">
+  <Card title="Account" icon="wallet" href="/base-account/overview/what-is-base-account">
     Authentication, payments, Basenames
   </Card>
-  <Card title="AI Agents" icon="robot" href="/ai-agents">
+  <Card title="Agents" icon="robot" href="/ai-agents">
     Build and deploy autonomous onchain agents
   </Card>
   <Card title="Solana Bridge" icon="bridge" href="/base-chain/quickstart/base-solana-bridge">


### PR DESCRIPTION
## Summary
- Rename top nav tabs from Base Chain/Base Account/AI Agents to Chain/Account/Agents
- Reorder tabs to Get Started, Chain, Account, Apps, Agents
- Remove OnchainKit from visible navigation while keeping its route available by URL

## Verification
- Parsed docs/docs.json and confirmed tab order: Get Started | Chain | Account | Apps | Agents