### PR TITLE
update networking table to include ingress/egress

### DIFF
--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -33,15 +33,26 @@ See the [Node Performance guide](/base-chain/node-operators/performance-tuning#h
 
 ### Networking
 
-Ensure the following ports are accessible (not blocked by firewall) for peer discovery and sync:
+Configure your firewall to allow the following inbound and outbound traffic. Operators with strict egress rules must open the outbound ports to connect to Base bootnodes.
+
+**Ingress (inbound)**
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
-| `30303` | TCP/UDP | P2P Discovery (discv4) & RLPx |
 | `9222` | TCP/UDP | Reth Discovery v5 (discv5) |
+| `30303` | TCP/UDP | P2P Discovery (discv4) & RLPx |
+
+**Egress (outbound)**
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| `9200` | UDP | Bootnode connectivity |
+| `9222` | TCP/UDP | Reth Discovery v5 (discv5) |
+| `30301` | TCP/UDP | Bootnode connectivity |
+| `30303` | TCP/UDP | P2P Discovery (discv4) & RLPx |
 
 <Note>
-Port `9222` is critical for Reth peer discovery. If this port is blocked, your node may have difficulty finding peers and syncing.
+Egress ports `9200` (UDP) and `30301` (TCP/UDP) are required to reach Base bootnodes. If outbound traffic to these ports is blocked, your node will fail to establish initial peer connections.
 </Note>
 
 ### Docker

--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -33,27 +33,28 @@ See the [Node Performance guide](/base-chain/node-operators/performance-tuning#h
 
 ### Networking
 
-Configure your firewall to allow the following inbound and outbound traffic. Operators with strict egress rules must open the outbound ports to connect to Base bootnodes.
+Configure your firewall to allow the following ports for peer discovery and sync. Operators with strict egress rules must open the outbound ports to connect to Base bootnodes.
 
-**Ingress (inbound)**
+<Tabs>
+  <Tab title="Ingress">
+    | Port | Protocol | Purpose |
+    |------|----------|---------|
+    | `9222` | TCP/UDP | Reth Discovery v5 (discv5) |
+    | `30303` | TCP/UDP | P2P Discovery (discv4) & RLPx |
+  </Tab>
+  <Tab title="Egress">
+    | Port | Protocol | Purpose |
+    |------|----------|---------|
+    | `9200` | UDP | Bootnode connectivity |
+    | `9222` | TCP/UDP | Reth Discovery v5 (discv5) |
+    | `30301` | TCP/UDP | Bootnode connectivity |
+    | `30303` | TCP/UDP | P2P Discovery (discv4) & RLPx |
 
-| Port | Protocol | Purpose |
-|------|----------|---------|
-| `9222` | TCP/UDP | Reth Discovery v5 (discv5) |
-| `30303` | TCP/UDP | P2P Discovery (discv4) & RLPx |
-
-**Egress (outbound)**
-
-| Port | Protocol | Purpose |
-|------|----------|---------|
-| `9200` | UDP | Bootnode connectivity |
-| `9222` | TCP/UDP | Reth Discovery v5 (discv5) |
-| `30301` | TCP/UDP | Bootnode connectivity |
-| `30303` | TCP/UDP | P2P Discovery (discv4) & RLPx |
-
-<Note>
-Egress ports `9200` (UDP) and `30301` (TCP/UDP) are required to reach Base bootnodes. If outbound traffic to these ports is blocked, your node will fail to establish initial peer connections.
-</Note>
+    <Note>
+    Ports `9200` (UDP) and `30301` (TCP/UDP) are required to reach Base bootnodes. If outbound traffic to these ports is blocked, your node will fail to establish initial peer connections.
+    </Note>
+  </Tab>
+</Tabs>
 
 ### Docker
 

--- a/docs/base-chain/node-operators/troubleshooting.mdx
+++ b/docs/base-chain/node-operators/troubleshooting.mdx
@@ -105,8 +105,9 @@ Refer to the [Snapshots](/base-chain/node-operators/snapshots) guide for the cor
     - **Check**: L2 client logs. Did it fail to start the RPC server?  
     - **Check**: Are the `--http.addr` and `--ws.addr` flags set to `0.0.0.0` in the client config/entrypoint to allow external connections (within the Docker network)?
 
-- **Issue**: Node has low peer count.  
-    - **Check**: P2P port accessibility. Ensure `30303` (TCP/UDP) and `9222` (TCP/UDP for Reth discv5) are not blocked by a firewall on the host or network.  
+- **Issue**: Node has low peer count or cannot connect to any peers.  
+    - **Check**: Ingress ports `30303` (TCP/UDP) and `9222` (TCP/UDP for Reth discv5) are open on your firewall.  
+    - **Check**: Egress ports `30301` (TCP/UDP) and `9200` (UDP) are open for outbound traffic. These are required to reach Base bootnodes — if outbound connections to these ports are blocked, your node cannot initiate peer discovery and will find zero peers regardless of ingress rules.  
     - **Check**: Node logs for P2P errors.  
     - **Action**: If behind NAT, configure the `--nat=extip:<your-ip>` flag via `ADDITIONAL_ARGS` in the `.env` file (see [Networking](/base-chain/node-operators/run-a-base-node#networking)).
 


### PR DESCRIPTION
**What changed? Why?**
Add egress ports and ingress/egress table split to networking docs.

The networking table was missing egress ports 9200 (UDP) and 30301 (TCP/UDP) required for Base bootnode connectivity, and didn't distinguish between inbound and outbound traffic. Operators with strict egress firewall rules had no indication these ports were needed, leaving their nodes unable to find peers.

**Notes to reviewers**

**How has it been tested?**
Locally