### PR TITLE
fix(docs): remove .mdx extension from signInWithEthereum link in wallet_connect reference

### DIFF
--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 


### PR DESCRIPTION
## Summary

Removes the `.mdx` extension from the `signInWithEthereum` link in `wallet_connect.mdx` line 193.

## Problem

The link included a `.mdx` extension which caused a 404 error when clicked.

- ❌ `/base-account/reference/core/capabilities/signInWithEthereum.mdx` → 404
- ✅ `/base-account/reference/core/capabilities/signInWithEthereum` → 200

## Changes

- `docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx` line 193

Fixes #1311