### PR TITLE
fix: convert http:// links to https:// in docs

### DIFF
--- a/docs/apps/builder-codes/app-developers.mdx
+++ b/docs/apps/builder-codes/app-developers.mdx
@@ -6,7 +6,7 @@ description: "Integrate Builder Codes into your app using Wagmi or Viem to attri
 
 ## Automatic Attribution on Base
 
-Once your app is registered on [base.dev](http://base.dev/), the Base App will auto-append your Builder Code to transactions its users make in your app (e.g. via your app, or the Base App's browser). This powers your onchain analytics in [base.dev](http://base.dev/) and qualifies you for potential future rewards.
+Once your app is registered on [base.dev](https://base.dev/), the Base App will auto-append your Builder Code to transactions its users make in your app (e.g. via your app, or the Base App's browser). This powers your onchain analytics in [base.dev](https://base.dev/) and qualifies you for potential future rewards.
 
 ## Integrating Outside the Base App
 

--- a/docs/base-account/basenames/basenames-faq.mdx
+++ b/docs/base-account/basenames/basenames-faq.mdx
@@ -25,12 +25,12 @@ Basenames are priced based on name length, and are designed to be globally acces
 
 You can get one free Basename (5+ letters) for one year if you meet any of the below criteria:
 
-- [Coinbase Verification](http://coinbase.com/onchain-verify)
+- [Coinbase Verification](https://coinbase.com/onchain-verify)
 - [Summer Pass Level 3 NFT](https://wallet.coinbase.com/ocs)
 - [Buildathon participant NFT](https://onchain-summer.devfolio.co/)
 - [base.eth NFT holder](https://opensea.io/collection/base-org-base-eth)
 - cb.id username (acquired prior to Fri Aug 9, 2024)
-- [BNS name owner](http://basename.app) - free 4+ letter name (basename.app)
+- [BNS name owner](https://basename.app) - free 4+ letter name (basename.app)
 
 An equivalent-value discount of 0.001 ETH will be applied if registering a shorter name, or registering for more than 1 year, with the exception of the BNS name owner discount (valued at 0.01 ETH per unique address). You will need to pay the standard registration fees if you wish to keep your Basename after your initial discount has been fully applied. Discounts are only applied once, and are limited to one per address. Even if you meet multiple criteria, you will only be eligible for a single discount on one Basename. If you satisfy multiple criteria, we will automatically apply the highest-value discount to your registration.
 
@@ -82,7 +82,7 @@ Transferring all 3 to the same address will fully transfer ownership of the Base
 
 Step by step:
 
-- Navigate to [base.org/names](http://base.org/names)
+- Navigate to [base.org/names](https://base.org/names)
 - Sign in with wallet that owns the basename
 - Click "My Basenames" in the top right corner
 - Click the three dots of the basename you want to transfer and click transfer name

--- a/docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx
+++ b/docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx
@@ -9,7 +9,7 @@ Below are some popular wallet libraries and what we know of their plans for day 
 | ---------------------------------------------------------------------------------- | ------- |
 | [Dynamic](https://docs.dynamic.xyz/wallets/advanced-wallets/coinbase-smart-wallet) | ✅      |
 | [Privy](https://docs.privy.io/guide/react/recipes/misc/coinbase-smart-wallets)     | ✅      |
-| [ThirdWeb](http://portal.thirdweb.com/connect)                                     | ✅      |
+| [ThirdWeb](https://portal.thirdweb.com/connect)                                     | ✅      |
 | [ConnectKit](https://docs.family.co/connectkit)                                    | ✅      |
 | [Web3Modal](https://docs.reown.com/web3modal/react/smart-accounts)                 | ✅      |
 | [Web3-Onboard](https://www.blocknative.com/coinbase-wallet-integration)            | ✅      |

--- a/docs/get-started/base-mentorship-program.mdx
+++ b/docs/get-started/base-mentorship-program.mdx
@@ -23,7 +23,7 @@ Base Mentors are experienced founders, operators, and subject matter experts acr
 | Anthony Bassili | [Coinbase Asset Management](https://x.com/SmartestBeta) |
 | Antonio García Martínez | [Spindl (acq. Coinbase)](https://x.com/antoniogm) |
 | Conor Grogan | [Coinbase](https://x.com/jconorgrogan) |
-| Conner Swenberg | [Station Labs (acq. Coinbase)](http://x.com/ilikesymmetry) |
+| Conner Swenberg | [Station Labs (acq. Coinbase)](https://x.com/ilikesymmetry) |
 | Dariush Aghai | [Study Hall Creative](https://studyhall.design/about) |
 | David Espinel | [Social Graph Ventures](https://www.socialgraph.vc/team) |
 | Elena Nadolinski | [Iron Fish (acq. Coinbase)](https://x.com/leanthebean) |

--- a/docs/terms-of-service.mdx
+++ b/docs/terms-of-service.mdx
@@ -111,7 +111,7 @@ Any questions, comments, suggestions, ideas, feedback, reviews, or other informa
 
 12. # **Privacy** 
 
-For more information regarding our collection, use, and disclosure of personal data and certain other data, please see our [Privacy Policy](http://docs.base.org/privacy-policy).  The processing of personal data by Coinbase as a processor will be subject to any data processing agreement that you enter into with Coinbase.
+For more information regarding our collection, use, and disclosure of personal data and certain other data, please see our [Privacy Policy](https://docs.base.org/privacy-policy).  The processing of personal data by Coinbase as a processor will be subject to any data processing agreement that you enter into with Coinbase.
 
 13. # **Third-Party Services**
 


### PR DESCRIPTION
## Summary

Converts 8 instances of `http://` URLs to `https://` across 5 documentation files to prevent mixed-content warnings and ensure secure connections to external and internal Base resources.

## Changes

| File | Link |
|------|------|
| `docs/terms-of-service.mdx` | Privacy Policy link (line 114) |
| `docs/base-account/basenames/basenames-faq.mdx` | 3 links (lines 28, 33, 85) |
| `docs/apps/builder-codes/app-developers.mdx` | 2 base.dev links (line 9) |
| `docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx` | ThirdWeb portal link |
| `docs/get-started/base-mentorship-program.mdx` | X/Twitter profile link |

## Why

- Mixed-content warnings in browsers can erode trust, especially in legal documents like the Terms of Service
- All target domains (coinbase.com, base.org, base.dev, basename.app, thirdweb.com, x.com) force HTTPS via redirect anyway — using `https://` directly avoids unnecessary 301 redirects
- Consistency: most other links in the same files already use `https://`

## Testing

No content changes — only protocol prefix. All target URLs verified accessible via HTTPS.