### PR TITLE
fix(docs): remove trailing comma from JSON response example in agent-builder-codes

### DIFF
--- a/docs/ai-agents/setup/agent-builder-codes.mdx
+++ b/docs/ai-agents/setup/agent-builder-codes.mdx
@@ -34,7 +34,7 @@ Response:
 ```json Response
 {
   "builderCode": "bc_a1b2c3d4",
-  "walletAddress": "0x...",
+  "walletAddress": "0x..."
 }
 ```
 


### PR DESCRIPTION
## Summary

Removes the trailing comma from the JSON response example in `agent-builder-codes.mdx`.

## Problem

The response example contained a trailing comma which is invalid JSON.

**Before:**
```json
{
  "builderCode": "bc_a1b2c3d4",
  "walletAddress": "0x...",
}
```

**After:**
```json
{
  "builderCode": "bc_a1b2c3d4",
  "walletAddress": "0x..."
}
```

Fixes #1313
