### PR TITLE
fix(docs): repair broken cross-reference anchors and links

### DIFF
--- a/docs/base-account/improve-ux/sub-accounts.mdx
+++ b/docs/base-account/improve-ux/sub-accounts.mdx
@@ -81,7 +81,7 @@ This is what the user will see when they connect their Base Account and automati
 </div>
 
 <Tip>
-We recommend using a [Paymaster](/base-account/improve-ux/sponsor-gas/paymasters) to sponsor gas to ensure the best user experience when integrating Sub Accounts. You can set a paymaster to be used for all transactions by configuring the `paymasterUrls` parameter in the SDK configuration. See the [createBaseAccount](/base-account/reference/core/createBaseAccount#param-paymaster-urls) reference for more information.
+We recommend using a [Paymaster](/base-account/improve-ux/sponsor-gas/paymasters) to sponsor gas to ensure the best user experience when integrating Sub Accounts. You can set a paymaster to be used for all transactions by configuring the `paymasterUrls` parameter in the SDK configuration. See the [createBaseAccount](/base-account/reference/core/createBaseAccount#paymaster-integration) reference for more information.
 </Tip>
 
 <Tip>

--- a/docs/base-account/reference/core/capabilities/dataSuffix.mdx
+++ b/docs/base-account/reference/core/capabilities/dataSuffix.mdx
@@ -144,7 +144,7 @@ Register on [base.dev](https://base.dev) to get your Builder Code for proper att
 3. **Keep suffixes small**: Larger suffixes increase gas costs
 
 <Info>
-For wallet developers implementing dataSuffix support, see the [For Wallet Developers](/apps/builder-codes/builder-codes#for-wallet-developers) section in the Builder Codes guide.
+For wallet developers implementing dataSuffix support, see the [For Wallet Developers](/apps/builder-codes/wallet-developers) section in the Builder Codes guide.
 </Info>
 
 ## Related Capabilities

--- a/docs/base-chain/flashblocks/faq.mdx
+++ b/docs/base-chain/flashblocks/faq.mdx
@@ -28,7 +28,7 @@ For a comprehensive introduction to how Flashblocks work, see the [Flashblocks O
   <Accordion title="Why is my transaction having trouble getting included?">
     Transactions with large gas limits (> ~18.75M gas, which is 1/10 of the ~187.5M block limit) may have longer inclusion times. This is because the builder allocates gas cumulatively—each Flashblock `j` can use up to `j/10` of the total block gas limit. Large transactions can be included once enough cumulative capacity exists.
 
-    See [Gas & Transaction Sizing](/base-chain/flashblocks/app-integration#gas-&-transaction-sizing) for the full breakdown.
+    See [Gas & Transaction Sizing](/base-chain/flashblocks/app-integration#gas--transaction-sizing) for the full breakdown.
   </Accordion>
 
   <Accordion title="How do I ensure my transaction is in the first Flashblock?">

--- a/docs/base-chain/flashblocks/overview.mdx
+++ b/docs/base-chain/flashblocks/overview.mdx
@@ -22,7 +22,7 @@ Flashblocks are always live on Base. All blocks are built by the Flashblocks bui
 | **Preconfirmation** | An ultra-fast signal that a transaction will be included, before the full block is sealed |
 | **Full Block** | A series of 10 Flashblocks combined to form the complete 2-second block |
 
-Each block contains **10 Flashblocks** (indexes 1-10), each arriving every 200ms. Index 0 exists but only contains system transactions. See [Gas & Transaction Sizing](/base-chain/flashblocks/app-integration#gas-&-transaction-sizing) for how gas budgets work.
+Each block contains **10 Flashblocks** (indexes 1-10), each arriving every 200ms. Index 0 exists but only contains system transactions. See [Gas & Transaction Sizing](/base-chain/flashblocks/app-integration#gas--transaction-sizing) for how gas budgets work.
 
 
 ## Architecture


### PR DESCRIPTION
## Summary
Repairs three broken cross-reference links. Each pointed to a non-existent anchor or page, so clicking silently dropped the reader to the top of the page (or the wrong page). All targets were verified against the current content.

## Changes
- **Flashblocks** (`base-chain/flashblocks/overview.mdx`, `faq.mdx`): the "Gas & Transaction Sizing" reference used a raw `&` (`#gas-&-transaction-sizing`), which doesn't match the generated slug. Updated to `#gas--transaction-sizing`.
- **dataSuffix** (`base-account/reference/core/capabilities/dataSuffix.mdx`): the "For Wallet Developers" link pointed to `/apps/builder-codes/builder-codes#for-wallet-developers`, an anchor that doesn't exist. Updated to the dedicated page `/apps/builder-codes/wallet-developers`.
- **Sub-Accounts** (`base-account/improve-ux/sub-accounts.mdx`): the paymaster reference pointed to `#param-paymaster-urls`, which isn't a real heading. Updated to the actual `#paymaster-integration` section.

## Verification
Anchor slugs follow github-slugger (Mintlify). Confirmed against an existing working example in the repo — "Remove Account Balances & Receipts" resolves to `#remove-account-balances--receipts` — which establishes that `&` is dropped and surrounding spaces collapse to a double dash. Each target was checked against current headings/pages.

4 files, link fragments only — no content changes.