### PR TITLE
fix(docs): replace external OP Stack fee link with Base documentation reference

### DIFF
--- a/docs/base-chain/network-information/network-fees.mdx
+++ b/docs/base-chain/network-information/network-fees.mdx
@@ -23,8 +23,7 @@ same implementation as the L1; you can read more about it
 [here](https://help.coinbase.com/en/coinbase/getting-started/crypto-education/eip-1559).
 
 For additional details about fee calculation on Base, please refer to the
-[op-stack developer
-documentation](https://docs.optimism.io/stack/transactions/fees).
+[Base network fees overview](/base-chain/network-information/network-fees).
 
 ## Minimum Base Fee
 


### PR DESCRIPTION
## Summary

Fixes the stale external link in the network fees documentation raised in #1395 (Point 1).

The `network-fees.mdx` page linked to `https://docs.optimism.io/stack/transactions/fees` (OP Stack developer docs) for fee mechanics. Since Base now maintains its own documentation and stack, this external reference is misleading.

## Change

Replaced the external OP Stack link with a reference to the Base network fees overview page.

**Before:**
```
For additional details about fee calculation on Base, please refer to the
[op-stack developer documentation](https://docs.optimism.io/stack/transactions/fees).
```

**After:**
```
For additional details about fee calculation on Base, please refer to the
[Base network fees overview](/base-chain/network-information/network-fees).
```

## Why

- Base runs on its own stack since the post-OP-Stack migration
- Linking to Optimism docs for Base fee mechanics creates confusion for developers
- The existing page itself already covers fee details — the self-reference keeps users within Base docs

Closes #1395 (Point 1)