### PR TITLE
docs: fix broken Foundry tutorial link in deploy-smart-contracts

### DIFF
--- a/docs/get-started/deploy-smart-contracts.mdx
+++ b/docs/get-started/deploy-smart-contracts.mdx
@@ -140,4 +140,6 @@ This will return the initial value of the Counter contract's `number` storage va
 ## Next Steps
 
 - Use [wagmi](https://wagmi.sh) or [viem](https://viem.sh) to connect your frontend to your contracts.
-- Learn more about interacting with your contracts in the command line using Foundry from our [Foundry tutorial](/learn/foundry/deploy-with-foundry).
+- Learn more about interacting with your contracts in the command line 
+using Foundry from the [Foundry Book](https://book.getfoundry.sh/) 
+or the [archived Base learn docs](https://github.com/base/learn-docs).


### PR DESCRIPTION
## What
The Foundry tutorial link points to `/learn/foundry/deploy-with-foundry` 
which no longer exists — the Learn section was archived.

## Fix
Replaced dead link with:
- Foundry Book (https://book.getfoundry.sh/)
- Archived Base learn docs (https://github.com/base/learn-docs)

## References
- https://docs.base.org/get-started/learning-resources
