### PR TITLE
fix(docs): update stale Apps quickstart links

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1782,7 +1782,7 @@
     },
     {
       "source": "/mini-apps/overview",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/features/wallet",
@@ -2146,27 +2146,27 @@
     },
     {
       "source": "/cookbook/growth/cast-actions",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/deploy-to-vercel",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/email-campaigns",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/gating-and-redirects",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/hyperframes",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/retaining-users",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/payments/build-ecommerce-app",
@@ -2178,19 +2178,19 @@
     },
     {
       "source": "/cookbook/social/convert-farcaster-frame",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/social/farcaster-nft-minting-guide",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/social/farcaster-no-code-nft-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/cast-actions",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/commerce/build-an-ecommerce-app",
@@ -2198,35 +2198,35 @@
     },
     {
       "source": "/cookbook/use-case-guides/create-email-campaigns",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/creator/convert-farcaster-frame-to-open-frame",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/deploy-to-vercel",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/gating-and-redirects",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/hyperframes",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/nft-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/no-code-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/retaining-users",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/transactions",
@@ -2638,7 +2638,7 @@
     },
     {
       "source": "/use-cases/decentralize-social-app",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/use-cases/defi-your-app",
@@ -2686,11 +2686,11 @@
     },
     {
       "source": "/base-app/introduction/what-are-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/introduction/why-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/overview",
@@ -2710,11 +2710,11 @@
     },
     {
       "source": "/base-app/miniapps/quickstart",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/build-with-minikit/quickstart",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/existing-apps/:slug*",
@@ -2726,15 +2726,15 @@
     },
     {
       "source": "/mini-apps/quickstart/new-apps/:slug*",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/build-with-minikit/mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/search-and-discovery",
@@ -2794,15 +2794,15 @@
     },
     {
       "source": "/mini-apps/quickstart/new-apps/install",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/new-apps/deploy",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/new-apps/create-manifest",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/design-ux/:slug*",
@@ -2898,7 +2898,7 @@
     },
     {
       "source": "/cookbook/onchain-social",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/defi-your-app",
@@ -2926,11 +2926,11 @@
     },
     {
       "source": "/cookbook/introduction-to-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/ai-powered-development-fundamentals",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/mastering-ai-prompt-engineering",
@@ -2938,7 +2938,7 @@
     },
     {
       "source": "/cookbook/essential-documentation-resources",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/ai-assisted-documentation-reading",
@@ -2950,7 +2950,7 @@
     },
     {
       "source": "/cookbook/minikit/build-your-mini-app-with-prompt",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/converting-customizing-mini-apps",
@@ -3054,7 +3054,7 @@
     },
     {
       "source": "/mini-apps/quickstart/create-new-miniapp",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/growth/build-viral-mini-apps",

--- a/docs/get-started/learning-resources.mdx
+++ b/docs/get-started/learning-resources.mdx
@@ -18,6 +18,6 @@ We will be adding more learning resources to help you build on Base. Stay tuned 
 - New educational content
 
 In the meantime, check out the following resources:
-- [Base Account](/base-account/overview/what-is-base-account), [Apps](/apps/quickstart/create-new-app), and [Base Chain](/base-chain/quickstart/why-base) for building on Base.
+- [Base Account](/base-account/overview/what-is-base-account), [Apps](/apps/quickstart/build-app), and [Base Chain](/base-chain/quickstart/why-base) for building on Base.
 - [CryptoZombies](https://cryptozombies.io/) and [Solidity by Example](https://solidity-by-example.org/) for learning Solidity.
 - [Base Prompt Library](/get-started/prompt-library) for building with AI.


### PR DESCRIPTION
## Summary

Updates stale Apps quickstart references from `/apps/quickstart/create-new-app` to the existing `/apps/quickstart/build-app` route.

## Changes

- Updated stale redirect destinations in [docs/docs.json](cci:7://file:///C:/Users/Zeki/CascadeProjects/base-docs-research/docs/docs.json:0:0-0:0)
- Updated the Apps link in [docs/get-started/learning-resources.mdx](cci:7://file:///C:/Users/Zeki/CascadeProjects/base-docs-research/docs/get-started/learning-resources.mdx:0:0-0:0)

## Why

`/apps/quickstart/create-new-app` does not exist and returns 404. The current Apps quickstart page is `/apps/quickstart/build-app`.

Fixes #1423 