### PR TITLE
docs(get-started): expand concepts page with full explanations

### DIFF
--- a/docs/get-started/concepts.mdx
+++ b/docs/get-started/concepts.mdx
@@ -1,13 +1,58 @@
 ---
-title: 'Core Concepts'
+title: 'Key Concepts'
+description: 'Core blockchain concepts you need to know before building on Base'
 ---
 
-Key concept overview:
-- Gas & Faucets
-- Blocks
-- Transactions
-- Signatures
-- Smart Contracts
-- Wallets
-- Nodes
-...
+## Overview
+
+Before building on Base, it helps to understand these fundamental blockchain concepts.
+
+## Gas & Faucets
+
+**Gas** is the unit that measures the computational effort required to execute transactions on Base. Every transaction requires gas, and users pay for it in ETH.
+
+- Gas fees on Base are significantly lower than Ethereum mainnet due to L2 architecture
+- Use a **faucet** to get free testnet ETH for development on Base Sepolia
+
+## Blocks
+
+Blocks are batches of transactions confirmed together and added to the blockchain. Each block contains:
+- A reference to the previous block (forming the "chain")
+- A list of transactions
+- A timestamp and block number
+
+Base produces blocks approximately every 2 seconds.
+
+## Transactions
+
+A transaction is a signed instruction sent to the network. Transactions can:
+- Transfer ETH between wallets
+- Call a smart contract function
+- Deploy a new smart contract
+
+Each transaction has a unique hash and is permanently recorded once confirmed.
+
+## Signatures
+
+Signatures prove ownership of a wallet without revealing the private key. They are used for:
+- Authorizing transactions
+- Sign-In With Ethereum (SIWE) for authentication
+- Off-chain message signing (e.g. permit approvals)
+
+## Smart Contracts
+
+Smart contracts are self-executing programs deployed on Base. They run exactly as programmed with no possibility of downtime or third-party interference. Written in **Solidity**, they power DeFi, NFTs, and onchain apps.
+
+## Wallets
+
+A wallet stores your private keys and lets you interact with Base. Types include:
+- **EOA (Externally Owned Account)** — standard user wallet like MetaMask or Coinbase Wallet
+- **Smart Account** — programmable wallet with features like gas sponsorship and batch transactions
+
+## Nodes
+
+Nodes are computers that run the Base software and maintain a copy of the blockchain. You can:
+- Run your own node for full decentralization
+- Use a node provider (e.g. Coinbase, Alchemy, QuickNode) for convenience
+
+See [Node Operators](/base-chain/node-operators/run-a-base-node) for setup instructions.


### PR DESCRIPTION
Page previously contained only a bullet list with no descriptions.
Added detailed explanations for Gas, Blocks, Transactions, Signatures,
Smart Contracts, Wallets, and Nodes.
