### PR TITLE
docs(snapshots): add aria2c installation note before download commands

### DIFF
--- a/docs/base-chain/node-operators/snapshots.mdx
+++ b/docs/base-chain/node-operators/snapshots.mdx
@@ -21,6 +21,11 @@ These steps assume you are in the cloned `node` directory (the one containing `d
 
 2. **Download Snapshot**: Choose the appropriate snapshot for your network and client from the table below. Download it into the `node` directory.
 
+    The download commands use `aria2c` for faster multi-connection downloads. If it is not already installed, run:
+    ```bash
+    sudo apt-get install -y aria2
+    ```
+
     | Network  | Snapshot Type | Download Command |
     | -------- | ------------- | ---------------- |
     | Testnet  | Archive (recommended)| `aria2c -c -x 16 -s 16 "https://sepolia-reth-archive-snapshots.base.org/$(curl -s https://sepolia-reth-archive-snapshots.base.org/latest)"` |


### PR DESCRIPTION
Fixes #1421.

The snapshot download commands were recently updated to use aria2c instead of wget. aria2c is not installed by default on Ubuntu and the page had no mention of this. Added a short note with the install command before the download table so operators do not hit command not found when following the guide.