### PR TITLE
docs: add related guides cross-references across Base Account documentation

### DIFF
--- a/docs/base-account/guides/accept-payments.mdx
+++ b/docs/base-account/guides/accept-payments.mdx
@@ -319,4 +319,14 @@ If you intend on using the BasePayButton, please follow the [Brand Guidelines](/
 2. Pass <code>testnet: true</code> in your <code>pay()</code> and <code>getPaymentStatus()</code> calls.  
 3. Use <a href="https://sepolia.basescan.org" target="_blank">Sepolia BaseScan</a> to watch the transaction.
 
- 
+ ## Related guides 
+
+After implementing payments, you may also want to: 
+
+- [Sponsor gas fees with Paymasters](/base-account/guides/paymasters) 
+
+- [Use Spend Permissions](/base-account/guides/spend-permissions) 
+
+- [Create subscriptions](/base-account/reference/account-sdk/subscriptions) 
+
+- [Integrate with Privy](/base-account/framework-integrations/privy/setup)

--- a/docs/base-account/improve-ux/sponsor-gas/paymasters.mdx
+++ b/docs/base-account/improve-ux/sponsor-gas/paymasters.mdx
@@ -299,3 +299,13 @@ the [Coinbase Developer Platform documentation](https://docs.cdp.coinbase.com/pa
 
   </Step>
 </Steps>
+
+## Related guides 
+
+After configuring Paymasters, you may also want to: 
+
+- [Accept payments](/base-account/guides/accept-payments) 
+
+- [Batch transactions](/base-account/guides/batch-transactions) 
+
+- [Configure account permissions](/base-account/guides/spend-permissions)


### PR DESCRIPTION
**What changed? Why?**

- Documentation pages often solve a specific problem, but developers frequently need to combine multiple Base Account features to build complete applications.

- Adding **Related Guides** section helps developers discover relevant documentation without leaving their current workflow. It also improves documentation retrieval for AI-powered assistants and search systems by creating explicit relationships between concepts.

- A developer reading one guide often needs two or three related guides next.

- Currently, those relationships may not always be obvious.

**Notes to reviewers**

- Added **Related guides** sections to `accept-payments.mdx` and `paymasters.mdx`

- Added semantic links to associated Framework Integration and Reference pages.

- Preserved the existing documentation hierarchy.

- Did not introduce any new top-level sections or subsections.