### PR TITLE
Fix MiniKit redirects pointing to a missing page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1080,51 +1080,51 @@
     },
     {
       "source": "/onchainkit/latest/components/minikit/overview",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/provider-and-initialization",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useMiniKit",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useOpenUrl",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useClose",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/usePrimaryButton",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useViewProfile",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useComposeCast",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useViewCast",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useAuthenticate",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useAddFrame",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useNotification",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps/guides/migrate-to-standard-web-app"
     },
     {
       "source": "/onchainkit/identity/identity",


### PR DESCRIPTION
Follow up to #1599.

The 12 /onchainkit/latest/components/minikit/* redirects pointed to /apps/introduction/overview which does not exist so they all 404. These are deprecated MiniKit pages.

The repo already redirects related MiniKit content to /apps/guides/migrate-to-standard-web-app (the Migrate to a Standard Web App guide), for example /mini-apps/introduction/* and several /cookbook/minikit/* entries. Pointed these 12 to the same guide for consistency.

Left /cookbook/base-app-coins out since it is not a MiniKit page and likely needs a different target.
