### PR TITLE
replace Math.random() nonce with crypto.randomUUID() in Wagmi integration example

### DIFF
--- a/docs/ai-agents/setup/agent-builder-codes.mdx
+++ b/docs/ai-agents/setup/agent-builder-codes.mdx
@@ -34,7 +34,7 @@ Response:
 ```json Response
 {
   "builderCode": "bc_a1b2c3d4",
-  "walletAddress": "0x...",
+  "walletAddress": "0x..."
 }
 ```
 

--- a/docs/base-account/framework-integrations/wagmi/setup.mdx
+++ b/docs/base-account/framework-integrations/wagmi/setup.mdx
@@ -335,9 +335,7 @@ export function SignInWithBase({ connector }: SignInWithBaseProps) {
     if (provider) {
       try {
         // Generate a fresh nonce (this will be overwritten with the backend nonce)
-        const clientNonce =
-          Math.random().toString(36).substring(2, 15) +
-          Math.random().toString(36).substring(2, 15);
+        const clientNonce = window.crypto.randomUUID().replace(/-/g, '');
         console.log("clientNonce", clientNonce);
         // Connect with SIWE to get signature, message, and address
         const accounts = await (provider as any).request({


### PR DESCRIPTION

Fixes #1390

The Wagmi integration setup guide uses Math.random() to generate a SIWE nonce. This is not cryptographically secure — Math.random() values can be predicted and should never be used for security-sensitive parameters.

This replaces it with window.crypto.randomUUID().replace(/-/g, ''), which is already the recommended approach in the authenticate-users guide — this brings the Wagmi integration into alignment.
