### PR TITLE
docs(specs): challenger description mentions challenge as well as nullify

### DIFF
--- a/docs/base-chain/specs/protocol/proofs/challenger.mdx
+++ b/docs/base-chain/specs/protocol/proofs/challenger.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Challenger"
-description: "Specification of the challenger, an offchain service that detects invalid AggregateVerifier games and submits dispute transactions on L1 to nullify them."
+description: "Specification of the challenger, an offchain service that detects invalid AggregateVerifier games and submits dispute transactions on L1 to challenge or nullify them."
 ---
 
 The challenger is an offchain service that protects the proof system by independently checking


### PR DESCRIPTION
## Summary

The challenger spec's frontmatter description omits the `challenge()` transaction type — only `nullify()` is mentioned. The spec body documents both as first-class actions.

## The drift

**`docs/base-chain/specs/protocol/proofs/challenger.mdx:3`** — frontmatter:
> "... submits dispute transactions on L1 to nullify them"

**Spec body**, however, documents two distinct transactions the challenger submits:
- `nullify()` — referenced at lines 26 and 57
- `challenge()` — referenced at lines 148–149

These are not the same. `challenge()` initiates a dispute against a proposed output; `nullify()` invalidates an already-finalized output. The challenger uses both depending on the attack scenario.

## Why this matters

The frontmatter description is what appears in:
- The browser tab title preview
- The sidebar navigation tooltip
- Search result snippets (Mintlify / docs.json indexing)
- Social embed cards if the page is shared

Reading "submits dispute transactions on L1 to nullify them" leads someone scanning the docs to believe nullification is the sole mechanism. That's the most likely misconception people will form before clicking into the page — and it's wrong.

## The fix

```diff
- description: "... submits dispute transactions on L1 to nullify them"
+ description: "... submits dispute transactions on L1 to challenge or nullify them"
```

Single-line change. Matches what the spec body already documents.

## Verification

- ✅ One file modified: `docs/base-chain/specs/protocol/proofs/challenger.mdx`
- ✅ Body of the spec unchanged
- ✅ Description now matches the two transaction types documented in the body