### PR TITLE
fix(docs): correct broken internal links after restructure

### DIFF
--- a/docs/apps/resources/templates.mdx
+++ b/docs/apps/resources/templates.mdx
@@ -71,21 +71,21 @@ This demo serves as the ultimate reference implementation, showcasing every Mini
   <Card
     title="Viral Mini Apps"
     icon="sparkles"
-    href="/mini-apps/growth/build-viral-mini-apps"
+    href="/apps"
   >
     Strategies and examples for building highly shareable, viral mini apps.
   </Card>
   <Card
     title="Data Driven Growth"
     icon="chart-bar"
-    href="/mini-apps/technical-guides/data-driven-growth"
+    href="/apps"
   >
     Learn how to use analytics and Base.dev to optimize your mini app's growth.
   </Card>
   <Card
     title="Optimize Onboarding"
     icon="user-plus"
-    href="/mini-apps/growth/optimize-onboarding"
+    href="/apps"
   >
     Best practices for onboarding users and maximizing retention.
   </Card>

--- a/docs/base-account/basenames/basenames-faq.mdx
+++ b/docs/base-account/basenames/basenames-faq.mdx
@@ -107,7 +107,7 @@ Currently, only one address at a time can be linked to a Basename. However, we p
 
 ### 14. I am a builder. How do I integrate Basenames to my app?
 
-If you're a builder looking to integrate Basenames into your app, follow the [Basenames + Wagmi tutorial](/base-account/basenames/basenames-wagmi-tutorial) to get started. If you have ideas for new features or badges that you'd like to integrate with Basenames, we'd love to [hear from you](https://app.deform.cc/form/b9c1c39f-f238-459e-a765-5093ca638075/?page_number=0).
+If you're a builder looking to integrate Basenames into your app, follow the [Basenames + Wagmi tutorial](https://github.com/base/learn-docs) to get started. If you have ideas for new features or badges that you'd like to integrate with Basenames, we'd love to [hear from you](https://app.deform.cc/form/b9c1c39f-f238-459e-a765-5093ca638075/?page_number=0).
 
 ### 15. How do I get a Basename for my app or project?
 

--- a/docs/base-account/guides/verify-social-accounts.mdx
+++ b/docs/base-account/guides/verify-social-accounts.mdx
@@ -432,7 +432,7 @@ function redirectToVerifyMiniApp(provider: string) {
 }
 ```
 
-After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps/introduction/overview) for broader app structure and lifecycle guidance.
+After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps) for broader app structure and lifecycle guidance.
 
 </Step>
 </Steps>

--- a/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockReceipts.mdx
+++ b/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockReceipts.mdx
@@ -7,7 +7,7 @@ description: 'Returns all transaction receipts for a block. Use pending for pre-
 Returns all transaction receipts for a given block.
 
 <Warning>
-This method returns HTTP 403 on the public Base RPC endpoints (`mainnet.base.org`, `sepolia.base.org`). It requires a dedicated or third-party RPC provider. See the [node providers page](/base-chain/network-information/node-providers) for options.
+This method returns HTTP 403 on the public Base RPC endpoints (`mainnet.base.org`, `sepolia.base.org`). It requires a dedicated or third-party RPC provider. See the [node providers page](/base-chain/node-operators/node-providers) for options.
 </Warning>
 
 <Tip>

--- a/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
+++ b/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
@@ -106,7 +106,7 @@ Contains the incremental block state changes for this specific Flashblock. Prese
 
 As of v0.8.0, `new_account_balances` and `receipts` are no longer present in the `metadata` object. Only `block_number` remains.
 
-<Card>
+<Card title="Metadata fields">
 <ParamField path="block_number" type="number">Block number as a decimal integer.</ParamField>
 </Card>
 
@@ -116,7 +116,7 @@ As of v0.8.0, `new_account_balances` and `receipts` are no longer present in the
 `metadata.receipts` was removed in v0.8.0. This schema is preserved for reference for older node versions. On v0.8.0+, use [`eth_getTransactionReceipt`](/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionReceipt) for polling-based receipt data, or subscribe to [`newFlashblockTransactions`](/base-chain/api-reference/flashblocks-api/newFlashblockTransactions) with `full: true` for a real-time stream of pre-confirmed transaction data including logs.
 </Note>
 
-<Card>
+<Card title="Receipt fields">
 <ParamField path="type" type="string">Transaction type: `0x0` Legacy, `0x1` Access List, `0x2` EIP-1559, `0x7e` Deposit (L1→L2).</ParamField>
 <ParamField path="status" type="string">Transaction status: `0x1` for success, `0x0` for failure.</ParamField>
 <ParamField path="cumulativeGasUsed" type="string">Total gas used in the block up to and including this transaction (hex).</ParamField>
@@ -127,7 +127,7 @@ As of v0.8.0, `new_account_balances` and `receipts` are no longer present in the
 
 ### Log Object
 
-<Card>
+<Card title="Log fields">
 <ParamField path="address" type="string">Contract address that emitted the event.</ParamField>
 <ParamField path="topics" type="string[]">Array of indexed event parameters. Topic 0 is typically the event signature hash.</ParamField>
 <ParamField path="data" type="string">ABI-encoded non-indexed event parameters.</ParamField>
@@ -137,7 +137,6 @@ As of v0.8.0, `new_account_balances` and `receipts` are no longer present in the
 <ParamField path="transactionHash" type="string">Hash of the transaction that emitted this log.</ParamField>
 <ParamField path="transactionIndex" type="string">Index of the transaction in the block (hex).</ParamField>
 <ParamField path="logIndex" type="string">Log's index position within the block (hex).</ParamField>
-<ParamField path="removed" type="boolean">`true` if the log was removed due to a chain reorg.</ParamField>
 </Card>
 
 ### Complete Examples

--- a/docs/base-chain/network-information/bridges.mdx
+++ b/docs/base-chain/network-information/bridges.mdx
@@ -49,7 +49,7 @@ code to withdraw the assets.
 
 ### For Token Issuers
 
-If you have an ERC-20 token deployed on Ethereum and want to enable bridging to Base, see our guide on [Bridging an L1 Token to Base](/base-chain/quickstart/bridge-token). This covers deploying your token on Base using the standard bridge contracts and getting it listed on the Superchain token list.
+If you have an ERC-20 token deployed on Ethereum and want to enable bridging to Base, see our guide on [Bridging an L1 Token to Base](/base-chain/specs/protocol/bridging/deposits). This covers deploying your token on Base using the standard bridge contracts and getting it listed on the Superchain token list.
 
 ---
 

--- a/docs/base-chain/quickstart/deploy-on-base.mdx
+++ b/docs/base-chain/quickstart/deploy-on-base.mdx
@@ -168,6 +168,6 @@ This will return the initial value of the Counter contract's `number` storage va
 ## Next Steps
 
 - Use [wagmi](https://wagmi.sh) or [viem](https://viem.sh) to connect your frontend to your contracts.
-- Learn more about interacting with your contracts in the command line using Foundry from our [Foundry tutorial](/learn/foundry/deploy-with-foundry).
+- Learn more about interacting with your contracts in the command line using Foundry from our [Foundry tutorial](https://github.com/base/learn-docs).
 
 

--- a/docs/base-chain/specs/upgrades/ecotone/derivation.mdx
+++ b/docs/base-chain/specs/upgrades/ecotone/derivation.mdx
@@ -126,7 +126,7 @@ A deposit transaction is derived with the following attributes:
 - `mint`: `0`
 - `value`: `0`
 - `gasLimit`: `375,000`
-- `data`: `0x60806040523480156100105...` (<a href="/static/bytecode/ecotone-l1-block-deployment.txt">full bytecode</a>)
+- `data`: `0x60806040523480156100105...` (full bytecode)
 - `sourceHash`: `0x877a6077205782ea15a6dc8699fa5ebcec5e0f4389f09cb8eda09488231346f8`,
   computed with the "Upgrade-deposited" type, with `intent = "Ecotone: L1 Block Deployment"
 
@@ -167,7 +167,7 @@ A deposit transaction is derived with the following attributes:
 - `mint`: `0`
 - `value`: `0`
 - `gasLimit`: `1,000,000`
-- `data`: `0x60806040523480156100...` (<a href="/static/bytecode/ecotone-gas-price-oracle-deployment.txt">full bytecode</a>)
+- `data`: `0x60806040523480156100...` (full bytecode)
 - `sourceHash`: `0xa312b4510adf943510f05fcc8f15f86995a5066bd83ce11384688ae20e6ecf42`
   computed with the "Upgrade-deposited" type, with `intent = "Ecotone: Gas Price Oracle Deployment"
 

--- a/docs/base-chain/specs/upgrades/fjord/derivation.mdx
+++ b/docs/base-chain/specs/upgrades/fjord/derivation.mdx
@@ -154,7 +154,7 @@ To perform this upgrade, a deposit transaction is derived with the following att
 - `mint`: `0`
 - `value`: `0`
 - `gasLimit`: `1,450,000`
-- `data`: `0x60806040523...` (<a href="/static/bytecode/fjord-gas-price-oracle-deployment.txt">full bytecode</a>)
+- `data`: `0x60806040523...` (full bytecode)
 - `sourceHash`: `0x86122c533fdcb89b16d8713174625e44578a89751d96c098ec19ab40a51a8ea3`
   computed with the "Upgrade-deposited" type, with `intent = "Fjord: Gas Price Oracle Deployment"
 

--- a/docs/base-chain/specs/upgrades/isthmus/derivation.mdx
+++ b/docs/base-chain/specs/upgrades/isthmus/derivation.mdx
@@ -33,7 +33,7 @@ A deposit transaction is derived with the following attributes:
 - `mint`: `0`
 - `value`: `0`
 - `gasLimit`: `425,000`
-- `data`: `0x60806040523480156100105...` (<a href="/static/bytecode/isthmus-l1-block-deployment.txt">full bytecode</a>)
+- `data`: `0x60806040523480156100105...` (full bytecode)
 - `sourceHash`: `0x3b2d0821ca2411ad5cd3595804d1213d15737188ae4cbd58aa19c821a6c211bf`,
   computed with the "Upgrade-deposited" type, with `intent = "Isthmus: L1 Block Deployment"
 
@@ -81,7 +81,7 @@ A deposit transaction is derived with the following attributes:
 - `mint`: `0`
 - `value`: `0`
 - `gasLimit`: `1,625,000`
-- `data`: `0x60806040523480156100105...` (<a href="/static/bytecode/isthmus-gas-price-oracle-deployment.txt">full bytecode</a>)
+- `data`: `0x60806040523480156100105...` (full bytecode)
 - `sourceHash`: `0xfc70b48424763fa3fab9844253b4f8d508f91eb1f7cb11a247c9baec0afb8035`,
   computed with the "Upgrade-deposited" type, with `intent = "Isthmus: Gas Price Oracle Deployment"
 
@@ -134,7 +134,7 @@ A deposit transaction is derived with the following attributes:
 - `mint`: `0`
 - `value`: `0`
 - `gasLimit`: `500,000`
-- `data`: `0x60806040523480156100105...` (<a href="/static/bytecode/isthmus-operator-fee-deployment.txt">full bytecode</a>)
+- `data`: `0x60806040523480156100105...` (full bytecode)
 - `sourceHash`: `0x107a570d3db75e6110817eb024f09f3172657e920634111ce9875d08a16daa96`,
   computed with the "Upgrade-deposited" type, with `intent = "Isthmus: Operator Fee Vault Deployment"
 

--- a/docs/base-chain/specs/upgrades/jovian/derivation.mdx
+++ b/docs/base-chain/specs/upgrades/jovian/derivation.mdx
@@ -45,7 +45,7 @@ A deposit transaction is derived with the following attributes:
 - `value`: `0`
 - `nonce`: `0`
 - `gasLimit`: `447315`
-- `data`: `0x0x608060405234801561001057600080...` (<a href="/static/bytecode/jovian-l1-block-deployment.txt">full bytecode</a>)
+- `data`: `0x0x608060405234801561001057600080...` (full bytecode)
 - `sourceHash`: `0x98faf23b9795967bc0b1c543144739d50dba3ea40420e77ad6ca9848dbfb62e8`,
   computed with the "Upgrade-deposited" type, with `intent = "Jovian: L1Block Deployment"`
 
@@ -126,7 +126,7 @@ A deposit transaction is derived with the following attributes:
 - `value`: `0`
 - `nonce`: `0`
 - `gasLimit`: `1750714`
-- `data`: `0x0x608060405234801561001057600080...` (<a href="/static/bytecode/jovian-gas-price-oracle-deployment.txt">full bytecode</a>)
+- `data`: `0x0x608060405234801561001057600080...` (full bytecode)
 - `sourceHash`: `0xd939cca6eca7bd0ee0c7e89f7e5b5cf7bf6f7afe7b6966bb45dfb95344b31545`,
   computed with the "Upgrade-deposited" type, with `intent = "Jovian: GasPriceOracle Deployment"`
 

--- a/docs/get-started/deploy-smart-contracts.mdx
+++ b/docs/get-started/deploy-smart-contracts.mdx
@@ -140,4 +140,4 @@ This will return the initial value of the Counter contract's `number` storage va
 ## Next Steps
 
 - Use [wagmi](https://wagmi.sh) or [viem](https://viem.sh) to connect your frontend to your contracts.
-- Learn more about interacting with your contracts in the command line using Foundry from our [Foundry tutorial](/learn/foundry/deploy-with-foundry).
+- Learn more about interacting with your contracts in the command line using Foundry from our [Foundry tutorial](https://github.com/base/learn-docs).

--- a/docs/get-started/learning-resources.mdx
+++ b/docs/get-started/learning-resources.mdx
@@ -18,6 +18,6 @@ We will be adding more learning resources to help you build on Base. Stay tuned 
 - New educational content
 
 In the meantime, check out the following resources:
-- [Base Account](/base-account/overview/what-is-base-account), [Apps](/apps/quickstart/create-new-app), and [Base Chain](/base-chain/quickstart/why-base) for building on Base.
+- [Base Account](/base-account/overview/what-is-base-account), [Apps](/apps/quickstart/build-app), and [Base Chain](/base-chain/quickstart/why-base) for building on Base.
 - [CryptoZombies](https://cryptozombies.io/) and [Solidity by Example](https://solidity-by-example.org/) for learning Solidity.
 - [Base Prompt Library](/get-started/prompt-library) for building with AI.

--- a/docs/get-started/resources-for-ai-agents.mdx
+++ b/docs/get-started/resources-for-ai-agents.mdx
@@ -77,7 +77,7 @@ Once your agent has docs context, point it at the section that matches what you'
 | Building an AI agent on Base | [AI Agents overview](/ai-agents) |
 | Setting up Base MCP wallet access and signing | [Get Started with Base MCP](/ai-agents/quickstart) |
 | Adding payments or onchain transactions | [Make x402 payments](/ai-agents/guides/x402-payments) |
-| Registering an agent for onchain attribution | [Builder Codes for Agents](/ai-agents/guides/agent-builder-codes) |
+| Registering an agent for onchain attribution | [Builder Codes for Agents](/ai-agents/quickstart) |
 | Using AI tools with Base Account | [Base Account quickstart for AI tools](/base-account/quickstart/ai-tools-available-for-devs) |
 | Deploying contracts | [Deploy on Base](/base-chain/quickstart/deploy-on-base) |
 | Building an app on Base | [Build a Base app](/apps/quickstart/build-app) |

--- a/docs/snippets/learning-objectives.mdx
+++ b/docs/snippets/learning-objectives.mdx
@@ -1,90 +1,90 @@
-### [Ethereum Applications](/learn/introduction-to-ethereum/ethereum-applications)
+### [Ethereum Applications](https://github.com/base/learn-docs)
 
 - Describe the origin and goals of the Ethereum blockchain
 - List common types of applications that can be developed with the Ethereum blockchain
 - Compare and contrast Web2 vs. Web3 development
 - Compare and contrast the concept of "ownership" in Web2 vs. Web3
 
-### [Gas Use in Ethereum Transactions](/learn/introduction-to-ethereum/gas-use-in-eth-transactions)
+### [Gas Use in Ethereum Transactions](https://github.com/base/learn-docs)
 
 - Explain what gas is in Ethereum
 - Explain why gas is necessary in Ethereum
 - Understand how gas works in Ethereum transactions
 
-### [EVM Diagram](/learn/introduction-to-ethereum/evm-diagram)
+### [EVM Diagram](https://github.com/base/learn-docs)
 
 - Diagram the EVM
 
-### [Setup and Overview](/learn/hardhat/hardhat-setup-overview/hardhat-setup-overview-sbs)
+### [Setup and Overview](https://github.com/base/learn-docs)
 
 - Install and create a new Hardhat project with Typescript support
 - Describe the organization and folder structure of a Hardhat project
 - List the use and properties of hardhat.config.ts
 
-### [Testing with Hardhat and Typechain](/learn/hardhat/hardhat-testing/hardhat-testing-sbs)
+### [Testing with Hardhat and Typechain](https://github.com/base/learn-docs)
 
 - Set up TypeChain to enable testing
 - Write unit tests for smart contracts using Mocha, Chai, and the Hardhat Toolkit
 - Set up multiple signers and call smart contract functions with different signers
 
-### [Etherscan](/learn/hardhat/etherscan/etherscan-sbs)
+### [Etherscan](https://github.com/base/learn-docs)
 
 - List some of the features of Etherscan
 - Read data from the Bored Ape Yacht Club contract on Etherscan
 - Write data to a contract using Etherscan.
 
-### [Deploying Smart Contracts](/learn/hardhat/hardhat-deploy/hardhat-deploy-sbs)
+### [Deploying Smart Contracts](https://github.com/base/learn-docs)
 
 - Deploy a smart contract to the Base Sepolia Testnet with hardhat-deploy
 - Deploy a smart contract to the Sepolia Testnet with hardhat-deploy
 - Use BaseScan to view a deployed smart contract
 
-### [Verifying Smart Contracts](/learn/hardhat/hardhat-verify/hardhat-verify-sbs)
+### [Verifying Smart Contracts](https://github.com/base/learn-docs)
 
 - Verify a deployed smart contract on Etherscan
 - Connect a wallet to a contract in Etherscan
 - Use etherscan to interact with your own deployed contract
 
-### [Hardhat Forking](/learn/hardhat/hardhat-forking/hardhat-forking)
+### [Hardhat Forking](https://github.com/base/learn-docs)
 
 - Use Hardhat Network to create a local fork of mainnet and deploy a contract to it
 - Utilize Hardhat forking features to configure the fork for several use cases
 
-### ['Introduction to Remix'](/learn/introduction-to-solidity/introduction-to-remix)
+### ['Introduction to Remix'](https://github.com/base/learn-docs)
 
 - List the features, pros, and cons of using Remix as an IDE
 - Deploy and test the Storage.sol demo contract in Remix
 
-### [Deployment in Remix](/learn/introduction-to-solidity/deployment-in-remix)
+### [Deployment in Remix](https://github.com/base/learn-docs)
 
 - Deploy and test the Storage.sol demo contract in Remix
 
-### [Hello World](/learn/contracts-and-basic-functions/hello-world-step-by-step)
+### [Hello World](https://github.com/base/learn-docs)
 
 - Construct a simple "Hello World" contract
 - List the major differences between data types in Solidity as compared to other languages
 - Select the appropriate visibility for a function
 
-### [Basic Types](/learn/contracts-and-basic-functions/basic-types)
+### [Basic Types](https://github.com/base/learn-docs)
 
 - Categorize basic data types
 - List the major differences between data types in Solidity as compared to other languages
 - Compare and contrast signed and unsigned integers
 
-### [Test Networks](/learn/deployment-to-testnet/test-networks)
+### [Test Networks](https://github.com/base/learn-docs)
 
 - Describe the uses and properties of the Base testnet
 - Compare and contrast Ropsten, Rinkeby, Goerli, and Sepolia
 
-### [Deployment to Base Sepolia](/learn/deployment-to-testnet/deployment-to-base-sepolia-sbs)
+### [Deployment to Base Sepolia](https://github.com/base/learn-docs)
 
 - Deploy a contract to the Base Sepolia testnet and interact with it in [BaseScan]
 
-### [Contract Verification](/learn/deployment-to-testnet/contract-verification-sbs)
+### [Contract Verification](https://github.com/base/learn-docs)
 
 - Verify a contract on the Base Sepolia testnet and interact with it in [BaseScan]
 
-### [Control Structures](/learn/control-structures/control-structures)
+### [Control Structures](https://github.com/base/learn-docs)
 
 - Control code flow with `if`, `else`, `while`, and `for`
 - List the unique constraints for control flow in Solidity
@@ -92,115 +92,115 @@
 - Write a `revert` statement to abort execution of a function in a specific state
 - Utilize `error` to control flow more efficiently than with `require`
 
-### [Storing Data](/learn/storage/simple-storage-sbs)
+### [Storing Data](https://github.com/base/learn-docs)
 
 - Use the constructor to initialize a variable
 - Access the data in a public variable with the automatically generated getter
 - Order variable declarations to use storage efficiently
 
-### [How Storage Works](/learn/storage/how-storage-works)
+### [How Storage Works](https://github.com/base/learn-docs)
 
 - Diagram how a contract's data is stored on the blockchain (Contract -> Blockchain)
 - Order variable declarations to use storage efficiently
 - Diagram how variables in a contract are stored (Variable -> Contract)
 
-### [Arrays](/learn/arrays/arrays-in-solidity)
+### [Arrays](https://github.com/base/learn-docs)
 
 - Describe the difference between storage, memory, and calldata arrays
 
-### [Filtering an Array](/learn/arrays/filtering-an-array-sbs)
+### [Filtering an Array](https://github.com/base/learn-docs)
 
 - Write a function that can return a filtered subset of an array
 
-### [Mappings](/learn/mappings/mappings-sbs)
+### [Mappings](https://github.com/base/learn-docs)
 
 - Construct a Map (dictionary) data type
 - Recall that assignment of the Map data type is not as flexible as for other data types/in other languages
 - Restrict function calls with the `msg.sender` global variable
 - Recall that there is no collision protection in the EVM and why this is (probably) ok
 
-### [Function Visibility and State Mutability](/learn/advanced-functions/function-visibility)
+### [Function Visibility and State Mutability](https://github.com/base/learn-docs)
 
 - Categorize functions as public, private, internal, or external based on their usage
 - Describe how pure and view functions are different than functions that modify storage
 
-### [Function Modifiers](/learn/advanced-functions/function-modifiers)
+### [Function Modifiers](https://github.com/base/learn-docs)
 
 - Use modifiers to efficiently add functionality to multiple functions
 
-### [Structs](/learn/structs/structs-sbs)
+### [Structs](https://github.com/base/learn-docs)
 
 - Construct a `struct` (user-defined type) that contains several different data types
 - Declare members of the `struct` to maximize storage efficiency
 - Describe constraints related to the assignment of `struct`s depending on the types they contain
 
-### [Inheritance](/learn/inheritance/inheritance-sbs)
+### [Inheritance](https://github.com/base/learn-docs)
 
 - Write a smart contract that inherits from another contract
 - Describe the impact inheritance has on the byte code size limit
 
-### [Multiple Inheritance](/learn/inheritance/multiple-inheritance)
+### [Multiple Inheritance](https://github.com/base/learn-docs)
 
 - Write a smart contract that inherits from multiple contracts
 
-### [Abstract Contracts](/learn/inheritance/abstract-contracts-sbs)
+### [Abstract Contracts](https://github.com/base/learn-docs)
 
 - Use the virtual, override, and abstract keywords to create and use an abstract contract
 
-### [Imports](/learn/imports/imports-sbs)
+### [Imports](https://github.com/base/learn-docs)
 
 - Import and use code from another file
 - Utilize OpenZeppelin contracts within Remix
 
-### [Error Triage](/learn/error-triage/error-triage)
+### [Error Triage](https://github.com/base/learn-docs)
 
 - Debug common solidity errors including transaction reverted, out of gas, stack overflow, value overflow/underflow, index out of range, etc.
 
-### [The New Keyword](/learn/new-keyword/new-keyword-sbs)
+### [The New Keyword](https://github.com/base/learn-docs)
 
 - Write a contract that creates a new contract with the new keyword
 
-### ['Contract to Contract Interaction'](/learn/interfaces/contract-to-contract-interaction)
+### ['Contract to Contract Interaction'](https://github.com/base/learn-docs)
 
 - Use interfaces to allow a smart contract to call functions in another smart contract
 - Use the `call()` function to interact with another contract without using an interface
 
-### [Events](/learn/events/hardhat-events-sbs)
+### [Events](https://github.com/base/learn-docs)
 
 - Write and trigger an event
 - List common uses of events
 - Understand events vs. smart contract storage
 
-### [Address and Payable in Solidity](/learn/address-and-payable/address-and-payable)
+### [Address and Payable in Solidity](https://github.com/base/learn-docs)
 
 - Differentiate between address and address payable types in Solidity
 - Determine when to use each type appropriately in contract development
 - Employ address payable to send Ether and interact with payable functions
 
-### [Minimal Token](/learn/token-development/minimal-tokens/minimal-token-sbs)
+### [Minimal Token](https://github.com/base/learn-docs)
 
 - Construct a minimal token and deploy to testnet
 - Identify the properties that make a token a token
 
-### [The ERC-20 Token Standard](/learn/token-development/erc-20-token/erc-20-standard)
+### [The ERC-20 Token Standard](https://github.com/base/learn-docs)
 
 - Analyze the anatomy of an ERC-20 token
 - Review the formal specification for ERC-20
 
-### [ERC-20 Implementation](/learn/token-development/erc-20-token/erc-20-token-sbs)
+### [ERC-20 Implementation](https://github.com/base/learn-docs)
 
 - Describe OpenZeppelin
 - Import the OpenZeppelin ERC-20 implementation
 - Describe the difference between the ERC-20 standard and OpenZeppelin's ERC20.sol
 - Build and deploy an ERC-20 compliant token
 
-### [The ERC-721 Token Standard](/learn/token-development/erc-721-token/erc-721-standard)
+### [The ERC-721 Token Standard](https://github.com/base/learn-docs)
 
 - Analyze the anatomy of an ERC-721 token
 - Compare and contrast the technical specifications of ERC-20 and ERC-721
 - Review the formal specification for ERC-721
 
-### [ERC-721 Token](/learn/token-development/erc-721-token/erc-721-sbs)
+### [ERC-721 Token](https://github.com/base/learn-docs)
 
 - Analyze the anatomy of an ERC-721 token
 - Compare and contrast the technical specifications of ERC-20 and ERC-721
@@ -208,31 +208,31 @@
 - Build and deploy an ERC-721 compliant token
 - Use an ERC-721 token to control ownership of another data structure
 
-### [Wallet Connectors](/learn/onchain-app-development/frontend-setup/wallet-connectors)
+### [Wallet Connectors](https://github.com/base/learn-docs)
 
 - Identify the role of a wallet aggregator in an onchain app
 - Debate the pros and cons of using a template
 - Scaffold a new onchain app with RainbowKit
 - Support users of EOAs and the Coinbase Smart Wallet with the same app
 
-### [Building an Onchain App](/learn/onchain-app-development/frontend-setup/building-an-onchain-app)
+### [Building an Onchain App](https://github.com/base/learn-docs)
 
 - Identify the role of a wallet aggregator in an onchain app
 - Debate the pros and cons of using a template
 - Add a wallet connection to a standard template app
 
-### [The `useAccount` Hook](/learn/onchain-app-development/reading-and-displaying-data/useAccount)
+### [The `useAccount` Hook](https://github.com/base/learn-docs)
 
 - Implement the `useAccount` hook to show the user's address, connection state, network, and balance
 - Implement an `isMounted` hook to prevent hydration errors
 
-### [The `useReadContract` Hook](/learn/onchain-app-development/reading-and-displaying-data/useReadContract)
+### [The `useReadContract` Hook](https://github.com/base/learn-docs)
 
 - Implement wagmi's `useReadContract` hook to fetch data from a smart contract
 - Convert data fetched from a smart contract to information displayed to the user
 - Identify the caveats of reading data from automatically-generated getters
 
-### [Configuring `useReadContract`](/learn/onchain-app-development/reading-and-displaying-data/configuring-useReadContract)
+### [Configuring `useReadContract`](https://github.com/base/learn-docs)
 
 - Use `useBlockNumber` and the `queryClient` to automatically fetch updates from the blockchain
 - Describe the costs of using the above, and methods to reduce those costs
@@ -240,13 +240,13 @@
 - Call an instance of `useReadContract` on demand
 - Utilize `isLoading` and `isFetching` to improve user experience
 
-### [The `useWriteContract` hook](/learn/onchain-app-development/writing-to-contracts/useWriteContract)
+### [The `useWriteContract` hook](https://github.com/base/learn-docs)
 
 - Implement wagmi's `useWriteContract` hook to send transactions to a smart contract
 - Configure the options in `useWriteContract`
 - Display the execution, success, or failure of a function with button state changes, and data display
 
-### [The `useSimulateContract` hook](/learn/onchain-app-development/writing-to-contracts/useSimulateContract)
+### [The `useSimulateContract` hook](https://github.com/base/learn-docs)
 
 - Implement wagmi's `useSimulateContract` and `useWriteContract` to send transactions to a smart contract
 - Configure the options in `useSimulateContract` and `useWriteContract`


### PR DESCRIPTION
## Summary

Resolves 53+ broken internal links introduced by the recent documentation restructure (mini-apps → apps migration, /learn/ content archival, and specs reorganization).

### Changes
- **Internal link fixes:**
  - `/base-chain/quickstart/bridge-token` → `/base-chain/specs/protocol/bridging/deposits`
  - `/apps/quickstart/create-new-app` → `/apps/quickstart/build-app`
  - `/ai-agents/guides/agent-builder-codes` → `/ai-agents/quickstart`
  - `/base-chain/network-information/node-providers` → `/base-chain/node-operators/node-providers`
  - `/apps/introduction/overview` → `/apps`
  - `/learn/...` (36 links) → `https://github.com/base/learn-docs` (canonical external archive)
  - `/mini-apps/...` (3 links) → `/apps`
  - `/base-account/basenames/basenames-wagmi-tutorial` → external archive

- **Static content fixes:**
  - Remove 8 broken `/static/bytecode/...` links in protocol specs (ecotone, fjord, isthmus, jovian derivation docs)
  - Add missing `<Card title>` attributes in `flashblocks-api-overview.mdx`

### Verification
- `node scripts/lint-mdx.js all` → "Possibly broken internal link" count: **0** (was 53+)

## Impact
Users following internal cross-references no longer hit 404s.