### PR TITLE
fix: redirect broken /apps/introduction/overview paths to /apps

### DIFF
--- a/docs/base-account/guides/verify-social-accounts.mdx
+++ b/docs/base-account/guides/verify-social-accounts.mdx
@@ -432,7 +432,7 @@ function redirectToVerifyMiniApp(provider: string) {
 }
 ```
 
-After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps/introduction/overview) for broader app structure and lifecycle guidance.
+After verification, the user returns to your `redirect_uri` with `?success=true`. Run the check again (step 3) and it now returns 200 with a token. If you're building for the Base app, see the [Apps overview](/apps) for broader app structure and lifecycle guidance.
 
 </Step>
 </Steps>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1094,51 +1094,51 @@
     },
     {
       "source": "/onchainkit/latest/components/minikit/overview",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/provider-and-initialization",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useMiniKit",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useOpenUrl",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useClose",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/usePrimaryButton",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useViewProfile",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useComposeCast",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useViewCast",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useAuthenticate",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useAddFrame",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/latest/components/minikit/hooks/useNotification",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/onchainkit/identity/identity",
@@ -2950,7 +2950,7 @@
     },
     {
       "source": "/cookbook/base-app-coins",
-      "destination": "/apps/introduction/overview"
+      "destination": "/apps"
     },
     {
       "source": "/cookbook/testing-onchain-apps",


### PR DESCRIPTION
## Summary

- 13 redirects in `docs/docs.json` pointed to `/apps/introduction/overview` which does not exist, causing 404 errors
- 1 inline link in `base-account/guides/verify-social-accounts.mdx` had the same broken path
- Updated all 14 destinations to `/apps` (the valid apps index page)

Fixes #1599

## Test plan
- [ ] Verify all previously broken redirect sources now land on `/apps` instead of 404
- [ ] Confirm `verify-social-accounts.mdx` inline link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)