### PR TITLE
fix(docs): correct Ethereum typo

### DIFF
--- a/docs/base-chain/network-information/diffs-ethereum-base.mdx
+++ b/docs/base-chain/network-information/diffs-ethereum-base.mdx
@@ -3,7 +3,7 @@ title: "Differences between Ethereum and Base"
 sidebarTitle: 'Differences: Ethereum & Base'
 ---
 
-Base is built to be as compatible as possible to Etherum, and there are very few differences when it comes to building on Base versus Ethereum.
+Base is built to be as compatible as possible to Ethereum, and there are very few differences when it comes to building on Base versus Ethereum.
 
 However, there are still some minor discrepancies between the behavior of Base and Ethereum that you should be aware of when building apps on top of Base.
 


### PR DESCRIPTION
## Summary
- Corrects the `Etherum` typo to `Ethereum` on the Differences between Ethereum and Base page.

## Verification
- `grep -R "Etherum" -n docs/base-chain/network-information/diffs-ethereum-base.mdx || true`
- `git diff --check`

Closes #1440