### PR TITLE
docs(security): add content to empty bug-bounty page

### DIFF
--- a/docs/base-chain/security/bug-bounty.mdx
+++ b/docs/base-chain/security/bug-bounty.mdx
@@ -1,4 +1,44 @@
 ---
 title: 'Bug Bounty'
+description: 'Report security vulnerabilities in Base and earn rewards'
 ---
 
+## Overview
+
+Base is committed to the security of its protocol and infrastructure. If you discover a security vulnerability, we encourage responsible disclosure through our bug bounty program.
+
+## Immunefi Program
+
+Base runs its bug bounty program through **Immunefi**, the leading Web3 security platform.
+
+👉 [View the Base Bug Bounty Program on Immunefi](https://immunefi.com/bug-bounty/base)
+
+## Scope
+
+The program covers vulnerabilities in:
+- Base bridge contracts
+- Core protocol smart contracts
+- Node software
+
+## Reward Tiers
+
+| Severity | Reward |
+|---|---|
+| Critical | Up to $1,000,000 |
+| High | Up to $100,000 |
+| Medium | Up to $10,000 |
+| Low | Up to $1,000 |
+
+## Responsible Disclosure
+
+Please **do not** publicly disclose vulnerabilities before they have been resolved. Submit all findings through Immunefi to ensure responsible disclosure and eligibility for rewards.
+
+## Out of Scope
+
+The following are generally out of scope:
+- Frontend UI bugs with no security impact
+- Denial of service attacks
+- Social engineering attacks
+- Previously known vulnerabilities
+
+For full program details, rules, and eligibility requirements, visit the [Immunefi program page](https://immunefi.com/bug-bounty/base).


### PR DESCRIPTION
Page previously had only a title with no content.
Added overview, Immunefi program link, scope, reward tiers,
and responsible disclosure guidelines.