### PR TITLE
update bug bounty page

### DIFF
--- a/docs/base-chain/security/report-vulnerability.mdx
+++ b/docs/base-chain/security/report-vulnerability.mdx
@@ -4,16 +4,20 @@ title: Reporting Vulnerabilities
 description: The Base procedures for reporting vulnerabilities.
 ---
 
-All potential vulnerability reports can be submitted via the [HackerOne](https://hackerone.com/coinbase) platform.
-
-The HackerOne platform allows us to have a centralized and single reporting source for us to deliver optimized SLAs and results. All reports submitted to the platform are triaged around the clock by our team of Coinbase engineers with domain knowledge, assuring the best quality of review.
-
 ## Bug bounty program
 
 In line with our strategy of being the safest way for users to access crypto:
 
-- Coinbase will be extending our [best-in-industry](https://www.coinbase.com/blog/celebrating-10-years-of-our-bug-bounty-program) million-dollar [HackerOne bug bounty program](https://hackerone.com/coinbase?type=team) to cover the Base network, the Base bridge contracts, and Base infrastructure.
-- Coinbase's bug bounty program will run alongside Optimism's existing [Immunefi Bedrock bounty program](https://immunefi.com/bounty/optimism/) to support the open source [Bedrock](https://docs.optimism.io/stack/getting-started) OP Stack framework.
+- Coinbase extended our [best-in-industry](https://www.coinbase.com/blog/celebrating-10-years-of-our-bug-bounty-program) million-dollar [HackerOne bug bounty program](https://hackerone.com/coinbase?type=team) to cover the Base network and Base infrastructure.
+- Coinbase has launched a 5 million-dollar [Cantina bug bounty program](https://cantina.xyz/code/55316f42-3c5e-4746-9bd0-0f18dcbc344b) to cover all deployed smart contracts for Base, and those used as part of Coinbase products and services.
 
-For more information on reporting vulnerabilities and our HackerOne bug bounty program, view our [security program policies](https://hackerone.com/coinbase?view_policy=true).
+## Reporting vulnerabilities
+
+Submit potential vulnerability reports via the appropriate platform below:
+
+1. [**HackerOne**](https://hackerone.com/coinbase) — For offchain components and services. All reports are triaged around the clock by Coinbase engineers with domain knowledge. For more information, view our [security program policies](https://hackerone.com/coinbase?view_policy=true).
+
+2. [**Cantina**](https://cantina.xyz/bounties/55316f42-3c5e-4746-9bd0-0f18dcbc344b) — For deployed smart contracts. For more information on what smart contracts are within scope, view the [Tier 0](https://cantina.xyz/code/55316f42-3c5e-4746-9bd0-0f18dcbc344b/overview?overviewTab=1&assetGroup=0) and [Tier 1](https://cantina.xyz/code/55316f42-3c5e-4746-9bd0-0f18dcbc344b/overview?overviewTab=1&assetGroup=1) scope guides.
+
+For all other security-related inquiries, contact [security@coinbase.com](mailto:security@coinbase.com).
 


### PR DESCRIPTION
**What changed? Why?**
Replaces the outdated ImmuneFi/Bedrock bounty reference with the new Cantina bug bounty program for Base smart contracts. Restructures the page to clearly direct reporters to the right platform (HackerOne for offchain components and Cantina for deployed smart contracts), mirroring the [base/base SECURITY.md](https://github.com/base/base/blob/main/SECURITY.md).

**Notes to reviewers**

**How has it been tested?**
Locally