### PR TITLE
docs: add noopener to verify social accounts example

### DIFF
--- a/docs/base-account/guides/verify-social-accounts.mdx
+++ b/docs/base-account/guides/verify-social-accounts.mdx
@@ -428,7 +428,7 @@ function redirectToVerifyMiniApp(provider: string) {
   const miniAppUrl = `${config.baseVerifyMiniAppUrl}?${params.toString()}`
 
   const deepLink = `cbwallet://miniapp?url=${encodeURIComponent(miniAppUrl)}`
-  window.open(deepLink, '_blank')
+  window.open(deepLink, '_blank', 'noopener,noreferrer')
 }
 ```
 


### PR DESCRIPTION
## Summary

- Adds `noopener,noreferrer` to the `window.open(..., '_blank')` example in the social verification guide.
- Fixes #1470.

## Testing

- Ran `node scripts/lint-mdx.js docs/base-account/guides/verify-social-accounts.mdx`.
- The command currently fails because this file already has existing frontmatter and code block language issues unrelated to this one-line change.
