### PR TITLE
Enhance bridging information for Brid.gg and Relay

### DIFF
--- a/docs/base-chain/network-information/bridges.mdx
+++ b/docs/base-chain/network-information/bridges.mdx
@@ -23,12 +23,22 @@ Superbridge enables you to bridge ETH and other supported assets from Ethereum m
 
 ### Brid.gg
 
-Brid.gg is another option that also helps you bridge ETH and supported assets between Ethereum mainnet (L1) and Base.
+Brid.gg helps you bridge ETH and supported assets between Ethereum mainnet (L1) and Base, as well as between Sepolia testnet and Base Sepolia.
 
 #### Supported Networks
 
-- [Base Mainnet](https://brid.gg/base)
-- [Base Sepolia (Testnet)](https://testnet.brid.gg/base-sepolia)
+- [Base Mainnet](https://brid.gg) - Select Ethereum → Base
+- [Base Sepolia (Testnet)](https://brid.gg) - Select Sepolia → Base Sepolia
+
+> **Note:** Brid.gg uses a selection interface. After visiting the link above, choose your source and destination chains from the dropdown menus.
+
+### Relay
+Relay seamlessly supports bridging assets on Base mainnet and Base Sepolia testnet.
+
+#### Supported Networks
+
+- [Base Mainnet](https://relay.link/bridge/base)
+- [Base Sepolia (Testnet)](https://testnets.relay.link/bridge/base-sepolia)
 
 ### Programmatic Bridging (Ethereum)
 


### PR DESCRIPTION
Updated Brid.gg section to include bridging options for Sepolia testnet and added Relay information.

**What changed? Why?**
- Fixed the Brid.gg link to point to the main page (https://brid.gg) instead of a broken subpage so users can properly select their source and destination chains via the interface.
- Added clarification that Brid.gg uses a dropdown selection interface for choosing source/destination chains.
- Added a new Relay bridge section with supported networks:
Base Mainnet
Base Sepolia Testnet

The previous Brid.gg documentation had a broken link (page not found) and was missing Base / Base-Sepolia testnet support. This update fixes the link, improves accuracy, and documents the newer Relay bridge option for better developer and user experience

**Notes to reviewers**
- All links have been verified as functional.

**How has it been tested?**
- Manually verified all bridge links and flows.