### PR TITLE
add beryl, b20 docs, activation timelines

### DIFF
--- a/docs/base-chain/specs/upgrades/azul/exec-engine.mdx
+++ b/docs/base-chain/specs/upgrades/azul/exec-engine.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Azul: Execution Engine"
+title: "Execution Engine"
 description: "Execution engine changes in the Azul hardfork, including the EIP-7825 transaction gas limit cap and secp256r1 precompile cost updates."
 ---
 

--- a/docs/base-chain/specs/upgrades/azul/overview.mdx
+++ b/docs/base-chain/specs/upgrades/azul/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Azul"
+title: "Overview"
 description: "Overview of the Azul hardfork, introducing Osaka EVM support, a simplified execution client, and a multi-proof system for L2 checkpoints."
 ---
 

--- a/docs/base-chain/specs/upgrades/azul/proofs.mdx
+++ b/docs/base-chain/specs/upgrades/azul/proofs.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Azul: Proof System"
+title: "Proof System"
 description: "Specification of the Azul multi-proof system, replacing the single output proposer with an AggregateVerifier contract for L2 checkpoint security."
 ---
 

--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -1,0 +1,131 @@
+---
+title: "Beryl: B20 Native Token Standard"
+description: "B20 tokens are implemented as Rust precompiles deployed via the IB20Factory precompile, with full ERC-20 compatibility and built-in access control, policy enforcement, and granular pause."
+---
+
+B20 is an ERC-20 superset for Base. Tokens are implemented as **Rust precompiles** deployed via the singleton `IB20Factory` precompile, bypassing EVM execution while remaining fully compatible with existing wallets, explorers, and tooling.
+
+B20 supports two variants:
+
+| Variant | Decimals | Additional Features |
+|---------|----------|---------------------|
+| **Asset** | 6–18 (configurable) | Rebase multiplier, onchain announcements, batched issuance |
+| **Stablecoin** | 6 (fixed) | Self-declared fiat currency code |
+
+## ERC-20 Compatibility
+
+B20 implements the full ERC-20 standard surface with complete selector parity - it is a drop-in replacement for existing tooling and integrations.
+
+## Roles Model
+
+B20 role-based access control extends OpenZeppelin `AccessControl` with a fixed set of roles and one behavioral override on admin renunciation.
+
+| Role | Gates |
+|------|-------|
+| `DEFAULT_ADMIN_ROLE` | All admin operations: role grants, policy updates, supply-cap changes |
+| `MINT_ROLE` | `mint`, `mintWithMemo` |
+| `BURN_ROLE` | Caller-side burns: `burn`, `burnWithMemo` |
+| `BURN_BLOCKED_ROLE` | Third-party burns against policy-blocked accounts: `burnBlocked` |
+| `PAUSE_ROLE` | `pause` |
+| `UNPAUSE_ROLE` | `unpause` |
+| `METADATA_ROLE` | `updateName`, `updateSymbol`, `updateContractURI` |
+
+User-defined roles are supported via `setRoleAdmin` and `grantRole`. They carry no built-in effect - B20 only enforces gates against the seven roles above.
+
+### Admin Renunciation
+
+The last `DEFAULT_ADMIN_ROLE` holder cannot be removed via `renounceRole` or `revokeRole` (both revert with `LastAdminCannotRenounce`). The dedicated `renounceLastAdmin()` is the only path to permanently transition a token to admin-less.
+
+Tokens that intend to launch admin-less from the start pass `initialAdmin == address(0)` at creation, which never grants the role and skips the `renounceLastAdmin` step entirely.
+
+After `renounceLastAdmin()` (or for tokens deployed with `initialAdmin == address(0)`):
+
+- Operations gated by `DEFAULT_ADMIN_ROLE` become permanently uncallable.
+- Roles already granted to other addresses (`MINT_ROLE`, `BURN_ROLE`, etc.) continue to function independently.
+- Admin resurrection is blocked: `grantRole`, `revokeRole`, and `setRoleAdmin` all revert with `AccessControlUnauthorizedAccount` even if the caller holds a custom role.
+
+## Policy Integration
+
+B20 declares a fixed set of policy scopes. Each scope stores a `uint64` policy ID pointing into the `PolicyRegistry`. On every gated operation, B20 calls `isAuthorized` against the relevant scope and reverts with `PolicyForbids` if the account is not authorized.
+
+| Scope | Gates |
+|-------|-------|
+| `TRANSFER_SENDER_POLICY` | The `from` of `transfer` / `transferFrom` |
+| `TRANSFER_RECEIVER_POLICY` | The `to` of `transfer` / `transferFrom` |
+| `TRANSFER_EXECUTOR_POLICY` | The `msg.sender` of `transferFrom` (not checked on `transfer`) |
+| `MINT_RECEIVER_POLICY` | The `to` of `mint` |
+
+`approve` is not policy-gated - only actual balance movement via `transfer` / `transferFrom` is checked.
+
+<Warning>
+Every scope defaults to `ALWAYS_ALLOW` at token creation unless overridden in the bootstrap `initCalls`. An unattended B20 deployment is fully open - token behavior must be intentionally constrained.
+</Warning>
+
+Scopes are read via `policyId(scope)` and written via `updatePolicy(scope, policyId)`. `updatePolicy` is admin-gated and reverts if the scope is not recognized.
+
+## Mint
+
+New supply is created via `mint` / `mintWithMemo`, gated by `MINT_ROLE`. The recipient is policy-checked against `MINT_RECEIVER_POLICY`. The operation reverts with `SupplyCapExceeded` if it would push `totalSupply` past the cap.
+
+## Burn
+
+Two burn paths exist:
+
+- **`burn` / `burnWithMemo`** - caller burns from their own balance. Gated by `BURN_ROLE`.
+- **`burnBlocked`** - burns from a third party's balance. Gated by `BURN_BLOCKED_ROLE`. The target account MUST be denied by `TRANSFER_SENDER_POLICY` - this is the freeze-and-seize path for regulated issuers.
+
+## Supply Cap
+
+The supply cap is optional. The sentinel `type(uint256).max` indicates no cap (the default at creation). `updateSupplyCap(newCap)` is admin-gated and emits `SupplyCapUpdated`. Lowering below the current `totalSupply` reverts with `InvalidSupplyCap`.
+
+## Memos
+
+A memo is an optional `bytes32` payload attached to a token operation for off-chain reference. Every memo-emitting operation emits `Memo(address indexed caller, bytes32 indexed memo)` immediately after the operation's primary event. Indexers join via `(transactionHash, logIndex − 1)`.
+
+Memo-emitting entrypoints: `transferWithMemo`, `transferFromWithMemo`, `mintWithMemo`, `burnWithMemo`.
+
+## Pause
+
+Pauses are granular: the `PausableFeature` enum partitions the token surface into independently pausable operations - `TRANSFER`, `MINT`, and `BURN`. The enum is append-only. `pause(features)` and `unpause(features)` are gated by separate roles (`PAUSE_ROLE` and `UNPAUSE_ROLE`) by design.
+
+## ERC-2612 Permit / EIP-712
+
+B20 implements ERC-2612 (signed approvals) using an EIP-712 domain shaped as `(name, version, chainId, verifyingContract)`, with `version` fixed at `"1"`. `updateName` rotates the domain separator and emits `EIP712DomainChanged` (ERC-5267). ERC-1271 contract signatures are not accepted - ECDSA only.
+
+## Contract URI (ERC-7572)
+
+`contractURI()` returns a string pointing to off-chain metadata per ERC-7572. `updateContractURI(newUri)` is gated by `METADATA_ROLE`.
+
+## Metadata Updates
+
+`METADATA_ROLE` gates:
+
+- `updateName(newName)` - updates `name` and rotates the EIP-712 domain separator. Emits `NameUpdated` and `EIP712DomainChanged`.
+- `updateSymbol(newSymbol)` - updates `symbol` only. Emits `SymbolUpdated`.
+
+## Variants
+
+### Asset
+
+The general-purpose variant for assets of all kinds. Decimals are configurable between 6 and 18 at deployment time. Adds: rebase multiplier, onchain announcements, and batched issuance.
+
+### Stablecoin
+
+The fixed-decimals, fiat-backed carveout. Decimals are fixed at 6. Adds a self-declared fiat currency code for use by compliant stablecoin issuers.
+
+## Roadmap
+
+Because B20 tokens execute in Rust outside the EVM, the node has advanced control over their behavior. The following capabilities are planned for future upgrades:
+
+### Frontier Features
+
+- **Pay transaction fees with B20** - enables transacting using only a custom asset, with no ETH required.
+- **Virtual addresses** - create unique deposit addresses that forward to a shared account.
+- **Indexed data** - Base Node RPCs serve aggregated balances, transfer history, and token metadata directly, with no external indexer required.
+
+### Performance Optimizations
+
+- **Lower fees** - approximately 50% cheaper transfers compared to ERC-20 contracts.
+- **Higher throughput** - approximately 2× the transfers per block compared to ERC-20 contracts.
+
+Further optimizations are planned for trading and payments use cases specifically.

--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -44,9 +44,65 @@ After `renounceLastAdmin()` (or for tokens deployed with `initialAdmin == addres
 - Roles already granted to other addresses (`MINT_ROLE`, `BURN_ROLE`, etc.) continue to function independently.
 - Admin resurrection is blocked: `grantRole`, `revokeRole`, and `setRoleAdmin` all revert with `AccessControlUnauthorizedAccount` even if the caller holds a custom role.
 
+## Policy Registry
+
+The PolicyRegistry is a singleton precompile that manages allowlists and blocklists. B20 tokens reference policies by `uint64` ID. Any caller can create a policy and nominate its admin.
+
+<Note>
+State-changing functions on the PolicyRegistry are gated by the ActivationRegistry, which tracks which Base features are live. Read functions (`isAuthorized`, `policyExists`, `policyAdmin`, `pendingPolicyAdmin`) are always callable.
+</Note>
+
+### Policy Types
+
+| Type | Default | Behavior |
+|------|---------|----------|
+| `BLOCKLIST` | Authorized | All accounts authorized by default; explicitly listed accounts are denied. |
+| `ALLOWLIST` | Denied | All accounts denied by default; explicitly listed accounts are authorized. |
+
+### Policy IDs
+
+Policy IDs are `uint64` values. The top byte encodes the `PolicyType`; the low 56 bits are a global counter starting at `2`.
+
+Two built-in IDs require no creation:
+
+| Constant | ID | Behavior |
+|----------|----|----------|
+| `ALWAYS_ALLOW` | `0` | Authorizes every account unconditionally. Default scope value on new B20 tokens. |
+| `ALWAYS_BLOCK` | `(uint64(ALLOWLIST) << 56) \| 1` | Denies every account unconditionally. |
+
+`isAuthorized` never reverts on a non-existent policy ID - it collapses to empty-member-set semantics (non-existent `BLOCKLIST` authorizes everyone; non-existent `ALLOWLIST` denies everyone).
+
+<Warning>
+Consumers that write a policy ID (e.g. `updatePolicy`) MUST validate `policyExists(policyId)` at write time to avoid silently binding to an unintended empty-set policy.
+</Warning>
+
+### Admin Model
+
+Each policy has one admin. Admin transfers are two-step: the current admin calls `transferPolicyAdmin(policyId, newAdmin)`, then the pending admin calls `acceptPolicyAdmin(policyId)`. `renouncePolicyAdmin(policyId)` permanently freezes the policy - membership can never be changed again.
+
+### Creating and Managing Policies
+
+```solidity
+// Create a policy
+uint64 policyId = policyRegistry.createPolicy(PolicyType.BLOCKLIST, adminAddress);
+
+// Update membership (batched)
+policyRegistry.addToPolicy(policyId, accounts);
+policyRegistry.removeFromPolicy(policyId, accounts);
+```
+
+### Read Interface
+
+| Method | Description |
+|--------|-------------|
+| `isAuthorized(policyId, account)` | Whether `account` is authorized under `policyId`. Never reverts. |
+| `policyExists(policyId)` | Whether a policy with this ID has been created. |
+| `policyAdmin(policyId)` | Current admin address. |
+| `pendingPolicyAdmin(policyId)` | Pending admin during a two-step transfer. |
+
 ## Policy Integration
 
-B20 declares a fixed set of policy scopes. Each scope stores a `uint64` policy ID pointing into the `PolicyRegistry`. On every gated operation, B20 calls `isAuthorized` against the relevant scope and reverts with `PolicyForbids` if the account is not authorized.
+B20 declares a fixed set of policy scopes. Each scope stores a `uint64` policy ID pointing into the PolicyRegistry. On every gated operation, B20 calls `isAuthorized` against the relevant scope and reverts with `PolicyForbids` if the account is not authorized.
 
 | Scope | Gates |
 |-------|-------|
@@ -103,15 +159,79 @@ B20 implements ERC-2612 (signed approvals) using an EIP-712 domain shaped as `(n
 - `updateName(newName)` - updates `name` and rotates the EIP-712 domain separator. Emits `NameUpdated` and `EIP712DomainChanged`.
 - `updateSymbol(newSymbol)` - updates `symbol` only. Emits `SymbolUpdated`.
 
+## Factory
+
+All B20 tokens are created through the singleton `IB20Factory` precompile via `createB20(variant, params, initCalls, salt)`.
+
+| Parameter | Description |
+|-----------|-------------|
+| `variant` | `ASSET` or `STABLECOIN` |
+| `params` | ABI-encoded, variant-specific creation struct (versioned by leading byte) |
+| `initCalls` | Optional array of ABI-encoded calls dispatched post-creation with admin privilege bypass |
+| `salt` | Caller-chosen entropy for address derivation |
+
+### Address Derivation
+
+B20 addresses are deterministic and encode the variant directly:
+
+```
+[10-byte B20 prefix][1-byte variant][9-byte keccak256(deployer, salt)]
+```
+
+The variant is recoverable from the address alone without an RPC call. Helper functions `getB20Address(variant, deployer, salt)`, `isB20(addr)`, and `isB20Initialized(addr)` are available on the factory.
+
+### initCalls Semantics
+
+`initCalls` are dispatched after token creation with admin privilege bypass, allowing configuration (e.g. setting policies, granting roles) in the same transaction as deployment. The bypass is partial:
+
+- `MINT_RECEIVER_POLICY` is always enforced even during `initCalls`.
+- Pause state is never bypassed.
+- Token invariants (supply cap, etc.) are never bypassed.
+
 ## Variants
 
 ### Asset
 
-The general-purpose variant for assets of all kinds. Decimals are configurable between 6 and 18 at deployment time. Adds: rebase multiplier, onchain announcements, and batched issuance.
+The general-purpose variant for assets of all kinds. Decimals are configurable between 6 and 18 at deployment time and are immutable after creation.
+
+In addition to the base B20 surface, Asset tokens add an `OPERATOR_ROLE` that gates the following capabilities:
+
+#### Multiplier
+
+A WAD-precision rebase multiplier applied to all balance reads. Raw balances are stored unchanged; the multiplier scales the view returned to callers.
+
+| Method | Description |
+|--------|-------------|
+| `multiplier()` | Current WAD-precision multiplier |
+| `scaledBalanceOf(account)` | Raw balance × multiplier |
+| `toScaledBalance(raw)` | Convert raw amount to scaled |
+| `toRawBalance(scaled)` | Convert scaled amount to raw |
+| `updateMultiplier(newMultiplier)` | Update the multiplier. Gated by `OPERATOR_ROLE`. |
+
+#### Announcements
+
+On-chain disclosure brackets that wrap sensitive operations (e.g. batch mints, multiplier updates) with a public notice period. Gated by `OPERATOR_ROLE`.
+
+`announce(internalCalls, id, description, uri)` emits an `Announcement` event, executes `internalCalls`, then emits `EndAnnouncement`. The `id` must be unique and is enforced forever. Inner call reverts are wrapped in `InternalCallFailed`.
+
+#### Batch Mint
+
+`batchMint(recipients, amounts)` mints to multiple recipients in a single call. Gated by `MINT_ROLE`. Should be wrapped in `announce()` for transparency.
+
+#### Extra Metadata
+
+An arbitrary key/value store for issuer-defined on-chain metadata.
+
+| Method | Description |
+|--------|-------------|
+| `extraMetadata(key)` | Read a value by key |
+| `updateExtraMetadata(key, value)` | Write a value. Gated by `METADATA_ROLE`. Setting an empty value removes the entry. |
 
 ### Stablecoin
 
-The fixed-decimals, fiat-backed carveout. Decimals are fixed at 6. Adds a self-declared fiat currency code for use by compliant stablecoin issuers.
+The fixed-decimals, fiat-backed carveout. Decimals are hard-wired to `6` and are not configurable.
+
+Adds `currency()`, which returns an ISO-style currency code string (e.g. `"USD"`, `"EUR"`). The code is set once at creation via `B20StablecoinCreateParams.currency`, restricted to characters `A`-`Z` only. It is self-declared and not verified against any external registry.
 
 ## Roadmap
 

--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Beryl: B20 Native Token Standard"
-description: "B20 tokens are implemented as Rust precompiles deployed via the IB20Factory precompile, with full ERC-20 compatibility and built-in access control, policy enforcement, and granular pause."
+title: "B20 Native Token Standard"
+description: "B20 is Base's native token standard - designed for stablecoin issuers, real-world asset (RWA) and equity issuers, and long-tail token creators."
 ---
 
-B20 is an ERC-20 superset for Base. Tokens are implemented as **Rust precompiles** deployed via the singleton `IB20Factory` precompile, bypassing EVM execution while remaining fully compatible with existing wallets, explorers, and tooling.
+B20 is the Base ecosystem's own version of [ERC-20](https://eips.ethereum.org/EIPS/eip-20). It ships with a built-in compliance toolkit: transfer policies, freeze-and-seize, role-based access control, memos, and supply caps.
 
 B20 supports two variants:
 
@@ -14,7 +14,11 @@ B20 supports two variants:
 
 ## ERC-20 Compatibility
 
+B20 tokens are implemented as **Rust precompiles** rather than EVM smart contracts, making them faster, cheaper, and more native to the chain. All tokens are deployed via the singleton `IB20Factory` precompile.
+
+<Check>
 B20 implements the full ERC-20 standard surface with complete selector parity - it is a drop-in replacement for existing tooling and integrations.
+</Check>
 
 ## Roles Model
 

--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -3,7 +3,7 @@ title: "B20 Native Token Standard"
 description: "B20 is Base's native token standard - designed for stablecoin issuers, real-world asset (RWA) and equity issuers, and long-tail token creators."
 ---
 
-B20 is the Base ecosystem's own version of [ERC-20](https://eips.ethereum.org/EIPS/eip-20). It ships with a built-in compliance toolkit: transfer policies, freeze-and-seize, role-based access control, memos, and supply caps.
+B20 is the Base ecosystem's own version of [ERC-20](https://eips.ethereum.org/EIPS/eip-20). It ships with a built-in compliance toolkit: transfer policies, freeze-and-seize, role-based access control, memos, and supply caps. The full interface specs are available in the [Base Standard Library](https://github.com/base/base-std) repository.
 
 B20 supports two variants:
 

--- a/docs/base-chain/specs/upgrades/beryl/overview.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/overview.mdx
@@ -1,0 +1,37 @@
+---
+title: "Beryl"
+description: "Overview of the Beryl hardfork, introducing the B20 native token standard and reduced withdrawal finalization times."
+---
+
+## Summary
+
+- Introduce [B20](/base-chain/specs/upgrades/beryl/b20): a native token standard implemented as Rust precompiles, deployed via an enshrined factory precompile, with full ERC-20 compatibility
+- Reduce the single-proof withdrawal finalization period from 7 days to 5 days for increased capital efficiency
+- [Reth V2](/base-chain/specs/upgrades/beryl/reth-v2): up to 50% disk reduction and a rewritten state root pipeline delivering +33% throughput
+
+## Activation Timestamps
+
+| Network | Timestamp | Date |
+|---------|-----------|------|
+| `mainnet` | `1782410400` | 2026-06-25 18:00:00 UTC |
+| `sepolia` | `1781805600` | 2026-06-18 18:00:00 UTC |
+
+## B20: Native Token Standard
+
+- [B20 Overview](/base-chain/specs/upgrades/beryl/b20)
+- [Roles Model](/base-chain/specs/upgrades/beryl/b20#roles-model)
+- [Policy Integration](/base-chain/specs/upgrades/beryl/b20#policy-integration)
+- [Mint & Burn](/base-chain/specs/upgrades/beryl/b20#mint)
+- [Variants](/base-chain/specs/upgrades/beryl/b20#variants)
+
+## Withdrawals
+
+The single-proof dispute game finalization window is reduced from 7 days to 5 days. The dual-proof fast path (TEE + ZK) introduced in Azul remains at 1 day.
+
+Shortening the single-proof window frees capital for fast-bridge liquidity providers sooner, reducing fees and improving reliability for users who bridge through third-party partners.
+
+## Reth V2
+
+- [Reth V2 Overview](/base-chain/specs/upgrades/beryl/reth-v2)
+- [Storage V2](/base-chain/specs/upgrades/beryl/reth-v2#storage-v2)
+- [State Root Computation](/base-chain/specs/upgrades/beryl/reth-v2#state-root-computation)

--- a/docs/base-chain/specs/upgrades/beryl/overview.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Beryl"
-description: "Overview of the Beryl hardfork, introducing the B20 native token standard and reduced withdrawal finalization times."
+description: "Overview of the Beryl hardfork, introducing the B20 native token standard, reduced withdrawal delays, and Reth V2."
 ---
 
 ## Summary
@@ -21,6 +21,8 @@ description: "Overview of the Beryl hardfork, introducing the B20 native token s
 - [B20 Overview](/base-chain/specs/upgrades/beryl/b20)
 - [Roles Model](/base-chain/specs/upgrades/beryl/b20#roles-model)
 - [Policy Integration](/base-chain/specs/upgrades/beryl/b20#policy-integration)
+- [Factory](/base-chain/specs/upgrades/beryl/b20#factory)
+- [Policy Registry](/base-chain/specs/upgrades/beryl/b20#policy-registry)
 - [Mint & Burn](/base-chain/specs/upgrades/beryl/b20#mint)
 - [Variants](/base-chain/specs/upgrades/beryl/b20#variants)
 

--- a/docs/base-chain/specs/upgrades/beryl/overview.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/overview.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Beryl"
+title: "Overview"
 description: "Overview of the Beryl hardfork, introducing the B20 native token standard, reduced withdrawal delays, and Reth V2."
 ---
 
 ## Summary
 
-- Introduce [B20](/base-chain/specs/upgrades/beryl/b20): a native token standard implemented as Rust precompiles, deployed via an enshrined factory precompile, with full ERC-20 compatibility
+- Introduce [B20](/base-chain/specs/upgrades/beryl/b20): Base's native token standard for stablecoin, real-world asset (RWA), and long-tail token issuers
 - Reduce the single-proof withdrawal finalization period from 7 days to 5 days for increased capital efficiency
 - [Reth V2](/base-chain/specs/upgrades/beryl/reth-v2): up to 50% disk reduction and a rewritten state root pipeline delivering +33% throughput
 
@@ -16,7 +16,13 @@ description: "Overview of the Beryl hardfork, introducing the B20 native token s
 | `mainnet` | `1782410400` | 2026-06-25 18:00:00 UTC |
 | `sepolia` | `1781805600` | 2026-06-18 18:00:00 UTC |
 
+<Warning>
+Action required before activation. Upgrade to the latest `base-reth-node` release on both Sepolia and Mainnet before their respective activation dates above. Required software versions will be published here ahead of activation.
+</Warning>
+
 ## B20: Native Token Standard
+
+B20 is Base's native token standard - ERC-20 compatible tokens implemented as Rust precompiles, designed for stablecoin, real-world asset, and long-tail token issuers.
 
 - [B20 Overview](/base-chain/specs/upgrades/beryl/b20)
 - [Roles Model](/base-chain/specs/upgrades/beryl/b20#roles-model)

--- a/docs/base-chain/specs/upgrades/beryl/reth-v2.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/reth-v2.mdx
@@ -1,0 +1,39 @@
+---
+title: "Beryl: Reth V2"
+description: "Reth V2 reduces node disk usage by up to 50% and delivers a rewritten state root pipeline with significantly higher throughput and lower block-execution latency."
+---
+
+Reth V2 is the next generation of `base-reth-node`, the high-performance Ethereum execution client that has been Base's sole execution client since Azul. It targets the two primary constraints on a high-throughput chain: disk usage and state root computation speed.
+
+<Note>
+Reth V2 does not require a network upgrade - it ships as a node software update alongside Beryl. Node operators should upgrade to the latest `base-reth-node` release before the [Beryl activation date](/base-chain/specs/upgrades/beryl/overview#activation-timestamps).
+</Note>
+
+## Storage V2
+
+Storage V2 restructures on-disk data layout to significantly reduce node storage requirements:
+
+| Node type | Disk reduction |
+|-----------|----------------|
+| Full | ~30% |
+| Minimal | ~50% |
+| Archive | ~23% |
+
+This removes a disk-growth ceiling that would otherwise constrain Base's ability to scale block throughput.
+
+## State Root Computation
+
+Reth V2 rewrites the state root pipeline with three improvements:
+
+- **Warm sparse-trie caching across blocks** - avoids recomputing unchanged subtrees between consecutive blocks.
+- **Parallel trie** - computes state root components concurrently across CPU cores.
+- **Proof V2** - a redesigned proof-generation path that reduces per-proof overhead.
+
+## Performance
+
+In Reth's published benchmarks, these changes deliver:
+
+- **+33% throughput**
+- **~25% lower mean block-execution latency**
+
+`base-reth-node` inherits these gains directly, contributing headroom on the path to 1 gigagas/s.

--- a/docs/base-chain/specs/upgrades/beryl/reth-v2.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/reth-v2.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Beryl: Reth V2"
+title: "Reth V2"
 description: "Reth V2 reduces node disk usage by up to 50% and delivers a rewritten state root pipeline with significantly higher throughput and lower block-execution latency."
 ---
 

--- a/docs/base-chain/specs/upgrades/beryl/reth-v2.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/reth-v2.mdx
@@ -3,7 +3,7 @@ title: "Reth V2"
 description: "Reth V2 reduces node disk usage by up to 50% and delivers a rewritten state root pipeline with significantly higher throughput and lower block-execution latency."
 ---
 
-Reth V2 is the next generation of `base-reth-node`, the high-performance Ethereum execution client that has been Base's sole execution client since Azul. It targets the two primary constraints on a high-throughput chain: disk usage and state root computation speed.
+Base uses Reth, a high-performance Ethereum execution client. Reth V2 is the next major release, targeting the two primary constraints on a high-throughput chain: disk usage and state root computation speed.
 
 <Note>
 Reth V2 does not require a network upgrade - it ships as a node software update alongside Beryl. Node operators should upgrade to the latest `base-reth-node` release before the [Beryl activation date](/base-chain/specs/upgrades/beryl/overview#activation-timestamps).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -249,6 +249,14 @@
                 "group": "Upgrades",
                 "pages": [
                   {
+                    "group": "Beryl",
+                    "pages": [
+                      "base-chain/specs/upgrades/beryl/overview",
+                      "base-chain/specs/upgrades/beryl/b20",
+                      "base-chain/specs/upgrades/beryl/reth-v2"
+                    ]
+                  },
+                  {
                     "group": "Azul",
                     "pages": [
                       "base-chain/specs/upgrades/azul/overview",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -98,6 +98,13 @@
         "tab": "Chain",
         "groups": [
           {
+            "group": "Beryl Upgrade",
+            "tag": "New",
+            "pages": [
+              "base-chain/specs/upgrades/beryl/overview"
+            ]
+          },
+          {
             "group": "Quickstart",
             "pages": [
               "base-chain/quickstart/why-base",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -96,7 +96,7 @@ const client = createPublicClient({ chain: base, transport: http() })
 - [Base Services Hub](https://docs.base.org/get-started/base-services-hub): A collection of services for building on Base.
 - [Block Explorers](https://docs.base.org/get-started/block-explorers): Documentation for block explorers for the Base network.
 - [Core Concepts](https://docs.base.org/get-started/concepts)
-- [Country Leads & Ambassadors](https://docs.base.org/get-started/country-leads-and-ambassadors): Connect with local Base community leaders and ambassadors around the world
+- [Regional Leads & Ambassadors](https://docs.base.org/get-started/country-leads-and-ambassadors): Connect with regional Base community leaders and ambassadors around the world
 - [Data Indexers](https://docs.base.org/get-started/data-indexers): Documentation for data indexing platforms for Base network.
 - [Deploy Smart Contracts](https://docs.base.org/get-started/deploy-smart-contracts): Step-by-step guide to deploying smart contracts on Base.
 - [Static Docs Files](https://docs.base.org/get-started/docs-llms): Use llms.txt and llms-full.txt to give AI assistants access to Base documentation.
@@ -114,7 +114,8 @@ const client = createPublicClient({ chain: base, transport: http() })
 - [L2 Execution Engine](https://docs.base.org/base-chain/specs/protocol/execution/index): Specification of the L2 execution engine, detailing EIP-1559 parameters, fee vaults, Engine API usage, and execution layer behavior.
 - [Overview](https://docs.base.org/base-chain/specs/protocol/overview): High-level overview of the Base Chain protocol, covering rollup architecture, core components, and user flows for deposits, transactions, and withdrawals.
 - [Proofs](https://docs.base.org/base-chain/specs/protocol/proofs/index): Overview of the offchain services and onchain contracts that make L2 checkpoint proposals verifiable from Ethereum in the Azul proof system.
-- [Azul](https://docs.base.org/base-chain/specs/upgrades/azul/overview): Overview of the Azul hardfork, introducing Osaka EVM support, a simplified execution client, and a multi-proof system for L2 checkpoints.
+- [Overview](https://docs.base.org/base-chain/specs/upgrades/azul/overview): Overview of the Azul hardfork, introducing Osaka EVM support, a simplified execution client, and a multi-proof system for L2 checkpoints.
+- [Overview](https://docs.base.org/base-chain/specs/upgrades/beryl/overview): Overview of the Beryl hardfork, introducing the B20 native token standard, reduced withdrawal delays, and Reth V2.
 - [Canyon](https://docs.base.org/base-chain/specs/upgrades/canyon/overview): Overview of the Canyon hardfork, bringing Ethereum Shanghai EIPs (EIP-3651, EIP-3855, EIP-3860) to the Base execution layer.
 - [Delta](https://docs.base.org/base-chain/specs/upgrades/delta/overview): Overview of the Delta hardfork, introducing span batches to reduce L1 data costs by compressing multiple L2 blocks into single batcher transactions.
 - [Ecotone](https://docs.base.org/base-chain/specs/upgrades/ecotone/overview): Overview of the Ecotone hardfork, integrating Ethereum Dencun changes including EIP-4844 blob transactions and EIP-4788 beacon block roots.
@@ -127,28 +128,28 @@ const client = createPublicClient({ chain: base, transport: http() })
 - [debug_traceBlockByNumber](https://docs.base.org/base-chain/api-reference/debug-api/debug_traceBlockByNumber): Returns EVM execution traces for all transactions in a block by block number.
 - [debug_traceTransaction](https://docs.base.org/base-chain/api-reference/debug-api/debug_traceTransaction): Returns the full EVM execution trace for a transaction. Requires a node with debug APIs enabled.
 - [eth_blockNumber](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_blockNumber): Returns the number of the most recently mined block.
-- [eth_call](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_call): Executes a message call without creating a transaction. Use pending on a Flashblocks endpoint to simulate against pre-confirmed state.
+- [eth_call](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_call): Executes a message call without creating a transaction. Use pending to simulate against pre-confirmed state.
 - [eth_chainId](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_chainId): Returns the chain ID of the current network.
-- [eth_estimateGas](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_estimateGas): Estimates the gas required for a transaction. Use pending on a Flashblocks endpoint to estimate against pre-confirmed state.
+- [eth_estimateGas](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_estimateGas): Estimates the gas required for a transaction. Use pending to estimate against pre-confirmed state.
 - [eth_feeHistory](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_feeHistory): Returns historical base fees and priority fee percentiles for a range of blocks.
 - [eth_gasPrice](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_gasPrice): Returns the current gas price in wei.
-- [eth_getBalance](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBalance): Returns the ETH balance of an account at a given block. Use the pending tag on a Flashblocks endpoint for 200ms pre-confirmed balances.
+- [eth_getBalance](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBalance): Returns the ETH balance of an account at a given block. Use the pending tag for 200ms pre-confirmed balances.
 - [eth_getBlockByHash](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockByHash): Returns block information by block hash.
 - [eth_getBlockByNumber](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockByNumber): Returns block information by number. On Flashblocks endpoints, the pending tag returns the live pre-confirmed block updated every ~200ms.
-- [eth_getBlockReceipts](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockReceipts): Returns all transaction receipts for a block. Use pending on a Flashblocks endpoint for pre-confirmed receipts.
+- [eth_getBlockReceipts](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockReceipts): Returns all transaction receipts for a block. Use pending for pre-confirmed receipts.
 - [eth_getBlockTransactionCountByHash](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockTransactionCountByHash): Returns the number of transactions in a block by block hash.
 - [eth_getBlockTransactionCountByNumber](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockTransactionCountByNumber): Returns the number of transactions in a block by block number.
-- [eth_getCode](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getCode): Returns the contract bytecode at an address. Use pending on a Flashblocks endpoint to detect newly deployed contracts before block finalization.
-- [eth_getLogs](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs): Returns logs matching a filter. Use pending on a Flashblocks endpoint to query logs from pre-confirmed transactions.
-- [eth_getStorageAt](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getStorageAt): Returns the value of a storage slot at an address. Use pending on a Flashblocks endpoint for pre-confirmed storage reads.
+- [eth_getCode](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getCode): Returns the contract bytecode at an address. Use pending to detect newly deployed contracts before block finalization.
+- [eth_getLogs](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs): Returns logs matching a filter. Use pending to query logs from pre-confirmed transactions.
+- [eth_getStorageAt](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getStorageAt): Returns the value of a storage slot at an address. Use pending for pre-confirmed storage reads.
 - [eth_getTransactionByBlockHashAndIndex](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByBlockHashAndIndex): Returns a transaction by block hash and index position.
 - [eth_getTransactionByBlockNumberAndIndex](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByBlockNumberAndIndex): Returns a transaction by block number and index position.
 - [eth_getTransactionByHash](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByHash): Returns a transaction by its hash.
-- [eth_getTransactionCount](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionCount): Returns the number of transactions sent from an address (the nonce). Use pending on a Flashblocks endpoint to get the pre-confirmed nonce.
+- [eth_getTransactionCount](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionCount): Returns the number of transactions sent from an address (the nonce). Use pending to get the pre-confirmed nonce.
 - [eth_getTransactionReceipt](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionReceipt): Returns the receipt for a mined transaction. Receipts are only available after a transaction is included in a block.
 - [eth_maxPriorityFeePerGas](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_maxPriorityFeePerGas): Returns the suggested EIP-1559 priority fee (tip) per gas.
-- [eth_sendRawTransaction](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_sendRawTransaction): Submits a pre-signed transaction to the network. Submit to a Flashblocks preconf endpoint to get 200ms pre-confirmation.
-- [eth_subscribe](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe): Creates a real-time WebSocket subscription. Flashblocks endpoints add three extra subscription types and emit newHeads every ~200ms.
+- [eth_sendRawTransaction](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_sendRawTransaction): Submits a pre-signed transaction to the network. All Base endpoints are Flashblocks-enabled, providing 200ms pre-confirmation.
+- [eth_subscribe](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe): Creates a real-time WebSocket subscription for new blocks, logs, and pending transactions.
 - [eth_syncing](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_syncing): Returns the sync status of the node.
 - [eth_unsubscribe](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_unsubscribe): Cancels an active WebSocket subscription.
 - [net_version](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/net_version): Returns the current network ID as a string.
@@ -172,7 +173,6 @@ const client = createPublicClient({ chain: base, transport: http() })
 - [Network Fees](https://docs.base.org/base-chain/network-information/network-fees): Documentation about network fees on Base. This page covers details of the two-component cost system involving L2 execution fees and L1 security fees, and offers insights on fee variations and cost-saving strategies.
 - [Transaction Finality](https://docs.base.org/base-chain/network-information/transaction-finality): Detailed information about transaction finality on Base.
 - [Troubleshooting Transactions](https://docs.base.org/base-chain/network-information/troubleshooting-transactions): Guide to diagnosing and resolving transaction issues on Base.
-- [Base Azul Upgrade](https://docs.base.org/base-chain/node-operators/base-v1-upgrade): Migrate your Base node to base-reth-node and base-consensus for Azul.
 - [Node Providers](https://docs.base.org/base-chain/node-operators/node-providers): Documentation for Node Providers for the Base network. Including details on their services, supported networks, and pricing plans.
 - [Node Performance](https://docs.base.org/base-chain/node-operators/performance-tuning): Hardware specifications, storage requirements, client recommendations, and configuration settings for running a performant Base node.
 - [Run a Node](https://docs.base.org/base-chain/node-operators/run-a-base-node): A tutorial that teaches how to set up and run a Base Node.
@@ -205,8 +205,11 @@ const client = createPublicClient({ chain: base, transport: http() })
 - [ZK Prover](https://docs.base.org/base-chain/specs/protocol/proofs/zk-prover): Specification of the ZK prover, an offchain service that uses SP1 programs to produce permissionless proofs for checkpoint proposals and disputes.
 - [Configuration](https://docs.base.org/base-chain/specs/reference/configurability): Reference for Base Chain configuration parameters across consensus, policy, admin, and sequencer categories.
 - [Glossary](https://docs.base.org/base-chain/specs/reference/glossary): Glossary of terms and definitions used throughout the Base Chain protocol specification.
-- [Azul: Execution Engine](https://docs.base.org/base-chain/specs/upgrades/azul/exec-engine): Execution engine changes in the Azul hardfork, including the EIP-7825 transaction gas limit cap and secp256r1 precompile cost updates.
-- [Azul: Proof System](https://docs.base.org/base-chain/specs/upgrades/azul/proofs): Specification of the Azul multi-proof system, replacing the single output proposer with an AggregateVerifier contract for L2 checkpoint security.
+- [Execution Engine](https://docs.base.org/base-chain/specs/upgrades/azul/exec-engine): Execution engine changes in the Azul hardfork, including the EIP-7825 transaction gas limit cap and secp256r1 precompile cost updates.
+- [Node Upgrade Guide](https://docs.base.org/base-chain/specs/upgrades/azul/node-upgrade): Migrate your Base node to base-reth-node and base-consensus for Azul.
+- [Proof System](https://docs.base.org/base-chain/specs/upgrades/azul/proofs): Specification of the Azul multi-proof system, replacing the single output proposer with an AggregateVerifier contract for L2 checkpoint security.
+- [B20 Native Token Standard](https://docs.base.org/base-chain/specs/upgrades/beryl/b20): B20 is Base's native token standard - designed for stablecoin issuers, real-world asset (RWA) and equity issuers, and long-tail token creators.
+- [Reth V2](https://docs.base.org/base-chain/specs/upgrades/beryl/reth-v2): Reth V2 reduces node disk usage by up to 50% and delivers a rewritten state root pipeline with significantly higher throughput and lower block-execution latency.
 - [Span-batches](https://docs.base.org/base-chain/specs/upgrades/delta/span-batches): Specification of span batches introduced in Delta, a new batch format that compresses sequences of L2 blocks for more efficient L1 data posting.
 - [Derivation](https://docs.base.org/base-chain/specs/upgrades/ecotone/derivation): Derivation changes in the Ecotone upgrade, extending the retrieval stage to support EIP-4844 blobs as an additional data availability source.
 - [Ecotone L1 Attributes](https://docs.base.org/base-chain/specs/upgrades/ecotone/l1-attributes): L1 attributes transaction changes in the Ecotone upgrade, updating calldata format to support the new blob-based fee calculation model.
@@ -361,7 +364,7 @@ const client = createPublicClient({ chain: base, transport: http() })
 
 ## AI Agents
 - [Guides](https://docs.base.org/ai-agents/guides/index): Step-by-step guides for common things to do with Base MCP
-- [Base MCP](https://docs.base.org/ai-agents/index): Give your AI assistant a wallet. Base MCP connects any AI to your Base Account — check balances, send funds, swap tokens, sign messages, and pay x402 APIs.
+- [Base MCP](https://docs.base.org/ai-agents/index): Give your AI assistant a wallet. Base MCP connects any AI to your Base Account. Check balances, send funds, swap tokens, sign messages, and pay with x402.
 - [Overview](https://docs.base.org/ai-agents/plugins/index): How the Base MCP Skill works and how plugins extend it
 - [Overview](https://docs.base.org/ai-agents/plugins/native/index): Plugins authored by the Base team that ship with the Base MCP skill
 - [Execute Contract Calls](https://docs.base.org/ai-agents/guides/batch-calls): Batch multiple contract interactions into a single user approval using send_calls and Base MCP
@@ -373,15 +376,15 @@ const client = createPublicClient({ chain: base, transport: http() })
 - [Make x402 Payments](https://docs.base.org/ai-agents/guides/x402-payments): Pay for x402-enabled API requests with USDC using Base MCP
 - [Custom Plugins](https://docs.base.org/ai-agents/plugins/custom-plugins): Build your own plugin that produces unsigned calldata and executes through Base MCP's send_calls
 - [Aerodrome](https://docs.base.org/ai-agents/plugins/native/aerodrome): Token swaps and basic-pool liquidity on Aerodrome (the leading DEX on Base) via sugar-sdk + Base MCP. CLI-only.
-- [Avantis](https://docs.base.org/ai-agents/plugins/native/avantis): Perpetual futures on Base via the Avantis tx-builder. CLI-only.
+- [Avantis](https://docs.base.org/ai-agents/plugins/native/avantis): Perpetual futures on Base via the Avantis tx-builder. Reads work on every surface; trade-building uses a CLI harness or the Avantis web UI.
 - [Bankr](https://docs.base.org/ai-agents/plugins/native/bankr): Discover the latest token launches on Base via the Bankr API and buy them with Base MCP's swap tool.
 - [Moonwell](https://docs.base.org/ai-agents/plugins/native/moonwell): Compound v2 lending on Base and Optimism via the Moonwell HTTP API
 - [Morpho](https://docs.base.org/ai-agents/plugins/native/morpho): Lending and vaults on Base via Morpho CLI, with Morpho MCP fallback for chat-only surfaces.
 - [Uniswap](https://docs.base.org/ai-agents/plugins/native/uniswap): Token swaps and V2/V3/V4 LP positions on Base via the Uniswap trade and liquidity APIs
 - [Virtuals](https://docs.base.org/ai-agents/plugins/native/virtuals): Create and operate Virtuals (ACP) AI agents — payment cards, email identities, agent management — signed in via Base MCP.
-- [Get Started with Base MCP](https://docs.base.org/ai-agents/quickstart): Connect Base MCP to your agent in under 2 minutes
+- [Get Started with Base MCP](https://docs.base.org/ai-agents/quickstart): Connect Base MCP to your agent in under 5 minutes
 - [Aerodrome Plugin](https://docs.base.org/ai-agents/skills/plugins/aerodrome): Skill plugin reference for building unsigned Aerodrome calldata with the Sugar SDK CLI and submitting it through Base MCP send_calls.
-- [Avantis Plugin](https://docs.base.org/ai-agents/skills/plugins/avantis): Skill plugin reference for trading perpetual futures on Avantis from CLI harnesses through Base MCP.
+- [Avantis Plugin](https://docs.base.org/ai-agents/skills/plugins/avantis): Skill plugin reference for reading Avantis market data and positions on any surface, and building perpetual-futures transactions from CLI harnesses (with an Avantis UI fallback on chat-only surfaces). Aligned with the canonical Avantis-Labs/avantis-trading-skill spec.
 - [Bankr Plugin](https://docs.base.org/ai-agents/skills/plugins/bankr): Skill plugin reference for discovering the latest token launches on Base via the Bankr API and buying them with Base MCP's swap tool.
 - [Moonwell Plugin](https://docs.base.org/ai-agents/skills/plugins/moonwell): Skill plugin reference for lending on Moonwell through Base MCP.
 - [Morpho Plugin](https://docs.base.org/ai-agents/skills/plugins/morpho): Skill plugin reference for lending on Morpho with Morpho CLI when available, or Morpho MCP on chat-only surfaces.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,7 +8,7 @@
 - [Base Services Hub](https://docs.base.org/get-started/base-services-hub): A collection of services for building on Base.
 - [Block Explorers](https://docs.base.org/get-started/block-explorers): Documentation for block explorers for the Base network.
 - [Core Concepts](https://docs.base.org/get-started/concepts)
-- [Country Leads & Ambassadors](https://docs.base.org/get-started/country-leads-and-ambassadors): Connect with local Base community leaders and ambassadors around the world
+- [Regional Leads & Ambassadors](https://docs.base.org/get-started/country-leads-and-ambassadors): Connect with regional Base community leaders and ambassadors around the world
 - [Data Indexers](https://docs.base.org/get-started/data-indexers): Documentation for data indexing platforms for Base network.
 - [Deploy Smart Contracts](https://docs.base.org/get-started/deploy-smart-contracts): Step-by-step guide to deploying smart contracts on Base.
 - [Static Docs Files](https://docs.base.org/get-started/docs-llms): Use llms.txt and llms-full.txt to give AI assistants access to Base documentation.
@@ -26,7 +26,8 @@
 - [L2 Execution Engine](https://docs.base.org/base-chain/specs/protocol/execution/index): Specification of the L2 execution engine, detailing EIP-1559 parameters, fee vaults, Engine API usage, and execution layer behavior.
 - [Overview](https://docs.base.org/base-chain/specs/protocol/overview): High-level overview of the Base Chain protocol, covering rollup architecture, core components, and user flows for deposits, transactions, and withdrawals.
 - [Proofs](https://docs.base.org/base-chain/specs/protocol/proofs/index): Overview of the offchain services and onchain contracts that make L2 checkpoint proposals verifiable from Ethereum in the Azul proof system.
-- [Azul](https://docs.base.org/base-chain/specs/upgrades/azul/overview): Overview of the Azul hardfork, introducing Osaka EVM support, a simplified execution client, and a multi-proof system for L2 checkpoints.
+- [Overview](https://docs.base.org/base-chain/specs/upgrades/azul/overview): Overview of the Azul hardfork, introducing Osaka EVM support, a simplified execution client, and a multi-proof system for L2 checkpoints.
+- [Overview](https://docs.base.org/base-chain/specs/upgrades/beryl/overview): Overview of the Beryl hardfork, introducing the B20 native token standard, reduced withdrawal delays, and Reth V2.
 - [Canyon](https://docs.base.org/base-chain/specs/upgrades/canyon/overview): Overview of the Canyon hardfork, bringing Ethereum Shanghai EIPs (EIP-3651, EIP-3855, EIP-3860) to the Base execution layer.
 - [Delta](https://docs.base.org/base-chain/specs/upgrades/delta/overview): Overview of the Delta hardfork, introducing span batches to reduce L1 data costs by compressing multiple L2 blocks into single batcher transactions.
 - [Ecotone](https://docs.base.org/base-chain/specs/upgrades/ecotone/overview): Overview of the Ecotone hardfork, integrating Ethereum Dencun changes including EIP-4844 blob transactions and EIP-4788 beacon block roots.
@@ -39,28 +40,28 @@
 - [debug_traceBlockByNumber](https://docs.base.org/base-chain/api-reference/debug-api/debug_traceBlockByNumber): Returns EVM execution traces for all transactions in a block by block number.
 - [debug_traceTransaction](https://docs.base.org/base-chain/api-reference/debug-api/debug_traceTransaction): Returns the full EVM execution trace for a transaction. Requires a node with debug APIs enabled.
 - [eth_blockNumber](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_blockNumber): Returns the number of the most recently mined block.
-- [eth_call](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_call): Executes a message call without creating a transaction. Use pending on a Flashblocks endpoint to simulate against pre-confirmed state.
+- [eth_call](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_call): Executes a message call without creating a transaction. Use pending to simulate against pre-confirmed state.
 - [eth_chainId](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_chainId): Returns the chain ID of the current network.
-- [eth_estimateGas](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_estimateGas): Estimates the gas required for a transaction. Use pending on a Flashblocks endpoint to estimate against pre-confirmed state.
+- [eth_estimateGas](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_estimateGas): Estimates the gas required for a transaction. Use pending to estimate against pre-confirmed state.
 - [eth_feeHistory](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_feeHistory): Returns historical base fees and priority fee percentiles for a range of blocks.
 - [eth_gasPrice](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_gasPrice): Returns the current gas price in wei.
-- [eth_getBalance](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBalance): Returns the ETH balance of an account at a given block. Use the pending tag on a Flashblocks endpoint for 200ms pre-confirmed balances.
+- [eth_getBalance](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBalance): Returns the ETH balance of an account at a given block. Use the pending tag for 200ms pre-confirmed balances.
 - [eth_getBlockByHash](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockByHash): Returns block information by block hash.
 - [eth_getBlockByNumber](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockByNumber): Returns block information by number. On Flashblocks endpoints, the pending tag returns the live pre-confirmed block updated every ~200ms.
-- [eth_getBlockReceipts](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockReceipts): Returns all transaction receipts for a block. Use pending on a Flashblocks endpoint for pre-confirmed receipts.
+- [eth_getBlockReceipts](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockReceipts): Returns all transaction receipts for a block. Use pending for pre-confirmed receipts.
 - [eth_getBlockTransactionCountByHash](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockTransactionCountByHash): Returns the number of transactions in a block by block hash.
 - [eth_getBlockTransactionCountByNumber](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockTransactionCountByNumber): Returns the number of transactions in a block by block number.
-- [eth_getCode](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getCode): Returns the contract bytecode at an address. Use pending on a Flashblocks endpoint to detect newly deployed contracts before block finalization.
-- [eth_getLogs](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs): Returns logs matching a filter. Use pending on a Flashblocks endpoint to query logs from pre-confirmed transactions.
-- [eth_getStorageAt](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getStorageAt): Returns the value of a storage slot at an address. Use pending on a Flashblocks endpoint for pre-confirmed storage reads.
+- [eth_getCode](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getCode): Returns the contract bytecode at an address. Use pending to detect newly deployed contracts before block finalization.
+- [eth_getLogs](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs): Returns logs matching a filter. Use pending to query logs from pre-confirmed transactions.
+- [eth_getStorageAt](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getStorageAt): Returns the value of a storage slot at an address. Use pending for pre-confirmed storage reads.
 - [eth_getTransactionByBlockHashAndIndex](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByBlockHashAndIndex): Returns a transaction by block hash and index position.
 - [eth_getTransactionByBlockNumberAndIndex](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByBlockNumberAndIndex): Returns a transaction by block number and index position.
 - [eth_getTransactionByHash](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByHash): Returns a transaction by its hash.
-- [eth_getTransactionCount](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionCount): Returns the number of transactions sent from an address (the nonce). Use pending on a Flashblocks endpoint to get the pre-confirmed nonce.
+- [eth_getTransactionCount](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionCount): Returns the number of transactions sent from an address (the nonce). Use pending to get the pre-confirmed nonce.
 - [eth_getTransactionReceipt](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionReceipt): Returns the receipt for a mined transaction. Receipts are only available after a transaction is included in a block.
 - [eth_maxPriorityFeePerGas](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_maxPriorityFeePerGas): Returns the suggested EIP-1559 priority fee (tip) per gas.
-- [eth_sendRawTransaction](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_sendRawTransaction): Submits a pre-signed transaction to the network. Submit to a Flashblocks preconf endpoint to get 200ms pre-confirmation.
-- [eth_subscribe](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe): Creates a real-time WebSocket subscription. Flashblocks endpoints add three extra subscription types and emit newHeads every ~200ms.
+- [eth_sendRawTransaction](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_sendRawTransaction): Submits a pre-signed transaction to the network. All Base endpoints are Flashblocks-enabled, providing 200ms pre-confirmation.
+- [eth_subscribe](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe): Creates a real-time WebSocket subscription for new blocks, logs, and pending transactions.
 - [eth_syncing](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_syncing): Returns the sync status of the node.
 - [eth_unsubscribe](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_unsubscribe): Cancels an active WebSocket subscription.
 - [net_version](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/net_version): Returns the current network ID as a string.
@@ -84,7 +85,6 @@
 - [Network Fees](https://docs.base.org/base-chain/network-information/network-fees): Documentation about network fees on Base. This page covers details of the two-component cost system involving L2 execution fees and L1 security fees, and offers insights on fee variations and cost-saving strategies.
 - [Transaction Finality](https://docs.base.org/base-chain/network-information/transaction-finality): Detailed information about transaction finality on Base.
 - [Troubleshooting Transactions](https://docs.base.org/base-chain/network-information/troubleshooting-transactions): Guide to diagnosing and resolving transaction issues on Base.
-- [Base Azul Upgrade](https://docs.base.org/base-chain/node-operators/base-v1-upgrade): Migrate your Base node to base-reth-node and base-consensus for Azul.
 - [Node Providers](https://docs.base.org/base-chain/node-operators/node-providers): Documentation for Node Providers for the Base network. Including details on their services, supported networks, and pricing plans.
 - [Node Performance](https://docs.base.org/base-chain/node-operators/performance-tuning): Hardware specifications, storage requirements, client recommendations, and configuration settings for running a performant Base node.
 - [Run a Node](https://docs.base.org/base-chain/node-operators/run-a-base-node): A tutorial that teaches how to set up and run a Base Node.
@@ -117,8 +117,11 @@
 - [ZK Prover](https://docs.base.org/base-chain/specs/protocol/proofs/zk-prover): Specification of the ZK prover, an offchain service that uses SP1 programs to produce permissionless proofs for checkpoint proposals and disputes.
 - [Configuration](https://docs.base.org/base-chain/specs/reference/configurability): Reference for Base Chain configuration parameters across consensus, policy, admin, and sequencer categories.
 - [Glossary](https://docs.base.org/base-chain/specs/reference/glossary): Glossary of terms and definitions used throughout the Base Chain protocol specification.
-- [Azul: Execution Engine](https://docs.base.org/base-chain/specs/upgrades/azul/exec-engine): Execution engine changes in the Azul hardfork, including the EIP-7825 transaction gas limit cap and secp256r1 precompile cost updates.
-- [Azul: Proof System](https://docs.base.org/base-chain/specs/upgrades/azul/proofs): Specification of the Azul multi-proof system, replacing the single output proposer with an AggregateVerifier contract for L2 checkpoint security.
+- [Execution Engine](https://docs.base.org/base-chain/specs/upgrades/azul/exec-engine): Execution engine changes in the Azul hardfork, including the EIP-7825 transaction gas limit cap and secp256r1 precompile cost updates.
+- [Node Upgrade Guide](https://docs.base.org/base-chain/specs/upgrades/azul/node-upgrade): Migrate your Base node to base-reth-node and base-consensus for Azul.
+- [Proof System](https://docs.base.org/base-chain/specs/upgrades/azul/proofs): Specification of the Azul multi-proof system, replacing the single output proposer with an AggregateVerifier contract for L2 checkpoint security.
+- [B20 Native Token Standard](https://docs.base.org/base-chain/specs/upgrades/beryl/b20): B20 is Base's native token standard - designed for stablecoin issuers, real-world asset (RWA) and equity issuers, and long-tail token creators.
+- [Reth V2](https://docs.base.org/base-chain/specs/upgrades/beryl/reth-v2): Reth V2 reduces node disk usage by up to 50% and delivers a rewritten state root pipeline with significantly higher throughput and lower block-execution latency.
 - [Span-batches](https://docs.base.org/base-chain/specs/upgrades/delta/span-batches): Specification of span batches introduced in Delta, a new batch format that compresses sequences of L2 blocks for more efficient L1 data posting.
 - [Derivation](https://docs.base.org/base-chain/specs/upgrades/ecotone/derivation): Derivation changes in the Ecotone upgrade, extending the retrieval stage to support EIP-4844 blobs as an additional data availability source.
 - [Ecotone L1 Attributes](https://docs.base.org/base-chain/specs/upgrades/ecotone/l1-attributes): L1 attributes transaction changes in the Ecotone upgrade, updating calldata format to support the new blob-based fee calculation model.
@@ -273,7 +276,7 @@
 
 ## AI Agents
 - [Guides](https://docs.base.org/ai-agents/guides/index): Step-by-step guides for common things to do with Base MCP
-- [Base MCP](https://docs.base.org/ai-agents/index): Give your AI assistant a wallet. Base MCP connects any AI to your Base Account — check balances, send funds, swap tokens, sign messages, and pay x402 APIs.
+- [Base MCP](https://docs.base.org/ai-agents/index): Give your AI assistant a wallet. Base MCP connects any AI to your Base Account. Check balances, send funds, swap tokens, sign messages, and pay with x402.
 - [Overview](https://docs.base.org/ai-agents/plugins/index): How the Base MCP Skill works and how plugins extend it
 - [Overview](https://docs.base.org/ai-agents/plugins/native/index): Plugins authored by the Base team that ship with the Base MCP skill
 - [Execute Contract Calls](https://docs.base.org/ai-agents/guides/batch-calls): Batch multiple contract interactions into a single user approval using send_calls and Base MCP
@@ -285,15 +288,15 @@
 - [Make x402 Payments](https://docs.base.org/ai-agents/guides/x402-payments): Pay for x402-enabled API requests with USDC using Base MCP
 - [Custom Plugins](https://docs.base.org/ai-agents/plugins/custom-plugins): Build your own plugin that produces unsigned calldata and executes through Base MCP's send_calls
 - [Aerodrome](https://docs.base.org/ai-agents/plugins/native/aerodrome): Token swaps and basic-pool liquidity on Aerodrome (the leading DEX on Base) via sugar-sdk + Base MCP. CLI-only.
-- [Avantis](https://docs.base.org/ai-agents/plugins/native/avantis): Perpetual futures on Base via the Avantis tx-builder. CLI-only.
+- [Avantis](https://docs.base.org/ai-agents/plugins/native/avantis): Perpetual futures on Base via the Avantis tx-builder. Reads work on every surface; trade-building uses a CLI harness or the Avantis web UI.
 - [Bankr](https://docs.base.org/ai-agents/plugins/native/bankr): Discover the latest token launches on Base via the Bankr API and buy them with Base MCP's swap tool.
 - [Moonwell](https://docs.base.org/ai-agents/plugins/native/moonwell): Compound v2 lending on Base and Optimism via the Moonwell HTTP API
 - [Morpho](https://docs.base.org/ai-agents/plugins/native/morpho): Lending and vaults on Base via Morpho CLI, with Morpho MCP fallback for chat-only surfaces.
 - [Uniswap](https://docs.base.org/ai-agents/plugins/native/uniswap): Token swaps and V2/V3/V4 LP positions on Base via the Uniswap trade and liquidity APIs
 - [Virtuals](https://docs.base.org/ai-agents/plugins/native/virtuals): Create and operate Virtuals (ACP) AI agents — payment cards, email identities, agent management — signed in via Base MCP.
-- [Get Started with Base MCP](https://docs.base.org/ai-agents/quickstart): Connect Base MCP to your agent in under 2 minutes
+- [Get Started with Base MCP](https://docs.base.org/ai-agents/quickstart): Connect Base MCP to your agent in under 5 minutes
 - [Aerodrome Plugin](https://docs.base.org/ai-agents/skills/plugins/aerodrome): Skill plugin reference for building unsigned Aerodrome calldata with the Sugar SDK CLI and submitting it through Base MCP send_calls.
-- [Avantis Plugin](https://docs.base.org/ai-agents/skills/plugins/avantis): Skill plugin reference for trading perpetual futures on Avantis from CLI harnesses through Base MCP.
+- [Avantis Plugin](https://docs.base.org/ai-agents/skills/plugins/avantis): Skill plugin reference for reading Avantis market data and positions on any surface, and building perpetual-futures transactions from CLI harnesses (with an Avantis UI fallback on chat-only surfaces). Aligned with the canonical Avantis-Labs/avantis-trading-skill spec.
 - [Bankr Plugin](https://docs.base.org/ai-agents/skills/plugins/bankr): Skill plugin reference for discovering the latest token launches on Base via the Bankr API and buying them with Base MCP's swap tool.
 - [Moonwell Plugin](https://docs.base.org/ai-agents/skills/plugins/moonwell): Skill plugin reference for lending on Moonwell through Base MCP.
 - [Morpho Plugin](https://docs.base.org/ai-agents/skills/plugins/morpho): Skill plugin reference for lending on Morpho with Morpho CLI when available, or Morpho MCP on chat-only surfaces.


### PR DESCRIPTION
**What changed? Why?**

Adds the Beryl hardfork specification section to base-chain/specs/upgrades, covering the three main deliverables:

- B20 (beryl/b20.mdx) - full spec for the native token standard: Rust precompile architecture, roles model, policy scopes, mint/burn paths, supply cap, memos, granular pause, ERC-2612/ERC-7572, Asset and Stablecoin variants, and the roadmap (gas payment, virtual addresses, indexed data, perf targets)
- Withdrawals (beryl/overview.mdx) - documents the single-proof finalization window reduction from 7 to 5 days, with the dual-proof fast path remaining at 1 day
- Reth V2 (beryl/reth-v2.mdx) - Storage V2 disk reductions (up to 50%), rewritten state root pipeline (sparse-trie caching, parallel trie, Proof V2), and published benchmarks (+33% throughput, ~25% lower latency)
- Activation timestamps

**Notes to reviewers**

**How has it been tested?**
Locally