### PR TITLE
docs: update Prompt Library with Base-Specific AI Agent Prompts 

### DIFF
--- a/docs/snippets/prompt-library.mdx
+++ b/docs/snippets/prompt-library.mdx
@@ -148,6 +148,69 @@ If you're unsure about something, simply state it clearly:
 I'm not sure how to proceed with this implementation. Could you provide some guidance on possible approaches?
 ```
 
+## Base-Specific Prompts for Onchain AI Agents
+
+Base provides excellent tooling for autonomous agents (MCP servers, agent wallets, x402 payments, skills). Use these prompts to get precise, production-ready implementations.
+
+### Quickstart Prompt for Agent Setup
+
+I'm building an autonomous onchain AI agent on Base. Use the latest Base best practices.
+
+Context from docs:
+
+- Fetch full index: https://docs.base.org/llms.txt
+
+- MCP server: https://docs.base.org/mcp
+
+- AI Agents section: /ai-agents
+
+Requirements:
+
+1. Set up a secure agent wallet with USDC for payments (reference Base Account or Smart Wallets).
+
+2. Implement x402 protocol for paying for API calls.
+
+3. Add autonomous transaction signing with proper error handling and gas optimization.
+
+4. Include Flashblocks awareness for low-latency if relevant.
+
+5. Provide complete, runnable TypeScript code using viem or wagmi where appropriate.
+
+6. Follow security best practices and include verification steps.
+
+Start with the wallet and signing setup, then show a sample agent loop.
+
+
+### x402 Payments Integration Prompt
+
+- Help me implement x402 payments in my Next.js app on Base so my AI agent can autonomously pay for API usage with USDC.
+
+- Use Base mainnet or Sepolia as specified.
+
+- Integrate with Base Account or a compatible wallet.
+
+- Show full request flow, including authorization headers and payment validation.
+
+- Handle errors (insufficient balance, rate limits) gracefully.
+
+- Provide both frontend and backend code snippets.
+
+### Deploy + Verify Contract with AI Agent Prompt
+
+Act as a senior Solidity engineer. Deploy an ERC-20 token contract to Base Sepolia using Foundry or Hardhat.
+
+Steps I want:
+
+1. Write the contract with standard OpenZeppelin patterns and Base-specific optimizations.
+
+2. Provide deployment script with proper verification on Basescan.
+
+3. Include post-deployment checks (supply, ownership transfer).
+
+4. Make it agent-friendly (e.g., expose functions for autonomous interactions).
+
+Use realistic constructor args and show expected output.
+
 ## Advanced Prompting Techniques
 
 Modern AI assistants have capabilities that you can leverage with these advanced techniques:


### PR DESCRIPTION
**What changed? Why?**

The existing prompt library is general-purpose for AI coding workflows. With Base's strong AI/agent focus (dedicated `resources-for-ai-agents`, MCP, skills, ai-agents section), adding **targeted**, **high-value prompts for onchain AI agents** improves builder onboarding, especially for LLM-driven development. This is a small, focused enhancement that leverages existing AI-friendly docs and recent features like x402, agent wallets, and MCP. It directly helps users (and AIs) build faster on Base without proliferating structure.

**Notes to reviewers**

- Update the import/snippet or append to `docs/snippets/prompt-library.mdx`

- Add a new section after "Debugging with AI"
