### PR TITLE
fix: replace insecure Math.random() nonces with crypto APIs

### DIFF
--- a/docs/base-account/framework-integrations/wagmi/setup.mdx
+++ b/docs/base-account/framework-integrations/wagmi/setup.mdx
@@ -335,9 +335,7 @@ export function SignInWithBase({ connector }: SignInWithBaseProps) {
     if (provider) {
       try {
         // Generate a fresh nonce (this will be overwritten with the backend nonce)
-        const clientNonce =
-          Math.random().toString(36).substring(2, 15) +
-          Math.random().toString(36).substring(2, 15);
+        const clientNonce = crypto.randomUUID();
         console.log("clientNonce", clientNonce);
         // Connect with SIWE to get signature, message, and address
         const accounts = await (provider as any).request({

--- a/docs/base-account/guides/sign-and-verify-typed-data.mdx
+++ b/docs/base-account/guides/sign-and-verify-typed-data.mdx
@@ -172,6 +172,7 @@ export async function verifyTypedData(req, res) {
 ## Example Express Server
 
 ```ts title="server/typed-data.ts"
+import crypto from 'crypto';
 import express from 'express';
 import { createPublicClient, http } from 'viem';
 import { base } from 'viem/chains';
@@ -190,7 +191,7 @@ const usedNonces = new Set<string>();
 app.get('/typed-data/prepare', (req, res) => {
   const { userAddress, action, resource } = req.query;
   
-  const nonce = Math.floor(Math.random() * 1000000);
+  const nonce = crypto.randomInt(1_000_000);
   const expiry = Math.floor(Date.now() / 1000) + 3600; // 1 hour
   
   const typedData = {

--- a/docs/base-account/reference/ui-elements/sign-in-with-base-button.mdx
+++ b/docs/base-account/reference/ui-elements/sign-in-with-base-button.mdx
@@ -325,7 +325,7 @@ const handleSignInWithSIWE = async () => {
       address: account,
       chainId: base.id,
       domain: window.location.host,
-      nonce: Math.random().toString(36).substring(7),
+      nonce: crypto.randomUUID(),
       uri: window.location.origin,
       version: '1',
       statement: 'Sign in to MyApp with your Base Account'


### PR DESCRIPTION
## What changed? Why?

Replaced all `Math.random()` usages for nonce generation with cryptographically secure alternatives across three documentation files.

`Math.random()` is not cryptographically secure and produces predictable output. Using it for SIWE nonces or security-sensitive values exposes developers who copy these examples to replay attacks.

### Changes

| File | Before | After |
|------|--------|-------|
| `wagmi/setup.mdx` | `Math.random().toString(36).substring(2, 15)` | `crypto.randomUUID()` |
| `sign-in-with-base-button.mdx` | `Math.random().toString(36).substring(7)` | `crypto.randomUUID()` |
| `sign-and-verify-typed-data.mdx` | `Math.floor(Math.random() * 1000000)` | `crypto.randomInt(1_000_000)` + added `import crypto` |

### Notes to reviewers

- `crypto.randomUUID()` is available in all modern browsers and Node.js 19+ (Web Crypto API)
- `crypto.randomInt()` is used in the server-side example (Node.js `crypto` module) since the nonce there is a numeric value
- Consistent with the existing `authenticate-users` guide which already uses `crypto.randomUUID()`

Closes #1477