### PR TITLE
fix(privy): secure SIWE verification with domain validation

### DIFF
--- a/docs/base-account/framework-integrations/privy/authentication.mdx
+++ b/docs/base-account/framework-integrations/privy/authentication.mdx
@@ -212,6 +212,7 @@ export async function GET() {
 import { NextRequest, NextResponse } from 'next/server';
 import { createPublicClient, http } from 'viem';
 import { base } from 'viem/chains';
+import { verifySiweMessage } from 'viem/siwe';
 import { nonceStore } from '@/lib/nonce-store';
 
 const client = createPublicClient({ 
@@ -233,12 +234,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Verify signature using viem
-    const valid = await client.verifyMessage({ 
-      address: address as `0x${string}`, 
-      message, 
-      signature: signature as `0x${string}` 
+    // Verify signature using viem with SIWE validation
+    const { isValid } = await verifySiweMessage(client, {
+      address: address as `0x${string}`,
+      message,
+      signature: signature as `0x${string}`,
+      domain: request.headers.get('host') ?? 'yourapp.com',
+      nonce: nonce,
     });
+    const valid = isValid;
 
     if (!valid) {
       return NextResponse.json(


### PR DESCRIPTION
## Security Fix

Addresses the cross-domain replay attack vulnerability in the Privy integration guide.

### Changes
- Added `import { verifySiweMessage } from 'viem/siwe';`
- Replaced `client.verifyMessage` with `verifySiweMessage`.
- Added `domain` and `nonce` validation parameters.

This ensures the signature is verified against the correct domain and prevents nonce reuse.