### PR TITLE
fix: update broken Brid.gg links in bridges documentation

### DIFF
--- a/docs/base-chain/network-information/bridges.mdx
+++ b/docs/base-chain/network-information/bridges.mdx
@@ -23,12 +23,9 @@ Superbridge enables you to bridge ETH and other supported assets from Ethereum m
 
 ### Brid.gg
 
-Brid.gg is another option that also helps you bridge ETH and supported assets between Ethereum mainnet (L1) and Base.
+Brid.gg is another option that also helps you bridge ETH and supported assets between Ethereum mainnet (L1) and Base. After visiting the site, use the chain selector to choose your source chain and select Base or Base Sepolia as the destination.
 
-#### Supported Networks
-
-- [Base Mainnet](https://brid.gg/base)
-- [Base Sepolia (Testnet)](https://testnet.brid.gg/base-sepolia)
+- [Brid.gg](https://brid.gg)
 
 ### Programmatic Bridging (Ethereum)
 


### PR DESCRIPTION
Closes #1537

## Summary
Brid.gg now uses a unified interface with dropdown selectors instead of dedicated sub-paths for each chain. The previous links (https://brid.gg/base and https://testnet.brid.gg/base-sepolia) return 404 errors.

## Changes
- Replaced the broken chain-specific Brid.gg links with a single link to https://brid.gg
- Added instructions for users to use the chain selector interface to choose Base or Base Sepolia as their destination