### PR TITLE
set v0.9.0 release in Azul upgrade page

### DIFF
--- a/docs/base-chain/node-operators/base-v1-upgrade.mdx
+++ b/docs/base-chain/node-operators/base-v1-upgrade.mdx
@@ -18,20 +18,12 @@ For full details on what's included, see the [Azul specification](/base-chain/sp
 | Mainnet | May 28, 2026 18:00 UTC | `1779991200` |
 | Sepolia | April 20, 2026 18:00 UTC | `1776708000` |
 
-<Warning>
-The mainnet activation date is tentative and subject to change. Follow [@buildonbase](https://x.com/buildonbase) for the latest updates before upgrading.
-</Warning>
-
 ## Required Software
 
 | Layer | Software | Mainnet | Testnet |
 |-------|----------|---------|-------------------|
-| Execution (EL) | `base-reth-node` | v0.9.0+ *(coming soon)* | [v0.7.0+](https://github.com/base/base/releases/tag/v0.7.0) |
-| Consensus (CL) | `base-consensus` | v0.9.0+ *(coming soon)* | [v0.7.0+](https://github.com/base/base/releases/tag/v0.7.0) |
-
-<Note>
-Release links for v0.9.0 will be added once published to [base/base releases](https://github.com/base/base/releases).
-</Note>
+| Execution (EL) | `base-reth-node` | [v0.9.0+](https://github.com/base/base/releases/tag/v0.9.0) | [v0.7.0+](https://github.com/base/base/releases/tag/v0.7.0) |
+| Consensus (CL) | `base-consensus` | [v0.9.0+](https://github.com/base/base/releases/tag/v0.9.0) | [v0.7.0+](https://github.com/base/base/releases/tag/v0.7.0) |
 
 <Note>
 Both clients are available from the [base/node](https://github.com/base/node/releases) repository, where most configuration is preconfigured and can be overridden via environment variables. See the `.env.mainnet` and `.env.sepolia` files for the full list of configurable options.
@@ -63,7 +55,7 @@ If you are already running OP Reth via [base/node](https://github.com/base/node)
    docker compose up
    ```
 
-4. Verify client version: `web3_clientVersion` should include `base` in the version string (e.g. `reth/v1.11.3-.../base/v0.7.0`)
+4. Verify client version: `web3_clientVersion` should include `base` in the version string (e.g. `reth/v1.11.3-.../base/v0.9.0`)
 
 ### Migrating from another client
 


### PR DESCRIPTION
**What changed? Why?**
Sets v0.9.0 release in Azul upgrade page.

**Notes to reviewers**

**How has it been tested?**
Locally