### PR TITLE
fix: order Azul as latest upgrade

### DIFF
--- a/docs/base-chain/llms-full.txt
+++ b/docs/base-chain/llms-full.txt
@@ -86,6 +86,7 @@
 - [Configurability](https://docs.base.org/base-chain/specs/reference/configurability.md) — All configurable protocol parameters
 
 ### Protocol Specs — Upgrades
+- [Azul](https://docs.base.org/base-chain/specs/upgrades/azul/overview.md) — Osaka EVM support and multi-proof system
 - [Jovian](https://docs.base.org/base-chain/specs/upgrades/jovian/overview.md) — Minimum base fee and DA footprint gas scalar
 - [Isthmus](https://docs.base.org/base-chain/specs/upgrades/isthmus/overview.md) — Pectra EIPs and operator fee mechanism
 - [Holocene](https://docs.base.org/base-chain/specs/upgrades/holocene/overview.md) — Dynamic EIP-1559 parameters and stricter derivation rules
@@ -94,7 +95,6 @@
 - [Ecotone](https://docs.base.org/base-chain/specs/upgrades/ecotone/overview.md) — EIP-4844 blob DA and Dencun integration
 - [Delta](https://docs.base.org/base-chain/specs/upgrades/delta/overview.md) — Span batches for efficient L1 data posting
 - [Canyon](https://docs.base.org/base-chain/specs/upgrades/canyon/overview.md) — Ethereum Shanghai EIPs (EIP-3651, EIP-3855, EIP-3860)
-- [Azul](https://docs.base.org/base-chain/specs/upgrades/azul/overview.md) — Osaka EVM support and multi-proof system
 - [Pectra Blob Schedule](https://docs.base.org/base-chain/specs/upgrades/pectra-blob-schedule/overview.md) — Optional delay of Ethereum blob count schedule changes
 
 ### Security

--- a/docs/base-chain/llms.txt
+++ b/docs/base-chain/llms.txt
@@ -47,6 +47,7 @@
 - [Configurability](https://docs.base.org/base-chain/specs/reference/configurability.md) — Consensus, policy, admin, and sequencer parameters
 
 ### Upgrade Specs
+- [Azul](https://docs.base.org/base-chain/specs/upgrades/azul/overview.md) — Osaka EVM support and multi-proof system
 - [Jovian](https://docs.base.org/base-chain/specs/upgrades/jovian/overview.md) — Configurable minimum base fee and DA footprint scalar
 - [Isthmus](https://docs.base.org/base-chain/specs/upgrades/isthmus/overview.md) — Pectra EIPs and operator fee mechanism
 - [Holocene](https://docs.base.org/base-chain/specs/upgrades/holocene/overview.md) — Dynamic EIP-1559 parameters and stricter derivation rules
@@ -54,7 +55,6 @@
 - [Fjord](https://docs.base.org/base-chain/specs/upgrades/fjord/overview.md) — FastLZ L1 fee estimation and brotli channel compression
 - [Ecotone](https://docs.base.org/base-chain/specs/upgrades/ecotone/overview.md) — EIP-4844 blob support and Dencun integration
 - [Delta](https://docs.base.org/base-chain/specs/upgrades/delta/overview.md) — Span batches for compressed L1 data posting
-- [Azul](https://docs.base.org/base-chain/specs/upgrades/azul/overview.md) — Osaka EVM support and multi-proof system
 
 ## Security
 - [Report a Vulnerability](https://docs.base.org/base-chain/security/report-vulnerability.md) — Security contact and disclosure

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -260,6 +260,14 @@
                 "group": "Upgrades",
                 "pages": [
                   {
+                    "group": "Azul",
+                    "pages": [
+                      "base-chain/specs/upgrades/azul/overview",
+                      "base-chain/specs/upgrades/azul/exec-engine",
+                      "base-chain/specs/upgrades/azul/proofs"
+                    ]
+                  },
+                  {
                     "group": "Jovian",
                     "pages": [
                       "base-chain/specs/upgrades/jovian/overview",
@@ -323,17 +331,7 @@
                   },
                   {
                     "group": "Canyon",
-                    "pages": [
-                      "base-chain/specs/upgrades/canyon/overview"
-                    ]
-                  },
-                  {
-                    "group": "Azul",
-                    "pages": [
-                      "base-chain/specs/upgrades/azul/overview",
-                      "base-chain/specs/upgrades/azul/exec-engine",
-                      "base-chain/specs/upgrades/azul/proofs"
-                    ]
+                    "pages": ["base-chain/specs/upgrades/canyon/overview"]
                   },
                   {
                     "group": "Pectra Blob Schedule",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -16,7 +16,7 @@ These resources give AI assistants direct access to Base documentation and reusa
 
 ### Base MCP server
 
-`https://docs.base.org/mcp` 
+`https://docs.base.org/mcp`
 
 ### Base skills
 
@@ -39,7 +39,7 @@ Narrow context to a specific type of work:
 - [Agent Registration](https://docs.base.org/ai-agents/setup/agent-registration) — Verification and trust between agents and services
 - [Base Account quickstart for AI tools](https://docs.base.org/base-account/quickstart/ai-tools-available-for-devs) — Agent-assisted wallet and account flows
 - [Deploy on Base](https://docs.base.org/base-chain/quickstart/deploy-on-base) — Contract deployment on Base
-- [Build a Base app](https://docs.base.org/get-started/build-app) 
+- [Build a Base app](https://docs.base.org/get-started/build-app)
 
 ### Docs index
 
@@ -101,6 +101,7 @@ Base is an Ethereum L2 by Coinbase. Docs for: Base Chain, Smart Wallet, OnchainK
 ||base-chain/specs/protocol/execution/evm:precompiles,predeploys,preinstalls,rpc
 ||base-chain/specs/protocol/fault-proof:index,cannon-fault-proof-vm,proposer
 ||base-chain/specs/protocol/fault-proof/stage-one:index,anchor-state-registry,bond-incentives,bridge-integration,dispute-game-interface,fault-dispute-game,honest-challenger-fdg,optimism-portal
+||base-chain/specs/upgrades/azul:overview,exec-engine,proofs
 ||base-chain/specs/upgrades/jovian:overview,exec-engine,derivation,l1-attributes,system-config
 ||base-chain/specs/upgrades/isthmus:overview,exec-engine,derivation,l1-attributes,predeploys,system-config
 ||base-chain/specs/upgrades/holocene:overview,exec-engine,derivation,system-config
@@ -109,7 +110,6 @@ Base is an Ethereum L2 by Coinbase. Docs for: Base Chain, Smart Wallet, OnchainK
 ||base-chain/specs/upgrades/ecotone:overview,derivation,l1-attributes
 ||base-chain/specs/upgrades/delta:overview,span-batches
 ||base-chain/specs/upgrades/canyon:overview
-||base-chain/specs/upgrades/azul:overview,exec-engine,proofs
 ||base-chain/specs/upgrades/pectra-blob-schedule:overview,derivation
 ||base-chain/specs/reference:glossary,configurability
 ||base-chain/specs/bcps:index,bcp-0000
@@ -119,5 +119,3 @@ Base is an Ethereum L2 by Coinbase. Docs for: Base Chain, Smart Wallet, OnchainK
 |onchainkit:migrate-from-onchainkit
 |root:agents,cookie-policy,privacy-policy,terms-of-service,tone_of_voice
 ```
-
-


### PR DESCRIPTION
**What changed? Why?**

The upgrade order has gone, and we probably want Azul on top anyway. `Isthmus -> Jovian -> Azul`

Also some tiny formatting fixes with extra newlines and trailing spaces.

**Notes to reviewers**

**How has it been tested?**
