### PR TITLE
docs(ai-agents/payments): add supported networks and tokens section t…

### DIFF
--- a/docs/ai-agents/payments/pay-for-services-with-x402.mdx
+++ b/docs/ai-agents/payments/pay-for-services-with-x402.mdx
@@ -143,7 +143,23 @@ The [CDP Agentic Wallet](https://docs.cdp.coinbase.com/agentic-wallet/) [`pay-fo
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
+## Supported networks and tokens
 
+x402 is chain-agnostic by design. The CDP facilitator currently supports the following networks:
+
+| Network | Type | Chain ID |
+| ------- | ---- | -------- |
+| Base | EVM (L2) | eip155:8453 |
+| Base Sepolia | EVM Testnet | eip155:84532 |
+| Solana | SVM | solana:mainnet |
+
+Accepted tokens vary by facilitator. The CDP facilitator supports:
+
+- **USDC** — recommended; uses EIP-3009 (gasless, no on-chain approval needed)
+- **EURC** — uses EIP-3009
+- **Any ERC-20** — supported via Permit2 (requires one-time on-chain approval)
+
+For a full list of supported networks and third-party facilitators, see the [x402 network support docs](https://docs.cdp.coinbase.com/x402/network-support) and the [x402 ecosystem](https://www.x402.org/ecosystem).
 ## Related
 
 <CardGroup cols={2}>


### PR DESCRIPTION
The page description promises information about "which networks and tokens are supported" but the page contained no such section.

This PR adds a "Supported networks and tokens" section covering:
- CDP facilitator supported networks (Base, Base Sepolia, Solana) with CAIP-2 chain IDs
- Accepted tokens (USDC via EIP-3009, EURC, any ERC-20 via Permit2)
- Links to the x402 network support docs and ecosystem page for a full list

Fixes #1460