### PR TITLE
docs(holocene): remove duplicate "is" in derivation spec

### DIFF
--- a/docs/base-chain/specs/protocol/fault-proof/stage-one/optimism-portal.mdx
+++ b/docs/base-chain/specs/protocol/fault-proof/stage-one/optimism-portal.mdx
@@ -320,7 +320,7 @@ Returns the value of the current
 
 Returns the address of the [L2 Withdrawal Sender](#l2-withdrawal-sender). If the `OptimismPortal`
 has not been initialized then this value will be `address(0)` and should not be used. If the
-`OptimismPortal` is not currently executing an withdrawal transaction then this value will be
+`OptimismPortal` is not currently executing a withdrawal transaction then this value will be
 `0x000000000000000000000000000000000000dEaD` and should not be used.
 
 ### proveWithdrawalTransaction

--- a/docs/base-chain/specs/upgrades/ecotone/l1-attributes.mdx
+++ b/docs/base-chain/specs/upgrades/ecotone/l1-attributes.mdx
@@ -49,7 +49,7 @@ and also set the following new attributes:
   The `1` value is derived from the EIP-4844 `MIN_BLOB_GASPRICE`.
 
 Note that the L1 blob bas fee is _not_ exposed as a part of the L1 origin block.
-It must be computed using an parameterized off-chain formula which takes the
+It must be computed using a parameterized off-chain formula which takes the
 excess blob gas field from the header of the L1 origin block as described in
 [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#base-fee-per-blob-gas-update-rule).
 The `BLOB_BASE_FEE_UPDATE_FRACTION` parameter in the formula varies

--- a/docs/base-chain/specs/upgrades/holocene/derivation.mdx
+++ b/docs/base-chain/specs/upgrades/holocene/derivation.mdx
@@ -227,7 +227,7 @@ better worst-case cached data usage.
 
 - The frame queue only ever holds frames from a single batcher transaction.
 - The channel bank only ever holds a single staging channel, that is either being built up by
-incoming frames, or is is being processed by later stages.
+incoming frames, or is being processed by later stages.
 - The batch queue only ever holds at most a single span batch (that is being processed) and a single singular
 batch (from the span batch, or the staging channel directly)
 - The sync start greatly simplifies in the average production case.

--- a/docs/base-chain/specs/upgrades/holocene/derivation.mdx
+++ b/docs/base-chain/specs/upgrades/holocene/derivation.mdx
@@ -283,7 +283,7 @@ experienced this on Base yet.
 The only conceivable scenarios in which a _valid_ batch leads to an _invalid_ payload are
 
 - a buggy or malicious sequencer+batcher
-- in the future, that an previously valid Interop dependency referenced in that payload is later
+- in the future, that a previously valid Interop dependency referenced in that payload is later
 invalidated, while the block that contained the Interop dependency got already batched.
 
 It is this latter case that inspired the Steady Block Derivation rule. It guarantees that the


### PR DESCRIPTION
Found a small typo while reading through the Holocene derivation spec a duplicated "is" in the channel bank description:

> The channel bank only ever holds a single staging channel, that is either being built up by
> incoming frames, or **is is** being processed by later stages.

Removed the extra "is". One word fix.