### PR TITLE
fix(docs): remove stale Fall 2025 reference in migration guide table

### DIFF
--- a/docs/base-account/guides/migration-guide.mdx
+++ b/docs/base-account/guides/migration-guide.mdx
@@ -15,7 +15,7 @@ Driving this change is a transition of our mobile app: the Coinbase Wallet app i
 
 Below is a table of existing users and how they will connect to apps now and in the future:
 
-| User Type | Today | Future (~Fall 2025) |
+| User Type | Today | Future |
 |-----------|-------|---------------------|
 | Smart Wallet users (web and mobile app) | Automatically have a Base Account, can use "Sign in with Base" | No change |
 | New Base app users | Automatically have a Base Account, can use "Sign in with Base" | No change |


### PR DESCRIPTION
Closes base/docs#1315

Removed the stale "(~Fall 2025)" reference from the migration guide table since this date has already passed.