### PR TITLE
docs: add x402 network and token support

### DIFF
--- a/docs/ai-agents/payments/pay-for-services-with-x402.mdx
+++ b/docs/ai-agents/payments/pay-for-services-with-x402.mdx
@@ -36,6 +36,21 @@ Any agent with a funded wallet can pay for any x402-enabled API — no pre-exist
 
 [Learn more about x402 →](https://docs.cdp.coinbase.com/x402/docs/client-server-model)
 
+## Supported networks and tokens
+
+x402 uses CAIP-2 network identifiers in payment requirements. For Base, the main identifiers are:
+
+| Network | CAIP-2 identifier | Common token |
+|---------|-------------------|--------------|
+| Base mainnet | `eip155:8453` | USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Base Sepolia | `eip155:84532` | USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+
+The x402 reference SDKs support EVM-compatible chains through `@x402/evm`. EIP-3009 tokens such as USDC and EURC can use gasless transfer authorizations, while other ERC-20 tokens can use Permit2 when the token and facilitator support it.
+
+Facilitator support is narrower than SDK support. The CDP facilitator currently supports Base, Base Sepolia, Polygon, Arbitrum, World, World Sepolia, Solana, and Solana Devnet. The public x402.org testnet facilitator supports Base Sepolia and Solana Devnet. Always read the returned payment requirement's `accepts[]` entries before signing; the selected entry defines the exact `network`, `asset`, `payTo`, and `maxAmountRequired` for that request.
+
+[Full x402 network support →](https://docs.cdp.coinbase.com/x402/network-support)
+
 ## Making x402 requests
 
 ### CDP Agentic Wallet


### PR DESCRIPTION
## Summary

- Adds the missing supported networks/tokens section promised by the x402 payment page description
- Calls out Base mainnet and Base Sepolia CAIP-2 identifiers plus common USDC addresses
- Clarifies the difference between reference SDK support and CDP/x402.org facilitator support
- Reminds custom clients to select from `accepts[]` before signing

Closes #1460.

## Testing

- `git diff --check`
- `node scripts/lint-mdx.js docs/ai-agents/payments/pay-for-services-with-x402.mdx` currently reports missing language specifiers on existing closing code fences in this page; this PR does not add or change code fences.