### PR TITLE
docs(specs): tee-prover description mentions re-derivation step

### DIFF
--- a/docs/base-chain/specs/protocol/proofs/tee-prover.mdx
+++ b/docs/base-chain/specs/protocol/proofs/tee-prover.mdx
@@ -1,6 +1,6 @@
 ---
 title: "TEE Prover"
-description: "Specification of the TEE prover, an offchain service that re-executes L2 block ranges inside AWS Nitro Enclaves to produce signed proof material for AggregateVerifier games."
+description: "Specification of the TEE prover, an offchain service that re-derives and re-executes L2 block ranges inside AWS Nitro Enclaves to produce signed proof material for AggregateVerifier games."
 ---
 
 The TEE prover is an offchain service that produces signed proof material for `AggregateVerifier`


### PR DESCRIPTION
## Summary

The TEE prover spec's frontmatter description says the prover "re-executes L2 block ranges", but the spec body explicitly includes re-derivation as part of the proof. Re-derivation is the trust-critical first step — omitting it from the description weakens what the page promises about the system's security model.

## The drift

**`docs/base-chain/specs/protocol/proofs/tee-prover.mdx:3`** — frontmatter:
> "... an offchain service that re-executes L2 block ranges"

**Spec body, line 7**:
> "... re-deriving and re-executing an L2 block range"

Re-derivation and re-execution are two distinct steps:

1. **Re-derivation** — reconstruct the canonical L2 state by reading posted L1 calldata and running the derivation pipeline. This is the step that anchors the L2 state to L1 data.
2. **Re-execution** — replay the resulting transactions against that derived state to produce a new state root.

Without step 1, step 2 is just "the operator hands the TEE some L2 state and asks it to re-execute" — which proves nothing about whether that state was honestly derived from L1. The security guarantee comes from the **combination**.

## Why this matters

The frontmatter description shows up wherever the page is previewed (sidebar tooltips, search results, social embeds). Describing the TEE prover as a service that "re-executes L2 block ranges" reads naturally as "the TEE runs the block again and signs the result" — which is technically true but misses the security-relevant half of the system.

A reader who only reads the description forms a weaker mental model of the trust assumption than the page itself documents. Aligning the description with the body fixes that.

## The fix

```diff
- description: "... an offchain service that re-executes L2 block ranges"
+ description: "... an offchain service that re-derives and re-executes L2 block ranges"
```

Single-line change. Matches the spec body verbatim.

## Verification

- ✅ One file modified: `docs/base-chain/specs/protocol/proofs/tee-prover.mdx`
- ✅ Spec body unchanged
- ✅ Description now matches the wording the body already uses