### PR TITLE
fix(docs): resolve broken internal and external links

### DIFF
--- a/docs/apps/resources/templates.mdx
+++ b/docs/apps/resources/templates.mdx
@@ -71,21 +71,21 @@ This demo serves as the ultimate reference implementation, showcasing every Mini
   <Card
     title="Viral Mini Apps"
     icon="sparkles"
-    href="/mini-apps/growth/build-viral-mini-apps"
+    href="/apps/growth/rewards"
   >
     Strategies and examples for building highly shareable, viral mini apps.
   </Card>
   <Card
     title="Data Driven Growth"
     icon="chart-bar"
-    href="/mini-apps/technical-guides/data-driven-growth"
+    href="/apps/growth/rewards"
   >
     Learn how to use analytics and Base.dev to optimize your mini app's growth.
   </Card>
   <Card
     title="Optimize Onboarding"
     icon="user-plus"
-    href="/mini-apps/growth/optimize-onboarding"
+    href="/apps/quickstart/build-app"
   >
     Best practices for onboarding users and maximizing retention.
   </Card>

--- a/docs/base-account/guides/verify-social-accounts.mdx
+++ b/docs/base-account/guides/verify-social-accounts.mdx
@@ -432,7 +432,7 @@ function redirectToVerifyMiniApp(provider: string) {
 }
 ```
 
-After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps/introduction/overview) for broader app structure and lifecycle guidance.
+After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps) for broader app structure and lifecycle guidance.
 
 </Step>
 </Steps>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,14 +9,21 @@
   },
   "favicon": "/logo/favicon.png",
   "contextual": {
-    "options": ["copy", "view", "claude", "chatgpt"]
+    "options": [
+      "copy",
+      "view",
+      "claude",
+      "chatgpt"
+    ]
   },
   "api": {
     "playground": {
       "display": "simple"
     },
     "examples": {
-      "languages": ["javascript"]
+      "languages": [
+        "javascript"
+      ]
     }
   },
   "seo": {
@@ -32,7 +39,9 @@
         "groups": [
           {
             "group": "Introduction",
-            "pages": ["get-started/base"]
+            "pages": [
+              "get-started/base"
+            ]
           },
           {
             "group": "Quickstart",
@@ -418,7 +427,9 @@
         "groups": [
           {
             "group": "Introduction",
-            "pages": ["base-account/overview/what-is-base-account"]
+            "pages": [
+              "base-account/overview/what-is-base-account"
+            ]
           },
           {
             "group": "Quickstart",
@@ -667,7 +678,9 @@
           },
           {
             "group": "Growth",
-            "pages": ["apps/growth/rewards"]
+            "pages": [
+              "apps/growth/rewards"
+            ]
           },
           {
             "group": "Builder Codes",
@@ -685,11 +698,15 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["ai-agents/index"]
+            "pages": [
+              "ai-agents/index"
+            ]
           },
           {
             "group": "Quickstart",
-            "pages": ["ai-agents/quickstart"]
+            "pages": [
+              "ai-agents/quickstart"
+            ]
           },
           {
             "group": "Guides",
@@ -1104,51 +1121,51 @@
     },
     {
       "source": "/onchainkit/latest/components/minikit/overview",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/provider-and-initialization",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useMiniKit",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useOpenUrl",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useClose",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/usePrimaryButton",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useViewProfile",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useComposeCast",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useViewCast",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useAuthenticate",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useAddFrame",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useNotification",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/identity/identity",
@@ -1836,7 +1853,7 @@
     },
     {
       "source": "/mini-apps/overview",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/features/wallet",
@@ -2196,27 +2213,27 @@
     },
     {
       "source": "/cookbook/growth/cast-actions",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/deploy-to-vercel",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/email-campaigns",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/gating-and-redirects",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/hyperframes",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/retaining-users",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/payments/build-ecommerce-app",
@@ -2228,19 +2245,19 @@
     },
     {
       "source": "/cookbook/social/convert-farcaster-frame",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/social/farcaster-nft-minting-guide",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/social/farcaster-no-code-nft-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/cast-actions",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/commerce/build-an-ecommerce-app",
@@ -2248,35 +2265,35 @@
     },
     {
       "source": "/cookbook/use-case-guides/create-email-campaigns",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/creator/convert-farcaster-frame-to-open-frame",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/deploy-to-vercel",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/gating-and-redirects",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/hyperframes",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/nft-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/no-code-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/retaining-users",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/transactions",
@@ -2688,7 +2705,7 @@
     },
     {
       "source": "/use-cases/decentralize-social-app",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/use-cases/defi-your-app",
@@ -2736,11 +2753,11 @@
     },
     {
       "source": "/base-app/introduction/what-are-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/introduction/why-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/overview",
@@ -2760,11 +2777,11 @@
     },
     {
       "source": "/base-app/miniapps/quickstart",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/build-with-minikit/quickstart",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/existing-apps/:slug*",
@@ -2776,15 +2793,15 @@
     },
     {
       "source": "/mini-apps/quickstart/new-apps/:slug*",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/build-with-minikit/mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/search-and-discovery",
@@ -2844,15 +2861,15 @@
     },
     {
       "source": "/mini-apps/quickstart/new-apps/install",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/new-apps/deploy",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/new-apps/create-manifest",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/design-ux/:slug*",
@@ -2948,7 +2965,7 @@
     },
     {
       "source": "/cookbook/onchain-social",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/defi-your-app",
@@ -2960,7 +2977,7 @@
     },
     {
       "source": "/cookbook/base-app-coins",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/cookbook/testing-onchain-apps",
@@ -2976,11 +2993,11 @@
     },
     {
       "source": "/cookbook/introduction-to-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/ai-powered-development-fundamentals",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/mastering-ai-prompt-engineering",
@@ -2988,7 +3005,7 @@
     },
     {
       "source": "/cookbook/essential-documentation-resources",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/ai-assisted-documentation-reading",
@@ -3000,7 +3017,7 @@
     },
     {
       "source": "/cookbook/minikit/build-your-mini-app-with-prompt",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/converting-customizing-mini-apps",
@@ -3100,7 +3117,7 @@
     },
     {
       "source": "/mini-apps/quickstart/create-new-miniapp",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/growth/build-viral-mini-apps",

--- a/docs/get-started/learning-resources.mdx
+++ b/docs/get-started/learning-resources.mdx
@@ -18,6 +18,6 @@ We will be adding more learning resources to help you build on Base. Stay tuned 
 - New educational content
 
 In the meantime, check out the following resources:
-- [Base Account](/base-account/overview/what-is-base-account), [Apps](/apps/quickstart/create-new-app), and [Base Chain](/base-chain/quickstart/why-base) for building on Base.
+- [Base Account](/base-account/overview/what-is-base-account), [Apps](/apps/quickstart/build-app), and [Base Chain](/base-chain/quickstart/why-base) for building on Base.
 - [CryptoZombies](https://cryptozombies.io/) and [Solidity by Example](https://solidity-by-example.org/) for learning Solidity.
 - [Base Prompt Library](/get-started/prompt-library) for building with AI.


### PR DESCRIPTION
## Summary

Fixes broken documentation links reported in #1423, #1308, and #1469.

### Changes

**docs.json** — Updated 49 broken redirect destinations:
- `/apps/quickstart/create-new-app` → `/apps/quickstart/build-app`
- `/apps/introduction/overview` → `/apps`

**docs/apps/resources/templates.mdx** — Fixed 3 broken links to removed mini-apps pages:
- `/mini-apps/growth/build-viral-mini-apps` → `/apps/growth/rewards`
- `/mini-apps/technical-guides/data-driven-growth` → `/apps/growth/rewards`
- `/mini-apps/growth/optimize-onboarding` → `/apps/quickstart/build-app`

**docs/base-account/guides/verify-social-accounts.mdx** — Fixed broken `/apps/introduction/overview` link → `/apps`

**docs/get-started/learning-resources.mdx** — Fixed broken `/apps/quickstart/create-new-app` link → `/apps/quickstart/build-app`

### Related Issues
- #1423 — Broken redirects to `/apps/quickstart/create-new-app`
- #1308 — Broken `/apps/introduction/overview` link
- #1469 — Broken internal links in Apps docs
- #759 — Broken links in Getting Started section