### PR TITLE
fix(docs): fix typo "Etherum" → "Ethereum" in diffs-ethereum-base

### DIFF
--- a/docs/base-chain/network-information/diffs-ethereum-base.mdx
+++ b/docs/base-chain/network-information/diffs-ethereum-base.mdx
@@ -3,7 +3,7 @@ title: "Differences between Ethereum and Base"
 sidebarTitle: 'Differences: Ethereum & Base'
 ---
 
-Base is built to be as compatible as possible to Etherum, and there are very few differences when it comes to building on Base versus Ethereum.
+Base is built to be as compatible as possible to Ethereum, and there are very few differences when it comes to building on Base versus Ethereum.
 
 However, there are still some minor discrepancies between the behavior of Base and Ethereum that you should be aware of when building apps on top of Base.
 


### PR DESCRIPTION
Fixes a typo in the opening sentence. "Etherum" should be "Ethereum".

**What changed? Why?**
Fixed a typo: "Etherum" → "Ethereum" in the opening sentence.
**Notes to reviewers**

**How has it been tested?**
Docs-only change, no code affected.