### PR TITLE
Adding CDP Wallets section to Builder Codes docs for App Developers

### DIFF
--- a/docs/apps/builder-codes/app-developers.mdx
+++ b/docs/apps/builder-codes/app-developers.mdx
@@ -126,17 +126,17 @@ When you register on [base.dev](https://base.dev/), you will receive a **Builder
   </Step>
 </Steps>
 
-## Using Privy
-
-Privy provides a `dataSuffix` plugin that automatically appends your Builder Code to all transactions—including both EOA transactions and ERC-4337 smart wallet user operations.
-
-See the [Privy Builder Codes integration guide](https://docs.privy.io/recipes/evm/base-builder-codes) for setup instructions.
-
 ## Using CDP Wallets
 
 [Coinbase Developer Platform (CDP) Wallets](https://docs.cdp.coinbase.com/wallets/non-custodial-wallets/overview) support Builder Codes on user operations from smart accounts. Pass `dataSuffix` when you send a user operation so your Builder Code is appended; no contract changes required. This works across the React hooks (`useSendUserOperation`), Node (TypeScript), and Python SDKs.
 
 See [Builder Codes](https://docs.cdp.coinbase.com/wallets/using-wallets/smart-accounts#builder-codes) in the CDP Wallets documentation for setup instructions, including how to generate the suffix with `Attribution.toDataSuffix` from `ox/erc8021`.
+
+## Using Privy
+
+Privy provides a `dataSuffix` plugin that automatically appends your Builder Code to all transactions—including both EOA transactions and ERC-4337 smart wallet user operations.
+
+See the [Privy Builder Codes integration guide](https://docs.privy.io/recipes/evm/base-builder-codes) for setup instructions.
 
 ## Legacy: Per-Transaction Approach
 

--- a/docs/apps/builder-codes/app-developers.mdx
+++ b/docs/apps/builder-codes/app-developers.mdx
@@ -132,6 +132,12 @@ Privy provides a `dataSuffix` plugin that automatically appends your Builder Cod
 
 See the [Privy Builder Codes integration guide](https://docs.privy.io/recipes/evm/base-builder-codes) for setup instructions.
 
+## Using CDP Wallets
+
+[Coinbase Developer Platform (CDP) Wallets](https://docs.cdp.coinbase.com/wallets/non-custodial-wallets/overview) support Builder Codes on user operations from smart accounts. Pass `dataSuffix` when you send a user operation so your Builder Code is appended; no contract changes required. This works across the React hooks (`useSendUserOperation`), Node (TypeScript), and Python SDKs.
+
+See [Builder Codes](https://docs.cdp.coinbase.com/wallets/using-wallets/smart-accounts#builder-codes) in the CDP Wallets documentation for setup instructions, including how to generate the suffix with `Attribution.toDataSuffix` from `ox/erc8021`.
+
 ## Legacy: Per-Transaction Approach
 
 <Accordion title="Appending dataSuffix Per-Transaction">


### PR DESCRIPTION
**What changed? Why?**
Adding a CDP Wallets section to Builder Codes --> For App Developers. Explains how to use Base Builder Codes with CDP Non-custodial Wallets, including links to relevant CDP documentation.

**Notes to reviewers**
N/A

**How has it been tested?**
Preview