### PR TITLE
docs(network-faucets): update Chainstack faucet requirement — mainnet…

### DIFF
--- a/docs/base-chain/network-information/network-faucets.mdx
+++ b/docs/base-chain/network-information/network-faucets.mdx
@@ -38,10 +38,10 @@ Requests to Bware Labs Faucet are limited to one claim per 24 hours.
 
 ## Chainstack Faucet
 
-[Chainstack Faucet](https://faucet.chainstack.com/) dispenses Base ETH based on your Chainstack platform API key.
+[Chainstack Faucet](https://faucet.chainstack.com/base-testnet-faucet) dispenses Base ETH to wallets with a minimum balance of 0.08 ETH on Ethereum mainnet.
 
 <Note>
-Chainstack faucet drips 0.5 ETH every 24 hours.
+Chainstack faucet drips 0.5 ETH every 24 hours. A minimum of 0.08 ETH on Ethereum mainnet is required to claim.
 </Note>
 
 


### PR DESCRIPTION
The Chainstack Faucet description was outdated. It previously stated that access requires a Chainstack platform API key, but Chainstack has since changed their requirements. The faucet now requires a minimum balance of 0.08 ETH on Ethereum mainnet.

Updated the description and note to reflect the current access requirements, and corrected the faucet link to point directly to the Base testnet faucet page.

Fixes #1458