### PR TITLE
fix(docs): broken/outdated link in `deploy-smart-contracts.mdx` (and the duplicate content in `deploy-on-base.mdx`).

### DIFF
--- a/docs/base-chain/quickstart/deploy-on-base.mdx
+++ b/docs/base-chain/quickstart/deploy-on-base.mdx
@@ -168,6 +168,4 @@ This will return the initial value of the Counter contract's `number` storage va
 ## Next Steps
 
 - Use [wagmi](https://wagmi.sh) or [viem](https://viem.sh) to connect your frontend to your contracts.
-- Learn more about interacting with your contracts in the command line using Foundry from our [Foundry tutorial](/learn/foundry/deploy-with-foundry).
-
-
+- Learn more about interacting with your contracts in the command line using [Foundry Book](https://book.getfoundry.sh/).

--- a/docs/get-started/deploy-smart-contracts.mdx
+++ b/docs/get-started/deploy-smart-contracts.mdx
@@ -140,4 +140,4 @@ This will return the initial value of the Counter contract's `number` storage va
 ## Next Steps
 
 - Use [wagmi](https://wagmi.sh) or [viem](https://viem.sh) to connect your frontend to your contracts.
-- Learn more about interacting with your contracts in the command line using Foundry from our [Foundry tutorial](/learn/foundry/deploy-with-foundry).
+- Learn more about interacting with your contracts in the command line using [Foundry Book](https://book.getfoundry.sh/).


### PR DESCRIPTION
**What changed? Why?**

- Edited an existing page (`get-started/deploy-smart-contracts.mdx`) within the established Quickstart group. (There is similar content under `base-chain/quickstart/deploy-on-base`)

- Eliminates 404s for users following the quickstart.

- Points to the archived repo explicitly, signaling the shift.

- Still encourages next steps (frontend integration + deeper Foundry usage) without dead ends.

