### PR TITLE
fix: replace invalid address placeholders with properly formatted '0x...'

### DIFF
--- a/docs/base-account/guides/accept-payments.mdx
+++ b/docs/base-account/guides/accept-payments.mdx
@@ -36,7 +36,7 @@ import { pay, getPaymentStatus } from '@base-org/account';
 try {
   const payment = await pay({
     amount: '1.00',           // USD amount (USDC used internally)
-    to:    '0xRecipient',     // your address
+    to:    '0x...',     // your address
     testnet: true            // set false for Mainnet
   });
   
@@ -70,7 +70,7 @@ Need an email, phone, or shipping address at checkout?  Pass a <code>payerInfo</
 try {
   const payment = await pay({
     amount: '25.00',
-    to: '0xRecipient',
+    to: '0x...',
     payerInfo: {
       requests: [
         { type: 'email' },
@@ -289,7 +289,7 @@ import { pay } from '@base-org/account';
 export function Checkout() {
   const handlePayment = async () => {
     try {
-      const payment = await pay({ amount: '5.00', to: '0xRecipient' });
+      const payment = await pay({ amount: '5.00', to: '0x...' });
       console.log(`Payment sent! Transaction ID: ${payment.id}`);
     } catch (error) {
       console.error(`Payment failed: ${error.message}`);

--- a/docs/base-account/quickstart/web-react.mdx
+++ b/docs/base-account/quickstart/web-react.mdx
@@ -101,7 +101,7 @@ export default function Home() {
     try {
       const { id } = await pay({
         amount: '0.01', // USD – SDK quotes equivalent USDC
-        to: '0xRecipientAddress', // Replace with your recipient address
+        to: '0x...', // Replace with your recipient address
         testnet: true // set to false or omit for Mainnet
       });
 
@@ -207,7 +207,7 @@ export default function Home() {
 <Note>
 **Note:**
 
-Make sure to replace `0xRecipientAddress` with your recipient address.
+Make sure to replace `0x...` with your recipient address.
 </Note>
 
 <Tip>


### PR DESCRIPTION
Replace invalid EVM address placeholders ('0xRecipient', '0xRecipientAddress') with '0x...' — the universally recognized format for "fill in your address".

The previous placeholders are 12 and 18 characters respectively, not valid 42-character EVM addresses. Developers copying these would get SDK errors or failed transactions.

Changes:
- docs/base-account/guides/accept-payments.mdx: 3 occurrences
- docs/base-account/quickstart/web-react.mdx: 2 occurrences (code + note)