### PR TITLE
add full node details to snapshot FAQ

### DIFF
--- a/docs/base-chain/node-operators/snapshots.mdx
+++ b/docs/base-chain/node-operators/snapshots.mdx
@@ -85,3 +85,15 @@ If you are running the [historical proofs ExEx](/base-chain/node-operators/run-a
 | Mainnet | `aria2c -c -x 16 -s 16 "https://mainnet-reth-proofs-snapshots.base.org/$(curl -s https://mainnet-reth-proofs-snapshots.base.org/latest)"` |
 
 The restore process is the same as above — follow the [Restoring from Snapshot](#restoring-from-snapshot) steps using this archive instead.
+
+## FAQ
+
+<AccordionGroup>
+<Accordion title="Why does Base provide a Pruned snapshot instead of a Full node snapshot?">
+
+In Reth, a "full" node is just a pruned node with a specific preset rather than a distinct node type. Reth's `--full` preset retains the last **10,064 blocks** (~1.4 days on Ethereum; ~5-6 hours on Base due to faster block times).
+
+Base's _pruned_ snapshot uses a 31-day rolling retention window instead. If a smaller storage footprint is preferred, you can override `reth.toml` to match the 10,064-block preset.
+
+</Accordion>
+</AccordionGroup>


### PR DESCRIPTION
**What changed? Why?**
Adds a FAQ section to the Snapshot page with aim to prevent operator confusion about the absence of a "full" snapshot option.

**Notes to reviewers**

**How has it been tested?**
Locally