### PR TITLE
fix: remove duplicate REJECT rule in p2p.mdx

### DIFF
--- a/docs/base-chain/specs/protocol/consensus/p2p.mdx
+++ b/docs/base-chain/specs/protocol/consensus/p2p.mdx
@@ -278,7 +278,6 @@ An [extended-validator] checks the incoming messages as follows, in order of ope
   (graceful boundary for worst-case propagation and clock skew)
 - `[REJECT]` if the `payload.timestamp` is more than 5 seconds into the future
 - `[REJECT]` if the `block_hash` in the `payload` is not valid
-- `[REJECT]` if the block is on the V1 topic and has withdrawals
 - `[REJECT]` if the block is on the V1 topic and has a withdrawals list
 - `[REJECT]` if the block is on a `topic >= V2` and does not have an empty withdrawals list
 - `[REJECT]` if the block is on a `topic <= V2` and has a blob gas-used value set


### PR DESCRIPTION
**What changed? Why?**
Removed a duplicate validation rule in the Block Validation section of `docs/base-chain/specs/protocol/consensus/p2p.mdx`.

Two consecutive lines said the same thing:
- `[REJECT]` if the block is on the V1 topic and has withdrawals
- `[REJECT]` if the block is on the V1 topic and has a withdrawals list

Kept the second (more precise) phrasing and removed the first.

**Notes to reviewers**
Single line removal, no content change — just deduplication.

**How has it been tested?**
Verified by reading the raw file. Both rules describe the same condition.

