### PR TITLE
finalize Azul upgrade docs post-activation

### DIFF
--- a/docs/base-chain/specs/upgrades/azul/node-upgrade.mdx
+++ b/docs/base-chain/specs/upgrades/azul/node-upgrade.mdx
@@ -1,22 +1,12 @@
 ---
-title: "Base Azul Upgrade"
+title: "Node Upgrade Guide"
+sidebarTitle: "Node Upgrade Guide"
 description: "Migrate your Base node to base-reth-node and base-consensus for Azul."
 ---
 
-<Warning>
-Base Azul is an upgrade that introduces Osaka features on Base and TEE/ZK proof systems. It requires migrating to Base-native clients.
-</Warning>
+Only `base-reth-node` (EL) and `base-consensus` (CL) support Azul. **Nodes running `op-node`, `op-geth`, `op-reth`, `nethermind`, or `kona` will not support the network upgrade and must be migrated.**
 
-Only `base-reth-node` (EL) and `base-consensus` (CL) support Azul. **Nodes running `op-node`, `op-geth`, `op-reth`, `nethermind`, or `kona` will not support the network upgrade and must be migrated before activation.**
-
-For full details on what's included, see the [Azul specification](/base-chain/specs/upgrades/azul/overview).
-
-## Activation Timeline
-
-| Network | Date | Timestamp |
-|---------|------|-----------|
-| Mainnet | May 28, 2026 18:00 UTC | `1779991200` |
-| Sepolia | April 20, 2026 18:00 UTC | `1776708000` |
+Azul activated on mainnet on **May 28, 2026 18:00 UTC** (`1779991200`). See the [Azul overview](/base-chain/specs/upgrades/azul/overview#activation-timestamps) for the full activation timestamp table.
 
 ## Required Software
 

--- a/docs/base-chain/specs/upgrades/azul/overview.mdx
+++ b/docs/base-chain/specs/upgrades/azul/overview.mdx
@@ -16,14 +16,10 @@ Only `base-consensus` and `base-reth-node` will support the Base Azul hardfork. 
 
 ## Activation Timestamps
 
-| Network | Activation timestamp |
-|---------|----------------------|
-| `mainnet` | `1779991200` (2026-05-28 18:00:00 UTC) |
-| `sepolia` | `1776708000` (2026-04-20 18:00:00 UTC) |
-
-<Warning>
-The mainnet activation date is tentative and subject to change. Follow [@buildonbase](https://x.com/buildonbase) for the latest updates.
-</Warning>
+| Network | Timestamp | Date |
+|---------|-----------|------|
+| `mainnet` | `1779991200` | 2026-05-28 18:00:00 UTC |
+| `sepolia` | `1776708000` | 2026-04-20 18:00:00 UTC |
 
 ## Execution Layer
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -131,7 +131,6 @@
           {
             "group": "Node Operators",
             "pages": [
-              "base-chain/node-operators/base-v1-upgrade",
               "base-chain/node-operators/run-a-base-node",
               "base-chain/node-operators/performance-tuning",
               "base-chain/node-operators/snapshots",
@@ -274,6 +273,7 @@
                     "group": "Azul",
                     "pages": [
                       "base-chain/specs/upgrades/azul/overview",
+                      "base-chain/specs/upgrades/azul/node-upgrade",
                       "base-chain/specs/upgrades/azul/exec-engine",
                       "base-chain/specs/upgrades/azul/proofs"
                     ]
@@ -786,6 +786,10 @@
     ]
   },
   "redirects": [
+    {
+      "source": "/base-chain/node-operators/base-v1-upgrade",
+      "destination": "/base-chain/specs/upgrades/azul/node-upgrade"
+    },
     {
       "source": "/ai-agents/quickstart/payments",
       "destination": "/ai-agents/guides/x402-payments"


### PR DESCRIPTION
**What changed? Why?**
Azul activated on mainnet May 28. This PR cleans up the docs to reflect that:
- Removes "tentative activation date" warning from Azul overview
- Consolidates duplicate activation timeline tables into one
- Moves the Azul node upgrade guide from Node Operators into the Azul specs section now that the upgrade is complete

**Notes to reviewers**

**How has it been tested?**
Locally