### PR TITLE
chore: Update Azul activation date

### DIFF
--- a/docs/base-chain/node-operators/base-v1-upgrade.mdx
+++ b/docs/base-chain/node-operators/base-v1-upgrade.mdx
@@ -16,7 +16,7 @@ For full details on what's included, see the [Azul specification](/base-chain/sp
 | Network | Date | Timestamp |
 |---------|------|-----------|
 | Sepolia | April 20, 2026 18:00 UTC | `1776708000` |
-| Mainnet | Early May 2026 | TBD |
+| Mainnet | May 21, 2026 18:00 UTC | `1779386400` |
 
 ## Required Software
 

--- a/docs/base-chain/specs/upgrades/azul/overview.mdx
+++ b/docs/base-chain/specs/upgrades/azul/overview.mdx
@@ -18,7 +18,7 @@ Only `base-consensus` and `base-reth-node` will support the Base Azul hardfork. 
 
 | Network   | Activation timestamp                   |
 | --------- | -------------------------------------- |
-| `mainnet` | `1778695200` (2026-05-13 18:00:00 UTC) |
+| `mainnet` | `1779386400` (2026-05-21 18:00:00 UTC) |
 | `sepolia` | `1776708000` (2026-04-20 18:00:00 UTC) |
 
 ## Execution Layer


### PR DESCRIPTION
**What changed? Why?**
Update azul date to match https://github.com/base/base/pull/2522

**Notes to reviewers**

**How has it been tested?**
