### PR TITLE
docs: add first contribution note by @TurgayAcar49

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,7 @@ The core team will review opened PRs. The SLA is 2 weeks, generally on a first-c
 ## Storybook for UI components
 
 See `storybook/README.md` for details on local Storybook and component docs.
+
+
+<!-- First open source contribution by @TurgayAcar49 -->
+<!-- Date: May 11, 2026 -->


### PR DESCRIPTION
## What changed?
Added my first open-source contribution note to README.md

## Why?
Starting to contribute to Base docs as part of my builder journey for Base Guild roles + Builders & Founders role.

## Testing
Just a small markdown addition - no breaking changes.

First PR 🔥