### PR TITLE
fix(docs): remove trailing comma from JSON response example in agent-builder-codes

### DIFF
--- a/docs/ai-agents/setup/agent-builder-codes.mdx
+++ b/docs/ai-agents/setup/agent-builder-codes.mdx
@@ -34,7 +34,7 @@ Response:
 ```json Response
 {
   "builderCode": "bc_a1b2c3d4",
-  "walletAddress": "0x...",
+  "walletAddress": "0x..."
 }
 ```
 


### PR DESCRIPTION
Closes #1313

**What changed? Why?**
The JSON response example in `docs/ai-agents/setup/agent-builder-codes.mdx` contained a trailing comma after `"walletAddress"`, making it invalid JSON.

Trailing commas are not valid in JSON (RFC 8259) and will cause parse errors in any strict JSON parser.

**Change**
```json
// Before (invalid JSON)
{
  "builderCode": "bc_a1b2c3d4",
  "walletAddress": "0x...",
}

// After (valid JSON)
{
  "builderCode": "bc_a1b2c3d4",
  "walletAddress": "0x..."
}
```

**How has it been tested?**
Validated with `JSON.parse()` — no errors after the fix.