### PR TITLE
docs: clarify public WebSocket availability for Flashblocks

### DIFF
--- a/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe.mdx
+++ b/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe.mdx
@@ -7,7 +7,7 @@ description: 'Creates a real-time WebSocket subscription. Flashblocks endpoints 
 Creates a real-time event subscription over a WebSocket connection. Returns a subscription ID; events are pushed as `eth_subscription` notifications without the client needing to poll.
 
 <Tip>
-**Flashblocks:** On `wss://mainnet-preconf.base.org`, `newHeads` emits every ~200ms (once per Flashblock) instead of every ~2 seconds. Three additional subscription types are also available: [`newFlashblockTransactions`](/base-chain/api-reference/flashblocks-api/newFlashblockTransactions), [`pendingLogs`](/base-chain/api-reference/flashblocks-api/pendingLogs), and [`newFlashblocks`](/base-chain/api-reference/flashblocks-api/newFlashblocks).
+**Flashblocks:** On a Flashblocks-aware provider or self-hosted node, `newHeads` emits every ~200ms (once per Flashblock) instead of every ~2 seconds. Three additional subscription types are also available: [`newFlashblockTransactions`](/base-chain/api-reference/flashblocks-api/newFlashblockTransactions), [`pendingLogs`](/base-chain/api-reference/flashblocks-api/pendingLogs), and [`newFlashblocks`](/base-chain/api-reference/flashblocks-api/newFlashblocks). The public `wss://*.base.org` endpoints listed in the RPC overview do not currently accept WebSocket upgrades.
 </Tip>
 
 ## Parameters

--- a/docs/base-chain/api-reference/flashblocks-api/newFlashblockTransactions.mdx
+++ b/docs/base-chain/api-reference/flashblocks-api/newFlashblockTransactions.mdx
@@ -7,7 +7,7 @@ description: 'Subscribe to receive each transaction as it is pre-confirmed into 
 Subscribe via `eth_subscribe` to receive each transaction as it is pre-confirmed into a Flashblock. Pass `true` as the second parameter to receive full transaction and log data.
 
 <Info>
-Only available on Flashblocks WebSocket endpoints: `wss://mainnet-preconf.base.org` / `wss://sepolia-preconf.base.org`.
+Only available on Flashblocks-aware WebSocket endpoints exposed by a node provider or your own node. The public `wss://*.base.org` endpoints do not currently accept WebSocket upgrades.
 </Info>
 
 <Note>

--- a/docs/base-chain/api-reference/flashblocks-api/newFlashblocks.mdx
+++ b/docs/base-chain/api-reference/flashblocks-api/newFlashblocks.mdx
@@ -7,7 +7,7 @@ description: 'Subscribe to receive full Flashblock payload stream as each pre-co
 Subscribe via `eth_subscribe` to receive full block state updates as each Flashblock is built. Each message contains the accumulated pre-confirmed state for the block in progress.
 
 <Info>
-Only available on Flashblocks WebSocket endpoints: `wss://mainnet-preconf.base.org` and `wss://sepolia-preconf.base.org`.
+Only available on Flashblocks-aware WebSocket endpoints exposed by a node provider or your own node. The public `wss://*.base.org` endpoints do not currently accept WebSocket upgrades.
 </Info>
 
 <Note>
@@ -44,8 +44,8 @@ Each subscription emits **one Flashblock Object per WebSocket message**. Events 
 ```javascript JavaScript
 import WebSocket from 'ws';
 
-// Use a Flashblocks-enabled provider WSS endpoint in production
-const ws = new WebSocket('wss://mainnet-preconf.base.org');
+// Replace with your provider or self-hosted Flashblocks WebSocket endpoint
+const ws = new WebSocket(process.env.BASE_FLASHBLOCKS_WSS_URL || 'wss://your-provider.example/ws');
 
 ws.on('open', () => {
   ws.send(JSON.stringify({

--- a/docs/base-chain/api-reference/flashblocks-api/pendingLogs.mdx
+++ b/docs/base-chain/api-reference/flashblocks-api/pendingLogs.mdx
@@ -7,7 +7,7 @@ description: 'Subscribe to logs from pre-confirmed transactions matching an opti
 Subscribe via `eth_subscribe` to receive logs from pre-confirmed transactions matching an optional filter. Useful for monitoring contract events with sub-block latency.
 
 <Info>
-Only available on Flashblocks WebSocket endpoints: `wss://mainnet-preconf.base.org` / `wss://sepolia-preconf.base.org`.
+Only available on Flashblocks-aware WebSocket endpoints exposed by a node provider or your own node. The public `wss://*.base.org` endpoints do not currently accept WebSocket upgrades.
 </Info>
 
 <Note>

--- a/docs/base-chain/api-reference/rpc-overview.mdx
+++ b/docs/base-chain/api-reference/rpc-overview.mdx
@@ -30,8 +30,12 @@ Base exposes a single, fully EVM-compatible JSON-RPC API across two performance 
   </Tab>
 </Tabs>
 
+<Warning>
+Public `base.org` RPC endpoints currently support HTTP only. WebSocket upgrade requests to the `wss://*.base.org` URLs above return `405 Method Not Allowed` as of May 2026. If you need `eth_subscribe`, `newFlashblocks`, `pendingLogs`, or `newFlashblockTransactions`, use a [node provider](/base-chain/node-operators/node-providers) or run your own [Flashblocks-aware node](/base-chain/node-operators/run-a-base-node#enable-flashblocks).
+</Warning>
+
 <Info>
-The public endpoints above are rate-limited and not suitable for production traffic. For production use, connect through a [node provider](/base-chain/node-operators/node-providers).
+The public HTTP endpoints above are rate-limited and not suitable for production traffic. For production use, connect through a [node provider](/base-chain/node-operators/node-providers).
 </Info>
 
 ## What is the Flashblocks Tier?
@@ -80,8 +84,8 @@ Methods marked ✓ support the `"pending"` block tag on Flashblocks endpoints.
 | [eth_syncing](/base-chain/api-reference/ethereum-json-rpc-api/eth_syncing) | Node sync status | — |
 | [net_version](/base-chain/api-reference/ethereum-json-rpc-api/net_version) | Network version ID | — |
 | [web3_clientVersion](/base-chain/api-reference/ethereum-json-rpc-api/web3_clientVersion) | Client version string | — |
-| [eth_subscribe](/base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe) | Subscribe to events (WSS) | ✓ |
-| [eth_unsubscribe](/base-chain/api-reference/ethereum-json-rpc-api/eth_unsubscribe) | Cancel a subscription (WSS) | — |
+| [eth_subscribe](/base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe) | Subscribe to events (provider or self-hosted WSS) | ✓ |
+| [eth_unsubscribe](/base-chain/api-reference/ethereum-json-rpc-api/eth_unsubscribe) | Cancel a subscription (provider or self-hosted WSS) | — |
 
 ### Flashblocks API
 

--- a/docs/base-chain/flashblocks/faq.mdx
+++ b/docs/base-chain/flashblocks/faq.mdx
@@ -105,11 +105,13 @@ For a comprehensive introduction to how Flashblocks work, see the [Flashblocks O
     Transaction data in the [`diff.transactions`](/base-chain/api-reference/flashblocks-api/flashblocks-api-overview#diff-object) array is Recursive Length Prefix (RLP) encoded.
   </Accordion>
 
-  <Accordion title="Why am I getting rate limited on the WebSocket?">
-    The public WebSocket has a maximum connection limit. For production use, we recommend:
+  <Accordion title="Why does the public WebSocket return 405 Method Not Allowed?">
+    The public `wss://*.base.org` endpoints do not currently accept WebSocket upgrade requests. If you need subscription-based Flashblocks data, use:
 
     1. Running your own [Flashblocks-aware RPC node](/base-chain/node-operators/run-a-base-node#enable-flashblocks)
     2. Using a third-party node provider with Flashblocks support
+
+    The public HTTP endpoints remain available for standard JSON-RPC requests.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary
- clarify that public `wss://*.base.org` RPC endpoints do not currently accept WebSocket upgrades
- update Flashblocks subscription docs to point readers to a node provider or self-hosted Flashblocks-aware node
- replace the direct `wss://mainnet-preconf.base.org` example with a provider/self-hosted placeholder

## Test plan
- reviewed all impacted docs pages for consistent wording
- confirmed the branch only contains the six documentation updates for this clarification

Fixes #1409
