### PR TITLE
docs: add x402 supported networks and tokens

### DIFF
--- a/docs/ai-agents/payments/pay-for-services-with-x402.mdx
+++ b/docs/ai-agents/payments/pay-for-services-with-x402.mdx
@@ -36,6 +36,19 @@ Any agent with a funded wallet can pay for any x402-enabled API — no pre-exist
 
 [Learn more about x402 →](https://docs.cdp.coinbase.com/x402/docs/client-server-model)
 
+## Supported networks and tokens
+
+x402 support depends on the facilitator and SDK your agent uses. The CDP facilitator supports Base, Base Sepolia, Polygon, Arbitrum, World, World Sepolia, Solana, and Solana Devnet for x402 payments.
+
+On EVM networks, x402 payments can use:
+
+- **USDC, EURC, and other EIP-3009 tokens** for gasless `TransferWithAuthorization` payments. On Base, the common USDC token address is `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`.
+- **Other ERC-20 tokens** through Permit2, when the token and facilitator support that route.
+
+On Solana networks, x402 supports SPL Token Program tokens, and Token2022 tokens in v2 flows.
+
+For the full CAIP-2 network identifiers, facilitator endpoints, token addresses, and version support, see the [x402 network support docs](https://docs.cdp.coinbase.com/x402/network-support).
+
 ## Making x402 requests
 
 ### CDP Agentic Wallet


### PR DESCRIPTION
## Summary
- Add a `Supported networks and tokens` section to the x402 agent payments guide.
- Clarify facilitator-dependent support for Base, Base Sepolia, Polygon, Arbitrum, World, Solana, and Solana Devnet.
- Explain EIP-3009 tokens, Permit2 ERC-20 payments, and Solana SPL/Token2022 support with a link to the canonical x402 network support docs.

## Verification
- `git diff --check`
- Direct inspection of `docs/ai-agents/payments/pay-for-services-with-x402.mdx`

Closes #1460
