### PR TITLE
fix: typo and broken anchor in legal docs

### DIFF
--- a/docs/apps/builder-codes/app-developers.mdx
+++ b/docs/apps/builder-codes/app-developers.mdx
@@ -6,7 +6,7 @@ description: "Integrate Builder Codes into your app using Wagmi or Viem to attri
 
 ## Automatic Attribution on Base
 
-Once your app is registered on [base.dev](http://base.dev/), the Base App will auto-append your Builder Code to transactions its users make in your app (e.g. via your app, or the Base App's browser). This powers your onchain analytics in [base.dev](http://base.dev/) and qualifies you for potential future rewards.
+Once your app is registered on [base.dev](https://base.dev/), the Base App will auto-append your Builder Code to transactions its users make in your app (e.g. via your app, or the Base App's browser). This powers your onchain analytics in [base.dev](https://base.dev/) and qualifies you for potential future rewards.
 
 ## Integrating Outside the Base App
 

--- a/docs/base-account/basenames/basenames-faq.mdx
+++ b/docs/base-account/basenames/basenames-faq.mdx
@@ -25,12 +25,12 @@ Basenames are priced based on name length, and are designed to be globally acces
 
 You can get one free Basename (5+ letters) for one year if you meet any of the below criteria:
 
-- [Coinbase Verification](http://coinbase.com/onchain-verify)
+- [Coinbase Verification](https://coinbase.com/onchain-verify)
 - [Summer Pass Level 3 NFT](https://wallet.coinbase.com/ocs)
 - [Buildathon participant NFT](https://onchain-summer.devfolio.co/)
 - [base.eth NFT holder](https://opensea.io/collection/base-org-base-eth)
 - cb.id username (acquired prior to Fri Aug 9, 2024)
-- [BNS name owner](http://basename.app) - free 4+ letter name (basename.app)
+- [BNS name owner](https://basename.app) - free 4+ letter name (basename.app)
 
 An equivalent-value discount of 0.001 ETH will be applied if registering a shorter name, or registering for more than 1 year, with the exception of the BNS name owner discount (valued at 0.01 ETH per unique address). You will need to pay the standard registration fees if you wish to keep your Basename after your initial discount has been fully applied. Discounts are only applied once, and are limited to one per address. Even if you meet multiple criteria, you will only be eligible for a single discount on one Basename. If you satisfy multiple criteria, we will automatically apply the highest-value discount to your registration.
 
@@ -82,7 +82,7 @@ Transferring all 3 to the same address will fully transfer ownership of the Base
 
 Step by step:
 
-- Navigate to [base.org/names](http://base.org/names)
+- Navigate to [base.org/names](https://base.org/names)
 - Sign in with wallet that owns the basename
 - Click "My Basenames" in the top right corner
 - Click the three dots of the basename you want to transfer and click transfer name

--- a/docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx
+++ b/docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx
@@ -9,7 +9,7 @@ Below are some popular wallet libraries and what we know of their plans for day 
 | ---------------------------------------------------------------------------------- | ------- |
 | [Dynamic](https://docs.dynamic.xyz/wallets/advanced-wallets/coinbase-smart-wallet) | ✅      |
 | [Privy](https://docs.privy.io/guide/react/recipes/misc/coinbase-smart-wallets)     | ✅      |
-| [ThirdWeb](http://portal.thirdweb.com/connect)                                     | ✅      |
+| [ThirdWeb](https://portal.thirdweb.com/connect)                                     | ✅      |
 | [ConnectKit](https://docs.family.co/connectkit)                                    | ✅      |
 | [Web3Modal](https://docs.reown.com/web3modal/react/smart-accounts)                 | ✅      |
 | [Web3-Onboard](https://www.blocknative.com/coinbase-wallet-integration)            | ✅      |

--- a/docs/base-chain/specs/upgrades/holocene/derivation.mdx
+++ b/docs/base-chain/specs/upgrades/holocene/derivation.mdx
@@ -227,7 +227,7 @@ better worst-case cached data usage.
 
 - The frame queue only ever holds frames from a single batcher transaction.
 - The channel bank only ever holds a single staging channel, that is either being built up by
-incoming frames, or is is being processed by later stages.
+incoming frames, or is being processed by later stages.
 - The batch queue only ever holds at most a single span batch (that is being processed) and a single singular
 batch (from the span batch, or the staging channel directly)
 - The sync start greatly simplifies in the average production case.

--- a/docs/get-started/base-mentorship-program.mdx
+++ b/docs/get-started/base-mentorship-program.mdx
@@ -23,7 +23,7 @@ Base Mentors are experienced founders, operators, and subject matter experts acr
 | Anthony Bassili | [Coinbase Asset Management](https://x.com/SmartestBeta) |
 | Antonio García Martínez | [Spindl (acq. Coinbase)](https://x.com/antoniogm) |
 | Conor Grogan | [Coinbase](https://x.com/jconorgrogan) |
-| Conner Swenberg | [Station Labs (acq. Coinbase)](http://x.com/ilikesymmetry) |
+| Conner Swenberg | [Station Labs (acq. Coinbase)](https://x.com/ilikesymmetry) |
 | Dariush Aghai | [Study Hall Creative](https://studyhall.design/about) |
 | David Espinel | [Social Graph Ventures](https://www.socialgraph.vc/team) |
 | Elena Nadolinski | [Iron Fish (acq. Coinbase)](https://x.com/leanthebean) |

--- a/docs/terms-of-service.mdx
+++ b/docs/terms-of-service.mdx
@@ -10,7 +10,7 @@ hide_table_of_contents: true
 
 We’re excited you’re interested in Base, a layer-two optimistic rollup on the Ethereum public blockchain. While we do not control Base, these Terms of Service (“Terms”) constitute a legally binding contract made between you and Coinbase Technologies, Inc. (“Coinbase,” “we,” or “us”) that governs your access to and use of the Coinbase Sequencer, Base Testnet, Basenames Interface, Basenames Profile Pages, and Dashboard, each of which is defined below (collectively, the “Services”). By using the Services in any way, you agree to be bound by these Terms. If you do not accept the terms and conditions of these Terms, you are not permitted to access or otherwise use the Services.
 
-**BEFORE WE INCLUDE ANY OTHER DETAILS, WE WANT TO GIVE YOU NOTICE OF SOMETHING UP FRONT: BY AGREEING TO THESE TERMS, YOU AND WE AGREE TO RESOLVE ANY DISPUTES WE MAY HAVE WITH EACH OTHER VIA BINDING ARBITRATION OR IN SMALL CLAIMS COURT (INSTEAD OF A COURT OF GENERAL JURISDICTION), AND YOU AGREE TO DO SO AS AN INDIVIDUAL (INSTEAD OF, FOR EXAMPLE, AS A REPRESENTATIVE OR MEMBER OF A CLASS IN A CLASS ACTION). TO THE EXTENT THAT THE LAW ALLOWS, YOU ALSO WAIVE YOUR RIGHT TO A TRIAL BY JURY. FOR MORE INFORMATION, SEE OUR [ARBITRATION AGREEMENT IN APPENDIX 1 BELOW](#bookmark=id.9q2273ceqaa4) “SEQUENCER, TESTNET, BASENAMES INTERFACE, AND DASHBOARD TERMS ARBITRATION AGREEMENT.”**
+**BEFORE WE INCLUDE ANY OTHER DETAILS, WE WANT TO GIVE YOU NOTICE OF SOMETHING UP FRONT: BY AGREEING TO THESE TERMS, YOU AND WE AGREE TO RESOLVE ANY DISPUTES WE MAY HAVE WITH EACH OTHER VIA BINDING ARBITRATION OR IN SMALL CLAIMS COURT (INSTEAD OF A COURT OF GENERAL JURISDICTION), AND YOU AGREE TO DO SO AS AN INDIVIDUAL (INSTEAD OF, FOR EXAMPLE, AS A REPRESENTATIVE OR MEMBER OF A CLASS IN A CLASS ACTION). TO THE EXTENT THAT THE LAW ALLOWS, YOU ALSO WAIVE YOUR RIGHT TO A TRIAL BY JURY. FOR MORE INFORMATION, SEE OUR [ARBITRATION AGREEMENT IN APPENDIX 1 BELOW](#appendix-1) “SEQUENCER, TESTNET, BASENAMES INTERFACE, AND DASHBOARD TERMS ARBITRATION AGREEMENT.”**
 
 1. # **Base and Bridging Smart Contracts**
 
@@ -198,6 +198,8 @@ If you reside in the United States or Canada, and if you have a dispute with us 
 **Disputes with Users Who Reside Outside the United States and Canada**
 
 If you do not reside in the United States or Canada, the Arbitration Agreement in Appendix 1 does not apply to you and you may resolve any claim you have with us relating to, arising out of, or in any way in connection with our Terms, us, or our Services in a court of competent jurisdiction.
+
+<a id="appendix-1"></a>
 
 **APPENDIX 1: ARBITRATION AGREEMENT**
 

--- a/docs/terms-of-service.mdx
+++ b/docs/terms-of-service.mdx
@@ -111,7 +111,7 @@ Any questions, comments, suggestions, ideas, feedback, reviews, or other informa
 
 12. # **Privacy** 
 
-For more information regarding our collection, use, and disclosure of personal data and certain other data, please see our [Privacy Policy](http://docs.base.org/privacy-policy).  The processing of personal data by Coinbase as a processor will be subject to any data processing agreement that you enter into with Coinbase.
+For more information regarding our collection, use, and disclosure of personal data and certain other data, please see our [Privacy Policy](https://docs.base.org/privacy-policy).  The processing of personal data by Coinbase as a processor will be subject to any data processing agreement that you enter into with Coinbase.
 
 13. # **Third-Party Services**
 


### PR DESCRIPTION
## Summary

Fixes two unrelated but small issues in documentation:

1. **Duplicate word "is is"** in the Holocene upgrade derivation spec
2. **Broken anchor link** in the Terms of Service pointing to a Google Docs bookmark ID that has no equivalent in the rendered Markdown

## Changes

### 1. `docs/base-chain/specs/upgrades/holocene/derivation.mdx` (line 230)

```diff
- or is is being processed by later stages
+ or is being processed by later stages
```

### 2. `docs/terms-of-service.mdx`

The intro section links to `#bookmark=id.9q2273ceqaa4` — a Google Docs internal bookmark ID copied during migration. The target section "APPENDIX 1: ARBITRATION AGREEMENT" is bold text without an HTML anchor, so this link 404s.

```diff
- [ARBITRATION AGREEMENT IN APPENDIX 1 BELOW](#bookmark=id.9q2273ceqaa4)
+ [ARBITRATION AGREEMENT IN APPENDIX 1 BELOW](#appendix-1)
```

Added an HTML anchor before the appendix heading:

```diff
+ <a id="appendix-1"></a>
**APPENDIX 1: ARBITRATION AGREEMENT**
```

## Why

- The "is is" duplicate is unambiguous and worth fixing in a technical spec doc
- The arbitration agreement anchor is in a legal document — broken self-references undermine the document's usability and trust