### PR TITLE
fix(base-chain): update per-tx gas cap to 16,777,216 after Azul (EIP-7825)

### DIFF
--- a/docs/base-chain/network-information/block-building.mdx
+++ b/docs/base-chain/network-information/block-building.mdx
@@ -54,9 +54,11 @@ For a comprehensive technical deep dive into Flashblocks architecture, see the [
 
 ### Per-Transaction Gas Maximum
 
-Base enforces a per-transaction gas maximum of **25,000,000 gas**. Transactions that specify a gas limit above this value are **rejected by the mempool before inclusion**. `eth_sendTransaction` or `eth_sendRawTransaction` will return a JSON-RPC error (for example: `exceeds maximum per-transaction gas limit`). This cap does **not** change the block gas limit or the block validity conditions.
+Base enforces a per-transaction gas maximum of **16,777,216 gas (2^24)** via [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825), activated on mainnet in the [Azul](/base-chain/specs/upgrades/azul/overview) hardfork. Transactions that specify a gas limit above this value are **rejected by the mempool before inclusion**. `eth_sendTransaction` or `eth_sendRawTransaction` will return a JSON-RPC error (for example: `exceeds maximum per-transaction gas limit`). This cap does **not** change the block gas limit.
 
-Fusaka's [EIP 7825](https://eips.ethereum.org/EIPS/eip-7825) **will** change the block validity conditions and enforce a lower per-transaction gas maximum of 16,777,216 gas (2^24). We expect this protocol change to be adopted in all OP Stack chains around January 2026.
+<Note>
+Deposit transactions are exempt from the per-transaction gas cap. See [Azul: Transaction Gas Limit Cap](/base-chain/specs/upgrades/azul/exec-engine#transaction-gas-limit-cap) for details.
+</Note>
 
 Bundler operators for smart contract wallets must configure their systems to limit the bundle size to fit within this cap.
 

--- a/docs/base-chain/network-information/troubleshooting-transactions.mdx
+++ b/docs/base-chain/network-information/troubleshooting-transactions.mdx
@@ -50,11 +50,11 @@ If you submit a transaction with a nonce that has already been used, it will be 
 
 ### Gas Limit Exceeds Maximum
 
-Base enforces a [per-transaction gas maximum](/base-chain/network-information/block-building#per-transaction-gas-maximum) of **25,000,000 gas**. Transactions specifying a higher gas limit are rejected by the mempool before inclusion.
+Base enforces a [per-transaction gas maximum](/base-chain/network-information/block-building#per-transaction-gas-maximum) of **16,777,216 gas (2^24)** via EIP-7825 (Azul). Transactions specifying a higher gas limit are rejected by the mempool before inclusion.
 
 **Error**: `exceeds maximum per-transaction gas limit`
 
-**Solution**: Reduce the gas limit to 25,000,000 or below. If your transaction genuinely requires more gas, you'll need to break it into multiple transactions.
+**Solution**: Reduce the gas limit to 16,777,216 or below. If your transaction genuinely requires more gas, break it into multiple transactions.
 
 ## Transaction Included But Failed
 


### PR DESCRIPTION
## Summary

Updates network-information docs to match post-Azul mainnet behavior (EIP-7825 per-transaction gas cap).

- `block-building.mdx`: replace outdated 25M cap and future-tense Fusaka note with **16,777,216 gas (2^24)** and link to Azul spec
- `troubleshooting-transactions.mdx`: align error guidance with the same cap

## Why

Azul activated on mainnet (2026-05-28). Spec pages were updated in #1580, but developer-facing network/troubleshooting pages still documented 25M and a January 2026 future change—causing incorrect mempool troubleshooting.

## Test plan

- [x] `cd docs && npx mint dev` — local preview at http://localhost:3000
- [x] Block building → Per-Transaction Gas Maximum shows 16,777,216 (Azul/EIP-7825), no 25M or Jan 2026 wording
- [x] Troubleshooting transactions → Gas Limit Exceeds Maximum shows 16,777,216 solution
- [x] Cross-checked with Azul exec-engine Transaction Gas Limit Cap (same value)