### PR TITLE
fix(docs): correct typo 'Etherum' to 'Ethereum' in diffs-ethereum-base

### DIFF
--- a/docs/base-chain/network-information/diffs-ethereum-base.mdx
+++ b/docs/base-chain/network-information/diffs-ethereum-base.mdx
@@ -3,7 +3,7 @@ title: "Differences between Ethereum and Base"
 sidebarTitle: 'Differences: Ethereum & Base'
 ---
 
-Base is built to be as compatible as possible to Etherum, and there are very few differences when it comes to building on Base versus Ethereum.
+Base is built to be as compatible as possible to Ethereum, and there are very few differences when it comes to building on Base versus Ethereum.
 
 However, there are still some minor discrepancies between the behavior of Base and Ethereum that you should be aware of when building apps on top of Base.
 


### PR DESCRIPTION
Fixes a typo in the opening sentence of `docs/base-chain/network-information/diffs-ethereum-base.mdx`, changing 'Etherum' to 'Ethereum'. Closes #1440.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._