### PR TITLE
docs(ai-agents): two grammar fixes in plugin examples

### DIFF
--- a/docs/ai-agents/plugins/native/avantis.mdx
+++ b/docs/ai-agents/plugins/native/avantis.mdx
@@ -28,7 +28,7 @@ Avantis is a perpetual futures DEX on Base mainnet. The plugin reads market data
 ## Try it
 
 ```text Read pairs and PnL (any surface)
-What's my Avantis open positions and PnL on Base?
+What are my Avantis open positions and PnL on Base?
 ```
 
 ```text Open long (CLI harness)

--- a/docs/ai-agents/plugins/native/index.mdx
+++ b/docs/ai-agents/plugins/native/index.mdx
@@ -107,7 +107,7 @@ Most transaction plugins follow the prepare → `send_calls` pattern described i
     ```
 
     ```text Uniswap
-    Create a ETH/USDC LP position on Uniswap
+    Create an ETH/USDC LP position on Uniswap
     ```
 
     ```text Avantis


### PR DESCRIPTION
## Summary

Two small grammar errors in example user prompts on the AI agents plugin documentation. Both prompts are shown prominently as "Try it" examples — they're the first interaction a developer has with the plugin docs.

## Changes

### `docs/ai-agents/plugins/native/index.mdx:110`

```diff
- Create a ETH/USDC LP position on Uniswap
+ Create an ETH/USDC LP position on Uniswap
```

`ETH` starts with a vowel sound when read aloud (*ee-tee-aitch*), so the indefinite article should be `an`. The same rule that gives us *"an FBI agent"* or *"an MRI scan"*.

### `docs/ai-agents/plugins/native/avantis.mdx:31`

```diff
- What's my Avantis open positions and PnL on Base?
+ What are my Avantis open positions and PnL on Base?
```

Subject-verb agreement. *"positions"* is plural, but *"What's"* expands to *"What is"* (singular). The sentence is asking about multiple positions, so it needs *"What are"*.

## Why this matters

Both fixes touch the **"Try it"** sections — the example prompts that show users what to type when first exercising a plugin. Grammar errors there are the first impression of doc quality, and these are the kinds of strings users may copy verbatim into their own integrations or screenshots.

## Verification

- ✅ Two files modified, one line each
- ✅ No other content touched
- ✅ Both fixes are objectively correct grammar, not style preference