### PR TITLE
security: add domain validation to SIWE authentication examples

### DIFF
--- a/docs/base-account/guides/authenticate-users.mdx
+++ b/docs/base-account/guides/authenticate-users.mdx
@@ -146,13 +146,22 @@ try {
 ```
 ```ts Backend (Viem)
 import { createPublicClient, http } from 'viem';
+import { verifySiweMessage } from 'viem/siwe';
 import { base } from 'viem/chains';
 
 const client = createPublicClient({ chain: base, transport: http() });
 
 export async function verifySig(req, res) {
   const { address, message, signature } = req.body;
-  const valid = await client.verifyMessage({ address, message, signature });
+  
+  // Verify SIWE message with domain validation
+  const valid = await verifySiweMessage(client, {
+    address,
+    message,
+    signature,
+    domain: 'yourapp.com', // Replace with your actual domain
+  });
+  
   if (!valid) return res.status(401).json({ error: 'Invalid signature' });
   // create session / JWT
   res.json({ ok: true });
@@ -184,6 +193,7 @@ export async function verifySig(req, res) {
 import crypto from "crypto";
 import express from "express";
 import { createPublicClient, http } from "viem";
+import { verifySiweMessage } from "viem/siwe";
 import { base } from "viem/chains";
 
 const app = express();
@@ -209,8 +219,15 @@ app.post("/auth/verify", async (req, res) => {
     return res.status(400).json({ error: "Invalid or reused nonce" });
   }
 
-  // 2. Verify signature
-  const valid = await client.verifyMessage({ address, message, signature });
+  // 2. Verify SIWE signature with domain validation (prevents cross-domain replay attacks)
+  const valid = await verifySiweMessage(client, {
+    address,
+    message,
+    signature,
+    domain: 'yourapp.com', // Replace with your actual domain
+    nonce, // verifySiweMessage validates nonce is in the message
+  });
+  
   if (!valid) return res.status(401).json({ error: "Invalid signature" });
 
   // 3. Create session / JWT here


### PR DESCRIPTION
## Summary

Fixes cross-domain replay attack vulnerability in the authenticate-users guide backend examples.

## Problem (Issue #1502)

The current backend verification code only checks the cryptographic signature without validating the SIWE message domain:

```ts
const valid = await client.verifyMessage({ address, message, signature });
```

This is **insecure**. A valid SIWE signature created for `evil.com` can be submitted to `yourapp.com`'s `/auth/verify` endpoint and will pass verification, because `verifyMessage` only validates the cryptographic signature — not whether the message was intended for this domain.

## EIP-4361 Requirement

[EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) explicitly requires relying parties to validate the `domain` field:

> "The full SIWE message MUST be checked for conformance... checked against expected values after parsing (e.g., expiration-time, nonce, request-uri, domain etc.)"

## Solution

Replace `verifyMessage` with `verifySiweMessage` which validates domain, nonce, and expiry:

```ts
import { verifySiweMessage } from 'viem/siwe';

const valid = await verifySiweMessage(client, {
  address,
  message,
  signature,
  domain: 'yourapp.com', // Validates message was intended for this domain
});
```

## Changes

- ✅ Updated both backend examples (inline + Express server)
- ✅ Added `verifySiweMessage` import from `viem/siwe`
- ✅ Added explicit `domain` parameter with comment
- ✅ Added security rationale comment in Express example

## Impact

**Before:** Developers following this guide ship authentication endpoints vulnerable to cross-domain replay attacks.

**After:** Secure authentication that complies with EIP-4361 spec.

## Testing

Code follows viem's official API:
- [verifySiweMessage documentation](https://viem.sh/docs/siwe/actions/verifySiweMessage)

Fixes #1502