### PR TITLE
Remove broken nav link to get-started/build-app

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -38,7 +38,6 @@
             "group": "Quickstart",
             "pages": [
               "get-started/resources-for-ai-agents",
-              "get-started/build-app",
               "get-started/launch-token",
               "get-started/deploy-smart-contracts",
               "get-started/learning-resources"


### PR DESCRIPTION
The Get Started > Quickstart group links to get-started/build-app but no file exists at that path. The page was moved to apps/quickstart/build-app which is already in the nav and /get-started/build-app now redirects there. So the entry is dead and shows up as a broken link.

This removes the stale entry. The page stays reachable from the Apps section and the old path keeps redirecting.
