### PR TITLE
fix: correct typo and missing blank line in glossary.mdx

### DIFF
--- a/docs/base-chain/specs/reference/glossary.mdx
+++ b/docs/base-chain/specs/reference/glossary.mdx
@@ -9,7 +9,7 @@ description: "Glossary of terms and definitions used throughout the Base Chain p
 
 [L1]: glossary#layer-1-L1
 
-Refers the Ethereum blockchain, used in contrast to [layer 2][L2], which refers to Base.
+Refers to the Ethereum blockchain, used in contrast to [layer 2][L2], which refers to Base.
 
 ### Layer 2 (L2)
 
@@ -431,6 +431,7 @@ introduced the change.
 
 The gas limit may not be set to a value larger than the
 [maximum gas limit](../protocol/consensus/derivation#system-configuration). This is to ensure that L2 blocks are provable and can be processed by consensus and execution software.
+
 ## Batch Submission
 
 [batch-submission]: glossary#batch-submission


### PR DESCRIPTION

**What changed? Why?**
Fixed two formatting issues in `docs/base-chain/specs/reference/glossary.mdx`:
1. Line 12: Missing word — "Refers the Ethereum blockchain" corrected to "Refers to the Ethereum blockchain"
2. Line 434: Missing blank line before the `## Batch Submission` section header, required for proper Markdown rendering

**Notes to reviewers**
Small, isolated fixes with no structural changes. Both issues are in the same file so combining them in one PR keeps the diff minimal.

**How has it been tested?**
Verified by reading the raw file. The typo is a clear grammatical error. The missing blank line is a standard Markdown requirement before headers.
