### PR TITLE
fix(docs): replace Math.random() with crypto.randomUUID() for SIWE nonces

### DIFF
--- a/docs/base-account/framework-integrations/wagmi/setup.mdx
+++ b/docs/base-account/framework-integrations/wagmi/setup.mdx
@@ -335,9 +335,7 @@ export function SignInWithBase({ connector }: SignInWithBaseProps) {
     if (provider) {
       try {
         // Generate a fresh nonce (this will be overwritten with the backend nonce)
-        const clientNonce =
-          Math.random().toString(36).substring(2, 15) +
-          Math.random().toString(36).substring(2, 15);
+        const clientNonce = crypto.randomUUID();
         console.log("clientNonce", clientNonce);
         // Connect with SIWE to get signature, message, and address
         const accounts = await (provider as any).request({

--- a/docs/base-account/guides/sign-and-verify-typed-data.mdx
+++ b/docs/base-account/guides/sign-and-verify-typed-data.mdx
@@ -190,7 +190,7 @@ const usedNonces = new Set<string>();
 app.get('/typed-data/prepare', (req, res) => {
   const { userAddress, action, resource } = req.query;
   
-  const nonce = Math.floor(Math.random() * 1000000);
+  const nonce = crypto.randomUUID();
   const expiry = Math.floor(Date.now() / 1000) + 3600; // 1 hour
   
   const typedData = {

--- a/docs/base-account/reference/ui-elements/sign-in-with-base-button.mdx
+++ b/docs/base-account/reference/ui-elements/sign-in-with-base-button.mdx
@@ -325,7 +325,7 @@ const handleSignInWithSIWE = async () => {
       address: account,
       chainId: base.id,
       domain: window.location.host,
-      nonce: Math.random().toString(36).substring(7),
+      nonce: crypto.randomUUID(),
       uri: window.location.origin,
       version: '1',
       statement: 'Sign in to MyApp with your Base Account'


### PR DESCRIPTION
## Summary

Replace all instances of `Math.random()` used for SIWE nonce generation with `crypto.randomUUID()`.

**Files fixed:**
- `sign-in-with-base-button.mdx` — nonce generation
- `sign-and-verify-typed-data.mdx` — nonce generation  
- `wagmi/setup.mdx` — client nonce generation

## Why

`Math.random()` is not cryptographically secure. Predictable nonces can be exploited for replay attacks. `crypto.randomUUID()` is:
- Cryptographically secure (Web Crypto API)
- Available in all modern browsers and Node.js 19+
- Already used in the `authenticate-users` guide

## Test Plan

- [ ] Verify all code examples still work with the new nonce format
- [ ] No other instances of Math.random() remain in SIWE-related docs

Closes #1477