### PR TITLE
docs(base-contracts): fix incorrect footnote about L2 address consist…

### DIFF
--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -48,7 +48,7 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | EASSchemaRegistry             | [0x4200000000000000000000000000000000000020](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000020) |
 | LegacyERC20ETH                | [0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000](https://sepolia.basescan.org/address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000) |
 
-\*_L2 contract addresses are the same on both mainnet and testnet._
+\*_Most L2 contract addresses are the same on both mainnet and testnet. Exception: `OptimismMintableERC20Factory` uses a different address on mainnet (`0xF10122D428B4bc8A9d050D06a2037259b4c4B83B`) than on testnet (`0x4200000000000000000000000000000000000012`)._
 
 ## L1 Contract Addresses
 


### PR DESCRIPTION
The footnote at the bottom of the L2 address table stated that all L2 contract addresses are the same on mainnet and testnet. This is incorrect — `OptimismMintableERC20Factory` uses different addresses on mainnet and testnet.

Updated the footnote to note this exception explicitly.

Fixes #1453
