### PR TITLE
Improve x402 docs: add security note and fix code blocks

### DIFF
--- a/docs/ai-agents/payments/accepting-payments.mdx
+++ b/docs/ai-agents/payments/accepting-payments.mdx
@@ -90,6 +90,10 @@ app.listen(3000);
 
 The middleware returns `402` to unpaid callers. The CDP facilitator handles verification and onchain settlement.
 
+<Note>
+When using postMessage or embedding third-party iframes, always validate the message origin to prevent potential security vulnerabilities.
+</Note>
+
 [x402 seller quickstart →](https://docs.cdp.coinbase.com/x402/docs/client-server-model)
 
 ## Configuring facilitators


### PR DESCRIPTION
## Overview
This PR improves the x402 documentation by adding a security note and fixing code block formatting.

## Changes
- Added a <Note> highlighting the importance of validating postMessage origin when using iframes
- Replaced non-standard "bash Terminal" code blocks with "bash"

## Impact
- Improves security awareness for developers using iframe integrations
- Ensures compatibility with MDX linting and rendering

## Notes
No functional changes — documentation only.