### PR TITLE
add beginner deployment note

### DIFF
--- a/docs/apps/quickstart/build-app.mdx
+++ b/docs/apps/quickstart/build-app.mdx
@@ -534,6 +534,10 @@ Base is a fast, low-cost Ethereum L2 built to bring the next billion users oncha
     ```bash Terminal
     npm run dev
     ```
+<Note>
+For beginners building their first Base mini-app, deploying with Vercel provides one of the simplest production workflows for testing and app verification.
+</Note>
+
   </Step>
 </Steps>
 


### PR DESCRIPTION
What changed? Why?

While following the "Build an app on Base" guide as a beginner, I felt that a short deployment recommendation could help new developers complete the mini-app workflow more smoothly. I added a small note mentioning Vercel as a simple option for testing and app verification.

Notes to reviewers

This is a documentation-only change with no functional impact.

How has it been tested?

Reviewed formatting and placement within the existing guide structure.
