### PR TITLE
fix(docs): remove trailing comma from JSON response example in agent-builder-codes

### DIFF
--- a/docs/ai-agents/setup/agent-builder-codes.mdx
+++ b/docs/ai-agents/setup/agent-builder-codes.mdx
@@ -34,7 +34,7 @@ Response:
 ```json Response
 {
   "builderCode": "bc_a1b2c3d4",
-  "walletAddress": "0x...",
+  "walletAddress": "0x..."
 }
 ```
 

--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 


### PR DESCRIPTION
## Summary

Removes the trailing comma from the JSON response example in `agent-builder-codes.mdx`.

## Problem

The response example contained a trailing comma which is invalid JSON and would cause errors if developers copied it directly.

**Before:**
```json
{
  "builderCode": "bc_a1b2c3d4",
  "walletAddress": "0x...",
}
```

**After:**
```json
{
  "builderCode": "bc_a1b2c3d4",
  "walletAddress": "0x..."
}
```

Fixes #1313