### PR TITLE
fix(docs): remove trailing comma from JSON response example in agent-…

### DIFF
--- a/docs/ai-agents/setup/agent-builder-codes.mdx
+++ b/docs/ai-agents/setup/agent-builder-codes.mdx
@@ -34,7 +34,7 @@ Response:
 ```json Response
 {
   "builderCode": "bc_a1b2c3d4",
-  "walletAddress": "0x...",
+  "walletAddress": "0x..."
 }
 ```
 


### PR DESCRIPTION
…builder-codes

Fixes #1313 - The JSON response example had a trailing comma which is invalid JSON syntax.

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
