### PR TITLE
docs(ai-agents): add supported networks and tokens section to x402 page

### DIFF
--- a/docs/ai-agents/payments/pay-for-services-with-x402.mdx
+++ b/docs/ai-agents/payments/pay-for-services-with-x402.mdx
@@ -36,6 +36,29 @@ Any agent with a funded wallet can pay for any x402-enabled API — no pre-exist
 
 [Learn more about x402 →](https://docs.cdp.coinbase.com/x402/docs/client-server-model)
 
+## Supported networks and tokens
+
+x402 is available on the following networks:
+
+| Network | Supported |
+|---------|-----------|
+| **Base** | USDC, EURC, other ERC-20s |
+| **Ethereum** | USDC, EURC, other ERC-20s |
+| **Arbitrum** | USDC, EURC, other ERC-20s |
+| **Polygon** | USDC, EURC, other ERC-20s |
+| **Solana** | USDC |
+
+Payments are made in **USDC** using [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) (permit-and-transfer in a single transaction), with **EURC** and other ERC-20 tokens supported via [Permit2](https://docs.uniswap.org/contracts/permit2/overview). On Solana, payments use native USDC SPL tokens.
+
+Which networks and tokens a specific endpoint accepts is returned in the `PAYMENT-REQUIRED` header. Facilitators like [CDP](https://docs.cdp.coinbase.com/x402/network-support) may also restrict which networks they support.
+
+<Note>
+  Your agent only needs a funded wallet on the network the API accepts. No bridging or multi-network setup required.
+</Note>
+
+[Full network support reference →](https://docs.cdp.coinbase.com/x402/network-support)
+[x402 ecosystem →](https://www.x402.org/ecosystem)
+
 ## Making x402 requests
 
 ### CDP Agentic Wallet


### PR DESCRIPTION
## What changed? Why?

Adds a "Supported networks and tokens" section to the x402 payment page.
The page's description promised this info but the section was missing.

## Related

Closes #1460
