### PR TITLE
Add NodeFlare to Base node providers

### DIFF
--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -103,6 +103,14 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 - Base Mainnet
 - Base Sepolia (Testnet)
 
+## NodeFlare
+
+[NodeFlare](https://nodeflare.app) is a multi-region RPC provider for Base and other EVM chains, with automatic failover and global request routing. It offers a free public endpoint, a free tier with an API key, and [paid plans](https://nodeflare.app/pricing) with higher rate limits and larger monthly quotas.
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+
 ## NodeReal
 
 [NodeReal](https://nodereal.io/) is a blockchain infrastructure and services provider that provides instant and easy-access to Base node APIs.


### PR DESCRIPTION
## Description

Adds **NodeFlare** to the Node Providers list for Base.

[NodeFlare](https://nodeflare.app) is a multi-region RPC provider supporting Base Mainnet, with automatic failover and global request routing. It offers a free public endpoint, a free tier with an API key, and paid plans with higher rate limits and larger monthly quotas.

The entry is inserted alphabetically (before NodeReal) and follows the existing format with a `Supported Networks` subsection.

## Supported Networks
- Base Mainnet