### PR TITLE
fix: update dead Superbridge and Brid.gg bridge links

### DIFF
--- a/docs/base-chain/network-information/bridges.mdx
+++ b/docs/base-chain/network-information/bridges.mdx
@@ -18,8 +18,8 @@ Superbridge enables you to bridge ETH and other supported assets from Ethereum m
 
 #### Supported Networks
 
-- [Base Mainnet](https://superbridge.app/base)
-- [Base Sepolia (Testnet)](https://superbridge.app/base-sepolia)
+- [Base Mainnet](https://superbridge.app/?fromChainId=1&toChainId=8453)
+- [Base Sepolia (Testnet)](https://superbridge.app/?fromChainId=11155111&toChainId=84532)
 
 ### Brid.gg
 
@@ -27,8 +27,8 @@ Brid.gg is another option that also helps you bridge ETH and supported assets be
 
 #### Supported Networks
 
-- [Base Mainnet](https://brid.gg/base)
-- [Base Sepolia (Testnet)](https://testnet.brid.gg/base-sepolia)
+- [Base Mainnet](https://www.brid.gg/?fromChainId=1&toChainId=8453)
+- [Base Sepolia (Testnet)](https://testnet.brid.gg/?fromChainId=11155111&toChainId=84532)
 
 ### Programmatic Bridging (Ethereum)
 


### PR DESCRIPTION
## Summary

The Superbridge and Brid.gg links on the [Bridges](https://docs.base.org/base-chain/network-information/bridges) page are dead (404).

Both providers retired their `/base` and `/base-sepolia` path routes in favor of a unified app that selects source/destination networks via `fromChainId`/`toChainId` query parameters. This updates the **Ethereum ↔ Base** links to the new format.

| Old (404) | New (200) |
|-----------|-----------|
| `superbridge.app/base` | `superbridge.app/?fromChainId=1&toChainId=8453` |
| `superbridge.app/base-sepolia` | `superbridge.app/?fromChainId=11155111&toChainId=84532` |
| `brid.gg/base` | `www.brid.gg/?fromChainId=1&toChainId=8453` |
| `testnet.brid.gg/base-sepolia` | `testnet.brid.gg/?fromChainId=11155111&toChainId=84532` |

Chain IDs: Ethereum mainnet `1` → Base `8453`; Ethereum Sepolia `11155111` → Base Sepolia `84532`.

## Testing

- Verified all old links return HTTP 404 and all new links return HTTP 200.
- The Garden (Bitcoin) links still resolve and were left unchanged.

Generated with Claude Code