### PR TITLE
fix(docs): add .slice(2) to dataSuffix hex stripping in builder codes…

### DIFF
--- a/tmp-builder-codes-outline.mdx
+++ b/tmp-builder-codes-outline.mdx
@@ -16,13 +16,13 @@ You do **not** build, validate, or encode anything — you just use the suffix w
 
 If your app sends a normal `eth_sendTransaction`:
 
-`tx.data = tx.data + dataSuffix;`
+`tx.data = tx.data + dataSuffix.slice(2);`
 
 ### **B. Smart Account / ERC-4337 UserOps**
 
 If your app constructs User Operations:
 
-`userOp.callData = userOp.callData + dataSuffix;`
+`userOp.callData = userOp.callData + dataSuffix.slice(2);`
 
 Smart accounts require putting the suffix inside the `callData` of the userOp.
 


### PR DESCRIPTION
## Problem
In tmp-builder-codes-outline.mdx, the dataSuffix hex stripping is inconsistent across examples. Some examples correctly strip the 0x prefix (dataSuffix.slice(2)) but the EOA and ERC-4337 sections don't:
- tx.data = tx.data + dataSuffix;
- userOp.callData = userOp.callData + dataSuffix;
Since dataSuffix has 0x prefix, this produces malformed double-prefixed hex strings.
## Fix
Added .slice(2) to both:
- tx.data = tx.data + dataSuffix.slice(2);
- userOp.callData = userOp.callData + dataSuffix.slice(2);
Matches existing pattern in lines 164, 175, 307, 319.
Closes #1474
