### PR TITLE
fix: broken mentor profile links on mentorship page

### DIFF
--- a/docs/get-started/base-mentorship-program.mdx
+++ b/docs/get-started/base-mentorship-program.mdx
@@ -29,20 +29,20 @@ Base Mentors are experienced founders, operators, and subject matter experts acr
 | Elena Nadolinski | [Iron Fish (acq. Coinbase)](https://x.com/leanthebean) |
 | Franklin Bi | [Pantera Capital](https://panteracapital.com/team/) |
 | Ian Dutra | [a16z crypto](https://a16zcrypto.com/team/ian-dutra/) |
-| Jack Gorman | [Variant](https://variant.fund/people/jack-gorman/) |
+| Jack Gorman | Variant |
 | Jacob Frantz | [Opyn (acq. Coinbase)](https://x.com/therealjfrantz) |
 | Jai Prasad | [Definitive](https://x.com/jai_prasad17) |
 | Jakub Rusiecki | [1kx](https://1kx.network/team/jakub-rusiecki) |
-| Jay Drain Jr | [a16z crypto](https://a16zcrypto.com/team/jay-drain/) |
+| Jay Drain Jr | a16z crypto |
 | Jonathan Wu | [Asylum Ventures](https://www.asylum.vc/) |
 | Kaito Cunningham | [Utopia Labs (acq. Coinbase)](https://x.com/kaycidot) |
 | Katie Chiou | [Archetype](https://www.archetype.fund/team) |
 | Lincoln Murr | [Coinbase](https://x.com/MurrLincoln) |
-| Maria Shen | [Electric Capital](https://www.electriccapital.com/team/maria-shen-c) |
+| Maria Shen | [Electric Capital](https://www.electriccapital.com/team/maria-shen) |
 | Mark Beylin | [Haun Ventures](https://www.haun.co/team/mark-beylin) |
 | Mike Tomaino | [1confirmation](https://www.1confirmation.com/about) |
 | Nick Tomaino | [1confirmation](https://www.1confirmation.com/about) |
-| Nina Suthers | [Variant](https://variant.fund/people/nina-suthers-2/) |
+| Nina Suthers | Variant |
 | Robin Ji | [Liquifi (acq. Coinbase)](https://x.com/robindavidji) |
 | Ryan Prescott | [a16z crypto](https://a16zcrypto.com/team/ryan-prescott/) |
 | Simone "Limone" Staffa | [Builders Garden](https://www.builders.garden/#mission) |


### PR DESCRIPTION
## Summary
Fixes broken (HTTP 404) mentor/investor profile links in `docs/get-started/base-mentorship-program.mdx`, found during a repo-wide external-link audit.

| Mentor | Old link | Action |
|--------|----------|--------|
| Maria Shen | `electriccapital.com/team/maria-shen-c` | → `/team/maria-shen` (verified 200) |
| Jay Drain Jr | `a16zcrypto.com/team/jay-drain/` | Removed link, kept "a16z crypto" text (no longer on a16z team) |
| Jack Gorman | `variant.fund/people/jack-gorman/` | Removed link, kept "Variant" text (Variant retired people pages) |
| Nina Suthers | `variant.fund/people/nina-suthers-2/` | Removed link, kept "Variant" text |

Note: variant.fund bot-blocks automated requests; the 404s were confirmed via a separate fetcher. The profile pages and the `/people/` index both 404.

Generated with Claude Code