### PR TITLE
docs: remove stale OP Stack fee reference

### DIFF
--- a/docs/base-chain/network-information/network-fees.mdx
+++ b/docs/base-chain/network-information/network-fees.mdx
@@ -22,9 +22,7 @@ transactions are being submitted to the L2. This adjustment mechanism has the
 same implementation as the L1; you can read more about it
 [here](https://help.coinbase.com/en/coinbase/getting-started/crypto-education/eip-1559).
 
-For additional details about fee calculation on Base, please refer to the
-[op-stack developer
-documentation](https://docs.optimism.io/stack/transactions/fees).
+For additional details about fee calculation on Base, see the sections below on the minimum base fee, EIP-1559 fee parameters, and querying the L1 fee.
 
 ## Minimum Base Fee
 


### PR DESCRIPTION
## Summary
- remove the outdated OP Stack fee documentation link from the Base network fees page
- replace it with a self-contained pointer to the relevant Base-specific sections already on the page

## Problem
Issue #1395 notes that `/base-chain/network-information/network-fees` still points readers to OP Stack developer docs even though Base now runs on the unified `base/base` stack.

## Solution
This change removes the external OP Stack reference and directs readers to the Base fee mechanics sections already documented on the page:
- minimum base fee
- EIP-1559 fee parameters
- querying the L1 fee

## Verification
- confirmed the stale OP Stack link existed in `docs/base-chain/network-information/network-fees.mdx`
- updated the page copy to remove the obsolete reference without changing page structure or navigation

Partially addresses #1395
