### PR TITLE
docs: enhance node-providers page with Flashblocks notes and self-hosting

### DIFF
--- a/docs/base-chain/node-operators/update-node-providers
+++ b/docs/base-chain/node-operators/update-node-providers
@@ -1,0 +1,153 @@
+---
+title: 'Node Providers'
+description: 'Reliable RPC providers for Base. Production recommendations, Flashblocks support, self-hosting options, and comparison guidance.'
+---
+
+import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
+
+# Node Providers
+
+Choose a reliable RPC provider for building on **Base**. Public endpoints are rate-limited and **not suitable for production**.
+
+**Production best practices**:
+- Use dedicated endpoints with generous rate limits or unlimited plans.
+- Monitor uptime, latency, and errors.
+- Implement fallback providers.
+- Prefer providers with **Flashblocks** support for ~200ms preconfirmations and real-time UX.
+- Test WebSocket connections for subscriptions and event-driven apps.
+## Quick Comparison
+
+| Provider                  | Free Tier          | Flashblocks | Archive / Trace+Debug          | Key Strengths                              | Networks                          |
+|---------------------------|--------------------|-------------|--------------------------------|--------------------------------------------|-----------------------------------|
+| **Coinbase CDP**          | Yes (rate-limited) | —           | Limited                        | Highest reliability (Coinbase infra)       | Mainnet + Sepolia                |
+| **QuickNode**             | Yes                | Yes         | Yes                            | Flashblocks, Streams, Webhooks, Marketplace| Mainnet + Sepolia                |
+| **Alchemy**               | Robust             | Yes         | Yes                            | SDKs, enhanced APIs, excellent tooling    | Mainnet + Sepolia                |
+| **Chainstack**            | Yes                | Yes         | Yes (archive)                  | Geo-balanced, low latency                  | Mainnet + Sepolia                |
+| **dRPC NodeCloud**        | Yes                | Yes         | Varies                         | Smart routing, 180+ networks, analytics   | Mainnet + Sepolia                |
+| **GetBlock**              | Yes                | Yes         | Yes                            | Instant full nodes, pay-per-use            | Mainnet + Sepolia                |
+| **Tenderly Web3 Gateway** | Yes                | Likely      | Yes                            | Fast nodes + full dev tooling suite        | Mainnet + Sepolia                |
+| **OnFinality**            | Generous           | —           | Yes (paid)                     | High-performance archive + Trace/Debug     | Mainnet + Sepolia                |
+| **1RPC**                  | Yes                | —           | —                              | Privacy-preserving, on-chain attested      | Mainnet                          |
+| **All That Node**         | Yes                | —           | —                              | Multi-chain suite                          | Mainnet + Sepolia                |
+| **Ankr**                  | Yes                | —           | —                              | Decentralized node network                 | Mainnet + Sepolia                |
+| **Blast**                 | Yes                | —           | —                              | Decentralized APIs                         | Mainnet + Sepolia                |
+| **Blockdaemon**           | Yes ($0 plan)      | —           | —                              | Hosted nodes via Ubiquity                  | Mainnet + Sepolia                |
+| **BlockPI**               | Yes                | —           | —                              | High-quality RPC service network           | Mainnet + Sepolia                |
+| **Nodies DLB**            | Yes (public)       | —           | —                              | High-performance for OP Stack              | Mainnet + Testnet (on request)   |
+| **NodeReal**              | Yes                | —           | —                              | Easy-access node APIs                      | Mainnet                          |
+| **NOWNodes**              | Yes                | —           | —                              | No rate-limit dedicated nodes              | Mainnet                          |
+| **RockX**                 | Yes                | —           | —                              | Global node network                        | Mainnet                          |
+| **Stackup**               | Yes                | —           | —                              | ERC-4337 + account abstraction tools       | Mainnet + Sepolia                |
+| **SubQuery**              | Generous           | —           | —                              | Decentralized RPC network                  | Mainnet                          |
+| **Unifra**                | Yes                | —           | —                              | Reliable & scalable infrastructure         | Mainnet                          |
+| **Validation Cloud**      | Strong (50M CU)    | —           | —                              | High speed, no rate limits on scale tier   | Mainnet                          |
+
+**Notes**: 
+- Flashblocks support is actively expanding — check provider dashboards for latest availability and dedicated endpoints.
+- “— ” indicates not prominently advertised or confirmed at the time of writing.
+
+## Recommended Providers
+
+### Coinbase Developer Platform (CDP)
+
+[CDP](https://portal.cdp.coinbase.com/) provides an RPC endpoint that runs on the same node infrastructure that powers Coinbase’s retail exchange.
+
+- **Supported Networks**
+  - Base Mainnet
+  - Base Sepolia (Testnet)
+
+### QuickNode
+
+[QuickNode](https://www.quicknode.com/chains/base) offers access to the Base network with **Flashblocks** and archive data support.
+
+### Alchemy
+
+[Alchemy](https://dashboard.alchemy.com/?utm_source=chain_partner&utm_medium=referral&utm_campaign=base) — robust free tier with excellent SDKs and enhanced APIs.
+
+### Chainstack
+
+[Chainstack](https://chainstack.com/build-better-with-base/) — high-performing elastic nodes with Flashblocks support.
+
+## Full List of Providers
+
+(Kept largely as in official docs with minor enhancements for consistency)
+
+### 1RPC
+[1RPC](https://1rpc.io/) — Privacy-preserving, on-chain attested RPC. Free and paid plans.  
+**Networks**: Base Mainnet
+
+### All That Node
+[All That Node](https://www.allthatnode.com/base.dsrv) — Multi-chain suite.  
+**Networks**: Mainnet + Sepolia
+
+### Ankr
+[Ankr](https://www.ankr.com/rpc/base/) — Decentralized node network.  
+**Networks**: Mainnet + Sepolia
+
+### Blast
+[Blast](https://blastapi.io/public-api/base) — Decentralized APIs.  
+**Networks**: Mainnet + Sepolia
+
+### Blockdaemon
+[Blockdaemon](https://www.blockdaemon.com/protocols/base/) — Hosted nodes via Ubiquity.  
+**Networks**: Mainnet + Sepolia
+
+### BlockPI
+[BlockPI](https://blockpi.io/) — High-quality RPC service network.  
+**Networks**: Mainnet + Sepolia
+
+### dRPC NodeCloud
+[dRPC NodeCloud](https://drpc.org/nodecloud-multichain-rpc-management) — Smart routing across providers.  
+**Networks**: Mainnet + Sepolia
+
+### GetBlock
+[GetBlock](https://getblock.io/nodes/base/) — Instant full node access with Flashblocks support.  
+**Networks**: Mainnet + Sepolia
+
+### NodeReal
+[NodeReal](https://nodereal.io/) — Easy-access Base node APIs.  
+**Networks**: Base Mainnet
+
+### Nodies DLB
+[Nodies DLB](https://nodies.app) — High-performance for OP Stack chains.  
+**Networks**: Mainnet + Testnet (on request)
+
+### NOWNodes
+[NOWNodes](https://nownodes.io/nodes/basechain-base) — No rate-limit nodes.  
+**Networks**: Base Mainnet
+
+### OnFinality
+[OnFinality](https://onfinality.io) — High-performance archive + Trace/Debug (paid).  
+**Networks**: Mainnet + Sepolia
+
+### RockX
+[RockX](https://access.rockx.com) — Global node network.  
+**Networks**: Base Mainnet
+
+### Stackup
+[Stackup](https://www.stackup.sh/) — ERC-4337 infrastructure with hosted nodes.  
+**Networks**: Mainnet + Sepolia
+
+### SubQuery
+[SubQuery](https://subquery.network/rpc) — Decentralized RPC network.  
+**Networks**: Base Mainnet
+
+### Tenderly Web3 Gateway
+[Tenderly Web3 Gateway](https://tenderly.co/web3-gateway) — Fast nodes + full dev tooling.  
+**Networks**: Mainnet + Sepolia
+
+### Unifra
+[Unifra](https://www.unifra.io) — Reliable, scalable node infrastructure.  
+**Networks**: Base Mainnet
+
+### Validation Cloud
+[Validation Cloud](https://app.validationcloud.io/) — World’s fastest node provider (per Compare Nodes), strong free tier.  
+**Networks**: Base Mainnet
+
+## Self-Hosting
+
+For maximum control, privacy, or hybrid setups, run your own Base node.
+
+- Official repository: [base/node](https://github.com/base/node)
+- Supports Docker Compose with Reth (recommended) and other clients.
+- Full **Flashblocks** support when configured properly.


### PR DESCRIPTION
**What changed? Why?**

- The current /base-chain/node-operators/node-providers page is a solid list but varies in depth, lacks unified performance/Flashblocks notes (critical for Base's speed features), and has limited self-hosting guidance despite the official base/node repo.

- Common developer pain points (outages, rate limits, production readiness, real-time precons) appear in related discussions. Public RPCs are explicitly not for production.

- Improves onboarding (aligns with recent PRs focused on builder experience) and AI-friendliness (clearer for agents/LLMs to parse provider tradeoffs).

- Small, focused, high-impact: Better structure + cross-links + one new subsection without proliferation.

**Notes to reviewers**

- **Restructure the page slightly for scannability**: Intro with warnings/best practices, comparison table (or Tabs), enhanced provider entries (standardized: features, networks, Flashblocks support, links), new "Self-Hosting" subsection.

- **Add value**: Notes on Flashblocks/WebSocket support, rate limits, tracing/debug, production tips. Link to base/node repo and related guides.

- **Fixes/Updates**: Ensure all entries mention supported networks consistently; add/update any outdated links (based on current knowledge; validate in PR).

- **Cross-links**: To Quickstart (connecting), Flashblocks/apps, Cookbook examples.
