### PR TITLE
remove outdated op references

### DIFF
--- a/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs.mdx
+++ b/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs.mdx
@@ -48,7 +48,7 @@ Queries spanning large block ranges or high-activity contracts can time out or b
     <ResponseField name="topics" type="array">Array of 0–4 indexed 32-byte topics. Topic 0 is typically the event signature hash.</ResponseField>
     <ResponseField name="data" type="string">ABI-encoded non-indexed event parameters.</ResponseField>
     <ResponseField name="blockNumber" type="string">Block number in which this log was emitted (hex).</ResponseField>
-    <ResponseField name="blockTimestamp" type="string">Unix timestamp of the block containing this log as a hex string. OP Stack extension to the standard Ethereum log schema.</ResponseField>
+    <ResponseField name="blockTimestamp" type="string">Unix timestamp of the block containing this log as a hex string. Base L2 extension to the standard Ethereum log schema.</ResponseField>
     <ResponseField name="transactionHash" type="string">32-byte hash of the transaction that emitted this log.</ResponseField>
     <ResponseField name="transactionIndex" type="string">Index of the transaction in the block (hex).</ResponseField>
     <ResponseField name="blockHash" type="string">32-byte hash of the block.</ResponseField>

--- a/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByHash.mdx
+++ b/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByHash.mdx
@@ -46,7 +46,7 @@ Returns information about a transaction given its hash. Returns `null` for unkno
 </ResponseField>
 
 <Note>
-**Transaction types on Base:** Base supports Ethereum-standard types (`0x0` legacy, `0x1` EIP-2930, `0x2` EIP-1559) as well as OP Stack deposit transactions (`0x7e`). Deposit transactions are injected by the sequencer at the start of each block. Fields like `maxFeePerGas`, `accessList`, and `chainId` are not present on `0x7e` transactions; instead they carry `sourceHash`, `mint`, `depositReceiptVersion`, and `yParity`.
+**Transaction types on Base:** Base supports Ethereum-standard types (`0x0` legacy, `0x1` EIP-2930, `0x2` EIP-1559) as well as Base deposit transactions (`0x7e`). Deposit transactions are injected by the sequencer at the start of each block. Fields like `maxFeePerGas`, `accessList`, and `chainId` are not present on `0x7e` transactions; instead they carry `sourceHash`, `mint`, `depositReceiptVersion`, and `yParity`.
 </Note>
 
 ## Example

--- a/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionReceipt.mdx
+++ b/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionReceipt.mdx
@@ -37,12 +37,12 @@ Receipts are only available for mined transactions. To monitor a transaction bef
     <ResponseField name="type" type="string">Transaction type: `"0x0"` Legacy, `"0x1"` Access List, `"0x2"` EIP-1559, `"0x7e"` Deposit (L1→L2).</ResponseField>
     <ResponseField name="status" type="string">`"0x1"` for success, `"0x0"` for failure (revert).</ResponseField>
     <ResponseField name="blobGasUsed" type="string">Blob gas consumed by this transaction (EIP-4844). `null` for non-blob transactions.</ResponseField>
-    <ResponseField name="l1Fee" type="string">Total L1 data fee paid for this transaction (hex). OP Stack L2 field.</ResponseField>
-    <ResponseField name="l1GasUsed" type="string">Amount of L1 gas used for the L1 data portion of this transaction (hex). OP Stack L2 field.</ResponseField>
-    <ResponseField name="l1GasPrice" type="string">L1 gas price at the time of inclusion (hex). OP Stack L2 field.</ResponseField>
-    <ResponseField name="l1BlobBaseFee" type="string">Blob base fee on L1 at the time of inclusion (hex). OP Stack L2 field.</ResponseField>
-    <ResponseField name="l1BlobBaseFeeScalar" type="string">Scalar applied to the blob base fee for L1 fee calculation (hex). OP Stack L2 field.</ResponseField>
-    <ResponseField name="l1BaseFeeScalar" type="string">Scalar applied to the L1 base fee for L1 fee calculation (hex). OP Stack L2 field.</ResponseField>
+    <ResponseField name="l1Fee" type="string">Total L1 data fee paid for this transaction (hex). Base L2 field.</ResponseField>
+    <ResponseField name="l1GasUsed" type="string">Amount of L1 gas used for the L1 data portion of this transaction (hex). Base L2 field.</ResponseField>
+    <ResponseField name="l1GasPrice" type="string">L1 gas price at the time of inclusion (hex). Base L2 field.</ResponseField>
+    <ResponseField name="l1BlobBaseFee" type="string">Blob base fee on L1 at the time of inclusion (hex). Base L2 field.</ResponseField>
+    <ResponseField name="l1BlobBaseFeeScalar" type="string">Scalar applied to the blob base fee for L1 fee calculation (hex). Base L2 field.</ResponseField>
+    <ResponseField name="l1BaseFeeScalar" type="string">Scalar applied to the L1 base fee for L1 fee calculation (hex). Base L2 field.</ResponseField>
     <ResponseField name="daFootprintGasScalar" type="string">Base-specific DA footprint scalar (hex).</ResponseField>
     <ResponseField name="depositNonce" type="string">Nonce used for the deposit transaction (hex). Present on type `0x7e` transactions only.</ResponseField>
     <ResponseField name="depositReceiptVersion" type="string">Deposit receipt version (hex). Present on type `0x7e` transactions only.</ResponseField>

--- a/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionReceipt.mdx
+++ b/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionReceipt.mdx
@@ -73,7 +73,7 @@ Receipts are only available for mined transactions. To monitor a transaction bef
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "blobGasUsed": "0x4154",
+    "blobGasUsed": null,
     "blockHash": "0x491bca01d4bc076d60833dbd973fe031a74e7ae31866bf70d077619e09edb6ff",
     "blockNumber": "0x2c31b0b",
     "contractAddress": null,

--- a/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
+++ b/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
@@ -104,7 +104,7 @@ Contains the incremental block state changes for this specific Flashblock. Prese
 **The `metadata` object is not stable.** Fields may be added, modified, or removed without prior notice. Do not build production dependencies on it — use the [`diff`](#diff-object) object or query finalized block data via standard RPC instead.
 </Warning>
 
-As of v0.8.0, `new_account_balances` and `receipts` are no longer present in the `metadata` object. Only `block_number` remains.
+As of v0.8.0, `new_account_balances` and `receipts` are no longer present in the `metadata` object. `block_number` remains. The `access_list` field is present but always empty.
 
 <Card>
 <ParamField path="block_number" type="number">Block number as a decimal integer.</ParamField>

--- a/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
+++ b/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
@@ -133,7 +133,7 @@ As of v0.8.0, `new_account_balances` and `receipts` are no longer present in the
 <ParamField path="data" type="string">ABI-encoded non-indexed event parameters.</ParamField>
 <ParamField path="blockHash" type="string">Hash of the block containing this log.</ParamField>
 <ParamField path="blockNumber" type="string">Block number in hex.</ParamField>
-<ParamField path="blockTimestamp" type="string">Unix timestamp of the block as a hex string. OP Stack extension to the standard Ethereum log schema.</ParamField>
+<ParamField path="blockTimestamp" type="string">Unix timestamp of the block as a hex string. Base L2 extension to the standard Ethereum log schema.</ParamField>
 <ParamField path="transactionHash" type="string">Hash of the transaction that emitted this log.</ParamField>
 <ParamField path="transactionIndex" type="string">Index of the transaction in the block (hex).</ParamField>
 <ParamField path="logIndex" type="string">Log's index position within the block (hex).</ParamField>

--- a/docs/base-chain/flashblocks/architecture.mdx
+++ b/docs/base-chain/flashblocks/architecture.mdx
@@ -10,8 +10,8 @@ Base operates a high-availability sequencer system with five sequencer instances
 
 | Component | Role |
 |-----------|------|
-| **op-node** | Standard OP Stack consensus layer (CL) |
-| **op-geth** | Standard OP Stack execution layer (EL) |
+| **base-consensus** | Consensus layer (CL) — replaced op-node after Azul |
+| **base-reth-node** | Execution layer (EL) — replaced op-geth after Azul |
 | **op-conductor** | High availability controller with Raft consensus for leader election |
 
 One sequencer instance acts as the **leader**, responsible for building blocks and propagating them via P2P. The remaining four act as **followers** that sync the chain. Leadership transfers if the current leader stops producing blocks.

--- a/docs/base-chain/flashblocks/architecture.mdx
+++ b/docs/base-chain/flashblocks/architecture.mdx
@@ -23,11 +23,11 @@ Flashblocks introduce several new infrastructure components:
 | Component | Purpose | What It Unlocks |
 |-----------|---------|-----------------|
 | **rollup-boost** | CL↔EL Engine API proxy | Enables sharing Flashblocks with the EL without modifying the CL. Provides a stable seam for future block-building evolutions (multi-builder, etc.) |
-| **op-rbuilder** | Out-of-protocol builder at 200ms cadence | Produces the sub-second Flashblocks, decoupled from the EL. Enables pluggable builder mechanisms |
+| **base-builder** | Out-of-protocol builder at 200ms cadence | Produces the sub-second Flashblocks, decoupled from the EL. Enables pluggable builder mechanisms |
 | **websocket-proxy** | Flashblocks stream fan-out | Broadcast layer so many consumers can read the stream without overwhelming the builder |
 | **[base](https://github.com/base/base)** | RPC surface exposing preconfirmations | Converts streamed Flashblocks into familiar RPCs so apps and wallets can consume preconfirmation state |
 
-Both [rollup-boost](https://github.com/flashbots/rollup-boost) and [op-rbuilder](https://github.com/flashbots/op-rbuilder) are built and maintained by Flashbots, while Base maintains the websocket-proxy and [base](https://github.com/base/base) components.
+[rollup-boost](https://github.com/flashbots/rollup-boost) is built and maintained by Flashbots, while Base maintains [base-builder](https://github.com/base/base/tree/main/crates/builder), the websocket-proxy, and the [base](https://github.com/base/base) components.
 
 ---
 

--- a/docs/base-chain/flashblocks/overview.mdx
+++ b/docs/base-chain/flashblocks/overview.mdx
@@ -41,7 +41,7 @@ User → DNS (mainnet.base.org) → Load Balancer → Proxyd → Mempool
 The transaction reaches the private mempool and is inserted into the txpool as pending.
 
 ### 2. Distribution
-The mempool maintains P2P connections with execution layers (op-reth, op-rbuilder), ensuring all pending transactions are synced for block building.
+The mempool maintains P2P connections with execution layers (base-reth-node, op-rbuilder), ensuring all pending transactions are synced for block building.
 
 ### 3. Block Building
 During each 200ms block building loop, op-rbuilder selects transactions based on:

--- a/docs/base-chain/flashblocks/overview.mdx
+++ b/docs/base-chain/flashblocks/overview.mdx
@@ -27,7 +27,7 @@ Each block contains **10 Flashblocks** (indexes 1-10), each arriving every 200ms
 
 ## Architecture
 
-For details on the sequencer system and Flashblocks infrastructure components (rollup-boost, op-rbuilder, websocket-proxy, and base), see the [Architecture](/base-chain/flashblocks/architecture) page.
+For details on the sequencer system and Flashblocks infrastructure components (rollup-boost, base-builder, websocket-proxy, and base), see the [Architecture](/base-chain/flashblocks/architecture) page.
 
 ## Transaction Lifecycle
 
@@ -41,10 +41,10 @@ User → DNS (mainnet.base.org) → Load Balancer → Proxyd → Mempool
 The transaction reaches the private mempool and is inserted into the txpool as pending.
 
 ### 2. Distribution
-The mempool maintains P2P connections with execution layers (base-reth-node, op-rbuilder), ensuring all pending transactions are synced for block building.
+The mempool maintains P2P connections with execution layers (base-reth-node, base-builder), ensuring all pending transactions are synced for block building.
 
 ### 3. Block Building
-During each 200ms block building loop, op-rbuilder selects transactions based on:
+During each 200ms block building loop, base-builder selects transactions based on:
 
 1. **Transaction fee** — transactions are ordered by fee (highest first)
 2. **Gas limit and remaining capacity** — each Flashblock `j` can use up to `j/10` of the total block gas limit

--- a/docs/base-chain/network-information/block-building.mdx
+++ b/docs/base-chain/network-information/block-building.mdx
@@ -64,6 +64,5 @@ Bundler operators for smart contract wallets must configure their systems to lim
 
 ### Vanilla
 
-Blocks are built every 2s by [op-geth](https://github.com/ethereum-optimism/op-geth). Transactions within those blocks are ordered by
-priority fee, see the ([code](https://github.com/ethereum-optimism/op-geth/blob/optimism/miner/worker.go#L627)).
+Blocks are built every 2s by `base-reth-node`. Transactions within those blocks are ordered by priority fee.
 

--- a/docs/base-chain/network-information/block-building.mdx
+++ b/docs/base-chain/network-information/block-building.mdx
@@ -22,7 +22,7 @@ See the [Configuration Changelog](/base-chain/network-information/configuration-
 
 ### Flashblocks
 
-Blocks are built using [op-rbuilder](https://github.com/flashbots/op-rbuilder) with priority fee auctions occurring every **200ms**. This reduces effective block times from 2 seconds to 200 milliseconds through preconfirmations.
+Blocks are built using [base-builder](https://github.com/base/base/tree/main/crates/builder) with priority fee auctions occurring every **200ms**. This reduces effective block times from 2 seconds to 200 milliseconds through preconfirmations.
 
 <Info>
 For a comprehensive technical deep dive into Flashblocks architecture, see the [Flashblocks Overview](/base-chain/flashblocks/overview).

--- a/docs/base-chain/network-information/diffs-ethereum-base.mdx
+++ b/docs/base-chain/network-information/diffs-ethereum-base.mdx
@@ -11,8 +11,8 @@ These minor differences include:
 
 - [Flashblocks](https://docs.base.org/base-chain/flashblocks/app-integration)
 - [Minimum base fee](/base-chain/network-information/network-fees#minimum-base-fee)
-- [Bridging](https://docs.optimism.io/stack/differences#bridging)
-- [Opcodes](https://docs.optimism.io/stack/differences#opcodes)
-- [Address aliasing](https://docs.optimism.io/stack/differences#address-aliasing)
-- [Transaction costs](https://docs.optimism.io/stack/differences#transaction-fees)
-- [Chain Finality](https://docs.optimism.io/stack/differences#chain-finality)
+- [Bridging](/base-chain/specs/protocol/bridging/bridges)
+- [Opcodes](/base-chain/specs/protocol/execution/evm/precompiles)
+- [Address aliasing](/base-chain/specs/protocol/bridging/deposits#address-aliasing)
+- [Transaction costs](/base-chain/network-information/network-fees)
+- [Chain Finality](/base-chain/network-information/transaction-finality)

--- a/docs/base-chain/network-information/diffs-ethereum-base.mdx
+++ b/docs/base-chain/network-information/diffs-ethereum-base.mdx
@@ -3,16 +3,16 @@ title: "Differences between Ethereum and Base"
 sidebarTitle: 'Differences: Ethereum & Base'
 ---
 
-Base is built to be as compatible as possible to Etherum, and there are very few differences when it comes to building on Base versus Ethereum.
+Base is built to be as compatible as possible to Ethereum, and there are very few differences when it comes to building on Base versus Ethereum.
 
 However, there are still some minor discrepancies between the behavior of Base and Ethereum that you should be aware of when building apps on top of Base.
 
 These minor differences include:
 
-- [Flashblocks](https://docs.base.org/base-chain/flashblocks/app-integration)
+- [Flashblocks](/base-chain/flashblocks/app-integration)
 - [Minimum base fee](/base-chain/network-information/network-fees#minimum-base-fee)
 - [Bridging](/base-chain/specs/protocol/bridging/bridges)
-- [Opcodes](/base-chain/specs/protocol/execution/evm/precompiles)
+- [Precompiles](/base-chain/specs/protocol/execution/evm/precompiles)
 - [Address aliasing](/base-chain/specs/protocol/bridging/deposits#address-aliasing)
 - [Transaction costs](/base-chain/network-information/network-fees)
 - [Chain Finality](/base-chain/network-information/transaction-finality)

--- a/docs/base-chain/network-information/network-fees.mdx
+++ b/docs/base-chain/network-information/network-fees.mdx
@@ -23,8 +23,7 @@ same implementation as the L1; you can read more about it
 [here](https://help.coinbase.com/en/coinbase/getting-started/crypto-education/eip-1559).
 
 For additional details about fee calculation on Base, please refer to the
-[op-stack developer
-documentation](https://docs.optimism.io/stack/transactions/fees).
+[network fees specification](/base-chain/specs/protocol/execution/evm/predeploys#gaspriceoracle).
 
 ## Minimum Base Fee
 
@@ -49,7 +48,7 @@ See the [Configuration Changelog](/base-chain/network-information/configuration-
 
 ## EIP-1559 Fee Parameters
 
-Base uses the OP Stack's implementation of EIP-1559, which controls how the L2 base fee adjusts in response to network demand. Two key parameters govern this behavior:
+Base uses its own implementation of EIP-1559, which controls how the L2 base fee adjusts in response to network demand. Two key parameters govern this behavior:
 
 ### Elasticity Multiplier
 
@@ -93,4 +92,4 @@ The **GasPriceOracle** predeployment at `0x4200000000000000000000000000000000000
 
 Use `getL1FeeUpperBound` when you need a quick estimate before the transaction is fully constructed. Use `getL1Fee` with the complete serialized transaction for an exact value before signing.
 
-[Jovian upgrade]: https://docs.optimism.io/notices/upgrade-17
+[Jovian upgrade]: /base-chain/specs/upgrades/jovian/overview

--- a/docs/base-chain/network-information/troubleshooting-transactions.mdx
+++ b/docs/base-chain/network-information/troubleshooting-transactions.mdx
@@ -31,7 +31,7 @@ During periods of high demand, transactions compete for block space through prio
 **Solution**: Most users simply wait for congestion to subside. For time-sensitive transactions, use `eth_maxPriorityFeePerGas` to get a priority fee estimate that can outbid enough recent transactions to be included.
 
 <Note>
-If [DA throttling](https://docs.optimism.io/chain-operators/guides/configuration/batcher#batcher-sequencer-throttling) is currently in effect, there's no RPC endpoint that calculates priority fee estimates with throttling in mind. During DA throttling, even transactions with high priority fees may be delayed as the sequencer limits L2 transactions to manage its L1 data availability throughput.
+If DA throttling is currently in effect, there's no RPC endpoint that calculates priority fee estimates with throttling in mind. During DA throttling, even transactions with high priority fees may be delayed as the sequencer limits L2 transactions to manage its L1 data availability throughput.
 </Note>
 
 ### Nonce Gap

--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -67,9 +67,11 @@ You'll need your own L1 RPC URL. This can be one that you run yourself, or via a
 ## Running a Node
 
 1. Clone the [repo](https://github.com/base/node).
-2. Ensure you have an Ethereum L1 full node RPC available (not Base), and set `BASE_NODE_L1_ETH_RPC` & `BASE_NODE_L1_BEACON` (in the `.env.*` file if using `docker-compose`). If running your own L1 node, it needs to be synced before Base will be able to fully sync.
-3. Uncomment the line relevant to your network (`.env.sepolia`, or `.env.mainnet`) under the 2 `env_file` keys in `docker-compose.yml`.
-4. Run `docker compose up`. Confirm you get a response from:
+2. Ensure you have an Ethereum L1 full node RPC available (not Base), and set `BASE_NODE_L1_ETH_RPC` & `BASE_NODE_L1_BEACON` in the appropriate `.env` file (`.env.mainnet` or `.env.sepolia`). If running your own L1 node, it needs to be synced before Base will be able to fully sync.
+3. Start the node:
+   - **Mainnet**: `docker compose up --build`
+   - **Testnet**: `NETWORK_ENV=.env.sepolia docker compose up --build`
+4. Confirm you get a response from:
 
 ```bash Terminal
 curl -d '{"id":0,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest",false]}' \
@@ -105,17 +107,15 @@ Once your node is synced, you can enable Flashblocks to serve 200ms preconfirmat
 
 ### Configuration
 
-To enable Flashblocks, start your node with the following environment variables:
+To enable Flashblocks, set `RETH_FB_WEBSOCKET_URL` when starting your node:
 
 ```sh
-NODE_TYPE=base CLIENT=reth RETH_FB_WEBSOCKET_URL="wss://mainnet.flashblocks.base.org/ws" docker-compose up
+RETH_FB_WEBSOCKET_URL="wss://mainnet.flashblocks.base.org/ws" docker compose up --build
 ```
 
-| Variable | Description | Values |
-|----------|-------------|--------|
-| `NODE_TYPE` | Enables base reth node with Flashblocks | `base` |
-| `CLIENT` | Execution client | `reth` |
-| `RETH_FB_WEBSOCKET_URL` | Flashblocks WebSocket endpoint | See below |
+| Variable | Description |
+|----------|-------------|
+| `RETH_FB_WEBSOCKET_URL` | Flashblocks WebSocket endpoint (see below) |
 
 ### WebSocket Endpoints
 

--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -67,7 +67,7 @@ You'll need your own L1 RPC URL. This can be one that you run yourself, or via a
 ## Running a Node
 
 1. Clone the [repo](https://github.com/base/node).
-2. Ensure you have an Ethereum L1 full node RPC available (not Base), and set `OP_NODE_L1_ETH_RPC` & `OP_NODE_L1_BEACON` (in the `.env.*` file if using `docker-compose`). If running your own L1 node, it needs to be synced before Base will be able to fully sync.
+2. Ensure you have an Ethereum L1 full node RPC available (not Base), and set `BASE_NODE_L1_ETH_RPC` & `BASE_NODE_L1_BEACON` (in the `.env.*` file if using `docker-compose`). If running your own L1 node, it needs to be synced before Base will be able to fully sync.
 3. Uncomment the line relevant to your network (`.env.sepolia`, or `.env.mainnet`) under the 2 `env_file` keys in `docker-compose.yml`.
 4. Run `docker compose up`. Confirm you get a response from:
 

--- a/docs/base-chain/node-operators/troubleshooting.mdx
+++ b/docs/base-chain/node-operators/troubleshooting.mdx
@@ -34,13 +34,11 @@ Before diving into specific issues, here are some general steps that often help:
     - **Check**: Syntax errors in the command (e.g., misspelled `NETWORK_ENV` or `CLIENT`).
 
 - **Issue**: Container fails to start, logs show errors related to `.env` files or environment variables.  
-    - **Check**: Did you correctly configure the L1 endpoints (`OP_NODE_L1_ETH_RPC`, `OP_NODE_L1_BEACON`) in the correct `.env` file (`.env.mainnet` or `.env.sepolia`)?  
-    - **Check**: Is the `OP_NODE_L1_BEACON_ARCHIVER` endpoint set if required by your configuration or L1 node?  
-    - **Check**: Is `OP_NODE_L1_RPC_KIND` set correctly for your L1 provider?  
-    - **Check**: (Reth) Are `RETH_CHAIN` and `RETH_SEQUENCER_HTTP` correctly set in the `.env` file?
+    - **Check**: Did you correctly configure the L1 endpoints (`BASE_NODE_L1_ETH_RPC`, `BASE_NODE_L1_BEACON`) in the correct `.env` file (`.env.mainnet` or `.env.sepolia`)?  
+    - **Check**: Are `RETH_CHAIN` and `RETH_SEQUENCER_HTTP` correctly set in the `.env` file?
 
-- **Issue**: Errors related to JWT secret or authentication between `op-node` and L2 client.  
-    - **Check**: Ensure you haven't manually modified the `OP_NODE_L2_ENGINE_AUTH` variable or the JWT file path (`$OP_NODE_L2_ENGINE_AUTH`) unless you know what you're doing. The `docker-compose` setup usually handles this automatically.
+- **Issue**: Errors related to JWT secret or authentication between `base-consensus` and the execution client.  
+    - **Check**: Ensure you haven't manually modified the `BASE_NODE_L2_ENGINE_AUTH` variable or the JWT file path (`$BASE_NODE_L2_ENGINE_AUTH`) unless you know what you're doing. The `docker-compose` setup usually handles this automatically.
 
 - **Issue**: Permission errors related to data volumes (`./reth-data`).
     - **Check**: Ensure the user running `docker compose` has write permissions to the directory where the `node` repository was cloned. Docker needs to be able to write to `./reth-data`. Sometimes running Docker commands with `sudo` can cause permission issues later; try running as a non-root user added to the `docker` group.
@@ -48,8 +46,8 @@ Before diving into specific issues, here are some general steps that often help:
 ### Syncing Problems
 
 - **Issue**: Node doesn't start syncing or appears stuck (block height not increasing).  
-    - **Check**: `op-node` logs. Look for errors connecting to L1 endpoints or the L2 client.  
-    - **Check**: Look at logs for the execution client. Look for errors connecting to `op-node` via the Engine API (port `8551`) or P2P issues.
+    - **Check**: `base-consensus` logs. Look for errors connecting to L1 endpoints or the execution client.  
+    - **Check**: Look at logs for the execution client. Look for errors connecting to `base-consensus` via the Engine API (port `8551`) or P2P issues.
     - **Check**: L1 node health and sync status. Is the L1 node accessible and fully synced?
     - **Check**: System time. Ensure the server’s clock is accurately synchronized (use `ntp` or `chrony`). Significant time drift can cause P2P issues.
 
@@ -57,9 +55,9 @@ Before diving into specific issues, here are some general steps that often help:
     - **Check**: Hardware specifications. Are you meeting the recommended specs (especially RAM and **NVMe SSD**) outlined in the [Node Performance](/base-chain/node-operators/performance-tuning) guide? Disk I/O is often the bottleneck.  
     - **Check**: L1 node performance. Is your L1 RPC endpoint responsive? A slow L1 node will slow down L2 sync.  
     - **Check**: Network connection quality and bandwidth.  
-    - **Check**: `op-node` and L2 client logs for any performance warnings or errors.
+    - **Check**: `base-consensus` and execution client logs for any performance warnings or errors.
 
-- **Issue**: `optimism_syncStatus` (port `7545` on `op-node`) shows a large time difference or errors.  
+- **Issue**: `optimism_syncStatus` (port `7545` on `base-consensus`) shows a large time difference or errors.  
     - **Action**: Check the logs for both the rollup node and the L2 execution client around the time the status was checked to identify the root cause (e.g., L1 connection issues, L2 client issues).
 
 - **Issue**: `Error: nonce has already been used` when trying to send transactions.  

--- a/docs/base-chain/node-operators/troubleshooting.mdx
+++ b/docs/base-chain/node-operators/troubleshooting.mdx
@@ -31,7 +31,7 @@ Before diving into specific issues, here are some general steps that often help:
 - **Issue**: Docker command fails (`docker compose up ...`)  
     - **Check**: Is Docker and Docker Compose installed and the Docker daemon running?  
     - **Check**: Are you in the correct directory (the cloned `node` directory containing `docker-compose.yml`)?  
-    - **Check**: Syntax errors in the command (e.g., misspelled `NETWORK_ENV` or `CLIENT`).
+    - **Check**: Syntax errors in the command (e.g., misspelled `NETWORK_ENV`).
 
 - **Issue**: Container fails to start, logs show errors related to `.env` files or environment variables.  
     - **Check**: Did you correctly configure the L1 endpoints (`BASE_NODE_L1_ETH_RPC`, `BASE_NODE_L1_BEACON`) in the correct `.env` file (`.env.mainnet` or `.env.sepolia`)?  

--- a/docs/base-chain/specs/protocol/bridging/withdrawals.mdx
+++ b/docs/base-chain/specs/protocol/bridging/withdrawals.mdx
@@ -113,7 +113,7 @@ recognize that having the same address does not imply that a contract on L2 will
 
 ## The Optimism Portal Contract
 
-The Optimism Portal serves as both the entry and exit point to the Optimism L2. It is a contract which inherits from
+The Optimism Portal serves as both the entry and exit point to the Base L2. It is a contract which inherits from
 the [OptimismPortal](deposits#deposit-contract) contract, and in addition provides the following interface for
 withdrawals:
 

--- a/docs/base-chain/specs/protocol/consensus/derivation.mdx
+++ b/docs/base-chain/specs/protocol/consensus/derivation.mdx
@@ -731,10 +731,10 @@ To interact with the engine, the [execution engine API][exec-engine] is used, wi
   - [`engine_newPayloadV3`] — executes an Ecotone execution payload to create a block.
   - [`engine_newPayloadV4`] - executes an Isthmus execution payload to create a block.
 
-`base-consensus` uses the `v4` Engine API RPC methods as well as `engine_newPayloadV3` and
-`engine_newPayloadV2`, due to `engine_newPayloadV4` only supporting Isthmus execution payloads. Both
-`engine_forkchoiceUpdatedV4` and `engine_getPayloadV4` are backwards compatible with Ecotone, Bedrock,
-Canyon & Delta payloads.
+`base-consensus` uses [`engine_forkchoiceUpdatedV3`] and [`engine_getPayloadV4`] as well as
+`engine_newPayloadV3` and `engine_newPayloadV2`, due to `engine_newPayloadV4` only supporting Isthmus
+execution payloads. `engine_forkchoiceUpdatedV3` is backwards compatible with Ecotone, Bedrock, Canyon
+& Delta payloads.
 
 Prior versions used `v3`, `v2` and `v1` methods.
 
@@ -742,6 +742,7 @@ Prior versions used `v3`, `v2` and `v1` methods.
 [`engine_forkchoiceUpdatedV3`]: ../execution/index#engine_forkchoiceupdatedv3
 [`engine_getPayloadV2`]: ../execution/index#engine_getpayloadv2
 [`engine_getPayloadV3`]: ../execution/index#engine_getpayloadv3
+[`engine_getPayloadV4`]: ../execution/index#engine_getpayloadv4
 [`engine_newPayloadV2`]: ../execution/index#engine_newpayloadv2
 [`engine_newPayloadV3`]: ../execution/index#engine_newpayloadv3
 [`engine_newPayloadV4`]: ../execution/index#engine_newpayloadv4
@@ -808,7 +809,7 @@ If consolidation succeeds, the forkchoice change will synchronize as described i
 
 If consolidation fails, the L2 payload attributes will be processed immediately as described in the section below.
 The payload attributes are chosen in favor of the previous unsafe L2 block, creating an L2 chain reorg on top of the
-current safe block. Immediately processing the new alternative attributes enables execution engines like go-ethereum to
+current safe block. Immediately processing the new alternative attributes enables execution engines to
 enact the change, as linear rewinds of the tip of the chain may not be supported.
 
 #### L1-sync: payload attributes processing

--- a/docs/base-chain/specs/protocol/consensus/derivation.mdx
+++ b/docs/base-chain/specs/protocol/consensus/derivation.mdx
@@ -88,7 +88,7 @@ denominated in seconds):
   - `prev_l2_timestamp` is the timestamp of the L2 block immediately preceding this one. If there
     is no preceding block, then this is the genesis block, and its timestamp is explicitly
     specified.
-  - `l2_block_time` is a configurable parameter of the time between L2 blocks (2s on Optimism).
+  - `l2_block_time` is a configurable parameter of the time between L2 blocks (2s on Base).
 
 - `l1_origin.timestamp <= block.timestamp <= max_l2_timestamp`, where
   - `max_l2_timestamp = max(l1_origin.timestamp + max_sequencer_drift, prev_l2_timestamp + l2_block_time)`
@@ -731,12 +731,12 @@ To interact with the engine, the [execution engine API][exec-engine] is used, wi
   - [`engine_newPayloadV3`] — executes an Ecotone execution payload to create a block.
   - [`engine_newPayloadV4`] - executes an Isthmus execution payload to create a block.
 
-The current version of `op-node` uses the `v4` Engine API RPC methods as well as `engine_newPayloadV3` and
+`base-consensus` uses the `v4` Engine API RPC methods as well as `engine_newPayloadV3` and
 `engine_newPayloadV2`, due to `engine_newPayloadV4` only supporting Isthmus execution payloads. Both
 `engine_forkchoiceUpdatedV4` and `engine_getPayloadV4` are backwards compatible with Ecotone, Bedrock,
 Canyon & Delta payloads.
 
-Prior versions of `op-node` used `v3`, `v2` and `v1` methods.
+Prior versions used `v3`, `v2` and `v1` methods.
 
 [`engine_forkchoiceUpdatedV2`]: ../execution/index#engine_forkchoiceupdatedv2
 [`engine_forkchoiceUpdatedV3`]: ../execution/index#engine_forkchoiceupdatedv3

--- a/docs/base-chain/specs/protocol/consensus/p2p.mdx
+++ b/docs/base-chain/specs/protocol/consensus/p2p.mdx
@@ -363,7 +363,7 @@ This serves as a method to fill gaps upon missed gossip, and sync short to mediu
 
 Protocol ID: `/opstack/req/payload_by_number/<chain-id>/0/`
 
-- `/MessageName` is `/block_by_number/<chain-id>` where `<chain-id>` is set to the consensus client L2 chain ID.
+- `/MessageName` is `/payload_by_number/<chain-id>` where `<chain-id>` is set to the consensus client L2 chain ID.
 - `/SchemaVersion` is `/0`
 
 Request format: `<num>`: a little-endian `uint64` - the block number to request.

--- a/docs/base-chain/specs/protocol/consensus/p2p.mdx
+++ b/docs/base-chain/specs/protocol/consensus/p2p.mdx
@@ -326,7 +326,7 @@ TODO: GossipSub per-topic scoring to fine-tune incentives for ideal propagation 
 
 ## Req-Resp
 
-The op-node implements a similar request-response encoding for its sync protocols as the L1 ethereum Beacon-Chain.
+The consensus client (`base-consensus`) implements a similar request-response encoding for its sync protocols as the L1 ethereum Beacon-Chain.
 See [L1 P2P-interface req-resp specification][eth2-p2p-reqresp] and [Altair P2P update][eth2-p2p-altair-reqresp].
 
 However, the protocol is simplified, to avoid several issues seen in L1:
@@ -363,7 +363,7 @@ This serves as a method to fill gaps upon missed gossip, and sync short to mediu
 
 Protocol ID: `/opstack/req/payload_by_number/<chain-id>/0/`
 
-- `/MessageName` is `/block_by_number/<chain-id>` where `<chain-id>` is set to the op-node L2 chain ID.
+- `/MessageName` is `/block_by_number/<chain-id>` where `<chain-id>` is set to the consensus client L2 chain ID.
 - `/SchemaVersion` is `/0`
 
 Request format: `<num>`: a little-endian `uint64` - the block number to request.

--- a/docs/base-chain/specs/protocol/consensus/p2p.mdx
+++ b/docs/base-chain/specs/protocol/consensus/p2p.mdx
@@ -347,7 +347,7 @@ except the trailing encoding schema part, which is now message-specific:
 /ProtocolPrefix/MessageName/SchemaVersion/
 ```
 
-The req-resp protocols served by the op-node all have `/ProtocolPrefix` set to `/opstack/req`.
+The req-resp protocols served by the consensus client all have `/ProtocolPrefix` set to `/opstack/req`.
 
 Individual methods may include the chain ID as part of the `/MessageName` segment,
 so it's immediately clear which chain the method applies to, if the communication is chain-specific.

--- a/docs/base-chain/specs/protocol/execution/evm/precompiles.mdx
+++ b/docs/base-chain/specs/protocol/execution/evm/precompiles.mdx
@@ -24,7 +24,6 @@ The `P256VERIFY` precompile performs signature verification for the secp256r1 el
 adoption. It's used by Passkeys, Apple Secure Enclave and many other systems.
 
 It is specified as part of [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) and was added to
-the Base protocol in the Fjord release. The op-geth implementation is
-[here](https://github.com/ethereum-optimism/op-geth/blob/optimism/core/vm/contracts.go#L1161-L1193).
+the Base protocol in the Fjord release.
 
 Address: `0x0000000000000000000000000000000000000100`

--- a/docs/base-chain/specs/protocol/execution/evm/precompiles.mdx
+++ b/docs/base-chain/specs/protocol/execution/evm/precompiles.mdx
@@ -14,9 +14,9 @@ Base contains the [standard Ethereum precompiles](https://www.evm.codes/precompi
 number of additional precompiles. The following table lists each of the additional precompiles. The system version
 indicates when the precompile was introduced.
 
-| Name       | Address                                    | Introduced |
-|------------| ------------------------------------------ |------------|
-| P256VERIFY | 0x0000000000000000000000000000000000000100 | Fjord      |
+| Name       | Address                                    | Introduced | Gas Cost |
+|------------| ------------------------------------------ |------------|----------|
+| P256VERIFY | 0x0000000000000000000000000000000000000100 | Fjord      | 6,900 (updated in Azul) |
 
 ## P256VERIFY
 
@@ -24,6 +24,19 @@ The `P256VERIFY` precompile performs signature verification for the secp256r1 el
 adoption. It's used by Passkeys, Apple Secure Enclave and many other systems.
 
 It is specified as part of [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) and was added to
-the Base protocol in the Fjord release.
+the Base protocol in the Fjord release with a gas cost of 3,450.
+
+With the [Azul hardfork](/base-chain/specs/upgrades/azul/exec-engine#secp256r1-precompile-gas-cost), the gas cost was updated to **6,900** to match [EIP-7951](https://eips.ethereum.org/EIPS/eip-7951) and maintain strict equivalence with L1 precompile pricing.
 
 Address: `0x0000000000000000000000000000000000000100`
+
+## Standard Ethereum Precompile Modifications (Azul)
+
+The [Azul hardfork](/base-chain/specs/upgrades/azul/exec-engine) introduced changes to two standard Ethereum precompiles:
+
+### MODEXP (address `0x05`)
+
+- **[EIP-7823](https://eips.ethereum.org/EIPS/eip-7823)** — input fields are capped at 1,024 bytes each. Calls with larger inputs are rejected.
+- **[EIP-7883](https://eips.ethereum.org/EIPS/eip-7883)** — minimum gas cost raised from 200 to 500; the general cost formula is tripled.
+
+These changes apply from the Azul activation timestamp and match Ethereum L1 behavior.

--- a/docs/base-chain/specs/upgrades/azul/exec-engine.mdx
+++ b/docs/base-chain/specs/upgrades/azul/exec-engine.mdx
@@ -133,6 +133,6 @@ The Base-specific behavior is:
   - `DEPOSIT_CONTRACT_ADDRESS`, `CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS`, and
     `WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS` are omitted.
 
-Base-specific predeploys and other OP Stack system contracts documented in the
+Base-specific predeploys and other Base system contracts documented in the
 [predeploys specification](../../protocol/execution/evm/predeploys) are not serialized into
 `eth_config` unless they are part of the EIP-7910 schema.

--- a/docs/base-chain/specs/upgrades/azul/exec-engine.mdx
+++ b/docs/base-chain/specs/upgrades/azul/exec-engine.mdx
@@ -51,9 +51,9 @@ strict equivalence with L1 precompile pricing.
 [EIP-7642](https://eips.ethereum.org/EIPS/eip-7642) updates the Ethereum wire protocol to version 69,
 removing legacy fields from the `Status` message and simplifying the handshake.
 
-### Discovery protocol now uses `basev0` protcol ID
+### Discovery protocol now uses `basev0` protocol ID
 
-The discovery protocol for the execution layer now uses `basev0` as the protocol ID. This allows Base nodes to find each other more quickly, especially on  networks with fewer nodes like Sepolia.
+The discovery protocol for the execution layer now uses `basev0` as the protocol ID. This allows Base nodes to find each other more quickly, especially on networks with fewer nodes like Sepolia.
 
 
 ### Remove Account Balances & Receipts

--- a/docs/base-chain/specs/upgrades/azul/overview.mdx
+++ b/docs/base-chain/specs/upgrades/azul/overview.mdx
@@ -31,7 +31,7 @@ Only `base-consensus` and `base-reth-node` will support the Base Azul hardfork. 
 - [EIP-7642: eth/69](/base-chain/specs/upgrades/azul/exec-engine#eth69)
 - [EIP-7910: eth_config RPC Method](/base-chain/specs/upgrades/azul/exec-engine#eth_config-rpc-method)
 - [Remove Account Balances & Receipts](/base-chain/specs/upgrades/azul/exec-engine#remove-account-balances--receipts)
-- [Use `basev0` protocol ID for discv5](/base-chain/specs/upgrades/azul/exec-engine#discovery-protocol-now-uses-basev0-protcol-id)
+- [Use `basev0` protocol ID for discv5](/base-chain/specs/upgrades/azul/exec-engine#discovery-protocol-now-uses-basev0-protocol-id)
 
 ## Proofs
 

--- a/docs/base-chain/specs/upgrades/isthmus/derivation.mdx
+++ b/docs/base-chain/specs/upgrades/isthmus/derivation.mdx
@@ -169,7 +169,7 @@ To verify the code hash:
 ```bash
 git checkout 9436dba8c4c906e36675f5922e57d1b55582889e
 make build-contracts
-export ETH_RPC_URL=https://mainnet.optimism.io # Any RPC running Cancun or Prague
+export ETH_RPC_URL=<YOUR_ETHEREUM_L1_RPC_URL> # Any Ethereum L1 RPC running Cancun or Prague
 cast k $(cast call --create $(jq -r ".bytecode.object" packages/contracts-bedrock/forge-artifacts/OperatorFeeVault.sol/OperatorFeeVault.json))
 ```
 


### PR DESCRIPTION
**What changed? Why?**
Removes references to OP which are no longer relevant post-Azul.

**Node operators:**
- run-a-base-node.mdx — OP_NODE_L1_ETH_RPC/OP_NODE_L1_BEACON → BASE_NODE_L1_ETH_RPC/BASE_NODE_L1_BEACON
- troubleshooting.mdx — All OP_NODE_* env vars → BASE_NODE_*, all op-node → base-consensus

**Network info:**
- network-fees.mdx — Replaced docs.optimism.io/stack/transactions/fees link with Base's own spec; "OP Stack's implementation of EIP-1559" → "Base's own implementation"; Jovian upgrade link docs.optimism.io/notices/upgrade-17 → /base-chain/specs/upgrades/jovian/overview
- diffs-ethereum-base.mdx — Replaced 5 docs.optimism.io links with equivalent Base docs (bridging, opcodes, address aliasing, fees, finality)
- troubleshooting-transactions.mdx — Removed broken docs.optimism.io link from DA throttling note
- block-building.mdx — Vanilla section: removed op-geth binary and dead GitHub link (op-geth no longer supported post-Azul)

**API references:**
- eth_getLogs.mdx, flashblocks-api-overview.mdx — "OP Stack extension" → "Base L2 extension"
- eth_getTransactionByHash.mdx — "OP Stack deposit transactions" → "Base deposit transactions"
- eth_getTransactionReceipt.mdx — All 6 "OP Stack L2 field" → "Base L2 field"

**Specs:**
- derivation.mdx — "(2s on Optimism)" → "(2s on Base)"; op-node → base-consensus in Engine API version section
- p2p.mdx — op-node → base-consensus in two places
- precompiles.mdx — Removed dead op-geth implementation link
- withdrawals.mdx — "Optimism L2" → "Base L2"
- azul/exec-engine.mdx — "OP Stack system contracts" → "Base system contracts"
- isthmus/derivation.mdx — mainnet.optimism.io example URL → generic Ethereum L1 RPC placeholder

**Notes to reviewers**

**How has it been tested?**
Locally