### PR TITLE
Fix Base MCP native plugin reference links

### DIFF
--- a/docs/ai-agents/plugins/native/aerodrome.mdx
+++ b/docs/ai-agents/plugins/native/aerodrome.mdx
@@ -38,6 +38,6 @@ The public `https://mainnet.base.org` RPC enforces a 10-call-per-batch limit and
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/aerodrome.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/aerodrome.md">
   Setup, RPC compatibility patches, calldata-bridge code, swap/LP orchestration patterns, and what works vs. what doesn't on the public RPC.
 </Card>

--- a/docs/ai-agents/plugins/native/avantis.mdx
+++ b/docs/ai-agents/plugins/native/avantis.mdx
@@ -59,6 +59,6 @@ No additional MCP server is required. View-only Avantis APIs are reached through
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/avantis.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/avantis.md">
   Endpoint inventory, parameters, unit/scaling rules, batching guidance, chat-only UI fallback, and error handling.
 </Card>

--- a/docs/ai-agents/plugins/native/bankr.mdx
+++ b/docs/ai-agents/plugins/native/bankr.mdx
@@ -38,6 +38,6 @@ The Bankr feed is unfiltered. Listed tokens are not vetted, audited, or endorsed
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/bankr.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/bankr.md">
   API response shape, orchestration steps, symbol-collision and adversarial-metadata safety notes for new launches.
 </Card>

--- a/docs/ai-agents/plugins/native/index.mdx
+++ b/docs/ai-agents/plugins/native/index.mdx
@@ -14,7 +14,7 @@ keywords:
   ]
 ---
 
-Seven plugins ship in the Base MCP skill — Morpho, Moonwell, Uniswap, Avantis, Aerodrome, Virtuals, and Bankr. They're authored by the Base team in partnership with the protocol teams and live alongside `SKILL.md` in [`github.com/base/skills`](https://github.com/base/skills/tree/main/skills/base-mcp/plugins). The assistant loads each spec on demand when a relevant request comes in.
+Seven plugins ship in the Base MCP skill — Morpho, Moonwell, Uniswap, Avantis, Aerodrome, Virtuals, and Bankr. They're authored by the Base team in partnership with the protocol teams and live alongside `SKILL.md` in [`github.com/base/skills`](https://github.com/base/skills/tree/master/skills/base-mcp/plugins). The assistant loads each spec on demand when a relevant request comes in.
 
 Most transaction plugins follow the prepare → `send_calls` pattern described in the [Overview](/ai-agents/plugins). Bankr uses Base MCP's `swap` tool for the purchase, and Virtuals uses Base MCP's `sign` tool only for SIWE login before continuing with a Virtuals session token. The plugin spec is the single source of truth; the cards below are pointers, not duplicates.
 

--- a/docs/ai-agents/plugins/native/moonwell.mdx
+++ b/docs/ai-agents/plugins/native/moonwell.mdx
@@ -34,6 +34,6 @@ The Moonwell API returns an ordered `transactions[]` array — `approve`, `enter
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/moonwell.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/moonwell.md">
   Endpoint inventory, response shapes, mToken notes, and health factor guide.
 </Card>

--- a/docs/ai-agents/plugins/native/morpho.mdx
+++ b/docs/ai-agents/plugins/native/morpho.mdx
@@ -47,6 +47,6 @@ In chat-only harnesses, use Morpho MCP tools for the same vault/market reads and
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/morpho.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/morpho.md">
   Environment detection, CLI and MCP paths, response shapes, safety checks, and orchestration details.
 </Card>

--- a/docs/ai-agents/plugins/native/uniswap.mdx
+++ b/docs/ai-agents/plugins/native/uniswap.mdx
@@ -34,6 +34,6 @@ Swap flow is three calls — `/check_approval`, `/quote`, `/swap` — batched in
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/uniswap.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/uniswap.md">
   Endpoint inventory, headers, response shapes, and orchestration for swap and LP flows.
 </Card>

--- a/docs/ai-agents/plugins/native/virtuals.mdx
+++ b/docs/ai-agents/plugins/native/virtuals.mdx
@@ -57,6 +57,6 @@ claude mcp add virtuals --transport http https://mcp.acp.virtuals.io/
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/virtuals.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/virtuals.md">
   Step-by-step SIWE auth flow, troubleshooting for the six common signature-verification failure modes, and orchestration recipes for agent / card / email operations.
 </Card>


### PR DESCRIPTION
**What changed? Why?**

The AI Agents native plugin pages linked to `base/skills` on the `main` branch, but that repository's default branch is `master`. Those links currently 404 from the docs cards, including the Bankr page reported in #1531.

This updates the native plugin overview and each plugin reference card to use the working `master` URLs.

**Notes to reviewers**

No content or navigation behavior changed; this is only fixing GitHub reference targets.

Closes #1531.

**How has it been tested?**

- `git diff --check`
- Verified the old `main` GitHub URLs return 404.
- Verified all updated `master` plugin URLs return 200.
- Ran `node scripts/lint-mdx.js docs/ai-agents/plugins/native`; it reports existing code-fence false positives on these pages, unrelated to this link-only change.
