### PR TITLE
set azul mainnet activation

### DIFF
--- a/docs/base-chain/node-operators/base-v1-upgrade.mdx
+++ b/docs/base-chain/node-operators/base-v1-upgrade.mdx
@@ -15,7 +15,7 @@ For full details on what's included, see the [Azul specification](/base-chain/sp
 
 | Network | Date | Timestamp |
 |---------|------|-----------|
-| Mainnet | TBD | TBD |
+| Mainnet | May 28, 2026 18:00 UTC | `1779991200` |
 | Sepolia | April 20, 2026 18:00 UTC | `1776708000` |
 
 <Warning>

--- a/docs/base-chain/specs/upgrades/azul/overview.mdx
+++ b/docs/base-chain/specs/upgrades/azul/overview.mdx
@@ -18,7 +18,7 @@ Only `base-consensus` and `base-reth-node` will support the Base Azul hardfork. 
 
 | Network | Activation timestamp |
 |---------|----------------------|
-| `mainnet` | TBD |
+| `mainnet` | `1779991200` (2026-05-28 18:00:00 UTC) |
 | `sepolia` | `1776708000` (2026-04-20 18:00:00 UTC) |
 
 <Warning>


### PR DESCRIPTION
**What changed? Why?**
Set date for Azul activation on mainnet: May 28, 2026 18:00 UTC / 1779991200

**Notes to reviewers**

**How has it been tested?**
Locally