### PR TITLE
fix(docs): fix table header and add missing Description row in connec…

### DIFF
--- a/docs/base-chain/quickstart/connecting-to-base.mdx
+++ b/docs/base-chain/quickstart/connecting-to-base.mdx
@@ -110,9 +110,10 @@ To add Base Sepolia as a custom network in MetaMask:
 4. Click **Add a network manually**.
 5. In the **Add a network manually** dialog that appears, enter the following information for the Base Sepolia testnet:
 
-   | Name            | Sepolia                                                                |
+   | Name            | Value                                                                  |
    | :-------------- | :--------------------------------------------------------------------- |
    | Network Name    | Base Sepolia                                                           |
+   | Description     | A public testnet for Base.                                             |
    | RPC Endpoint    | [https://sepolia.base.org](https://sepolia.base.org)                   |
    | Chain ID        | 84532                                                                  |
    | Currency Symbol | ETH                                                                    |


### PR DESCRIPTION
Fixes Base Sepolia MetaMask table header from "Name | Sepolia" to "Name | Value"
and adds missing Description row for consistency with Base Mainnet table.

Closes #1442
