### PR TITLE
fix(docs): add rate-limit warning for publicnode fallback RPC in buil…

### DIFF
--- a/docs/get-started/build-app.mdx
+++ b/docs/get-started/build-app.mdx
@@ -155,7 +155,7 @@ Base is a fast, low-cost Ethereum L2 built to bring the next billion users oncha
     ```
 
     <Note>
-    If `https://sepolia.base.org` is unreachable, use an alternative public endpoint such as `https://base-sepolia-rpc.publicnode.com`. For production apps, use a dedicated RPC provider.
+    If `https://sepolia.base.org` is unreachable, use an alternative public endpoint such as `https://base-sepolia-rpc.publicnode.com`. Note that this fallback endpoint is also rate-limited and not suitable for production use. For production apps, use a dedicated RPC provider.
     </Note>
 
     Load the variable and import your deployer key securely.


### PR DESCRIPTION
Closes #1356

**What changed? Why?**
The build-app guide mentioned `https://base-sepolia-rpc.publicnode.com` as a fallback RPC endpoint but did not warn that it is also rate-limited and unsuitable for production — unlike the main endpoint which already had this warning.

**Changes**
Updated the Note in Step 4 to explicitly state that the publicnode fallback is rate-limited and for testing only, consistent with the existing warning for the primary endpoint.