### PR TITLE
fix(docs): replace Math.random() nonce with crypto.randomUUID() in Wagmi setup example

### DIFF
--- a/docs/base-account/framework-integrations/wagmi/setup.mdx
+++ b/docs/base-account/framework-integrations/wagmi/setup.mdx
@@ -334,10 +334,8 @@ export function SignInWithBase({ connector }: SignInWithBaseProps) {
     const provider = await connector.getProvider();
     if (provider) {
       try {
-        // Generate a fresh nonce (this will be overwritten with the backend nonce)
-        const clientNonce =
-          Math.random().toString(36).substring(2, 15) +
-          Math.random().toString(36).substring(2, 15);
+        // Generate a cryptographically secure nonce using Web Crypto API
+        const clientNonce = crypto.randomUUID();
         console.log("clientNonce", clientNonce);
         // Connect with SIWE to get signature, message, and address
         const accounts = await (provider as any).request({


### PR DESCRIPTION
## Summary

Replaces the insecure `Math.random()` nonce generation with `crypto.randomUUID()` in the Wagmi integration setup example.

## Problem

`Math.random()` is **not cryptographically secure** and should never be used for SIWE (Sign-In With Ethereum) nonces. A predictable nonce can be exploited to perform replay attacks.

**Before:**
```ts
const clientNonce =
  Math.random().toString(36).substring(2, 15) +
  Math.random().toString(36).substring(2, 15);
```

**After:**
```ts
// Generate a cryptographically secure nonce using Web Crypto API
const clientNonce = crypto.randomUUID();
```

## Why `crypto.randomUUID()`

- ✅ Cryptographically secure (uses the Web Crypto API)
- ✅ Available in all modern browsers and Node.js 14.17+
- ✅ Already used in the `authenticate-users` guide — keeps docs consistent
- ✅ Returns a UUID v4 — more than sufficient entropy for a SIWE nonce

Fixes #1390