### PR TITLE
fix: broken data-indexer partner links

### DIFF
--- a/docs/get-started/data-indexers.mdx
+++ b/docs/get-started/data-indexers.mdx
@@ -9,12 +9,12 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 
 [Allium](https://www.allium.so/) is an Enterprise Data Platform that serves accurate, fast, and simple blockchain data. Currently serving 15 blockchains and over 100+ schemas, Allium offers near real-time Base data for infrastructure needs and enriched Base data (NFT, DEX, Decoded, Wallet360) for research and analytics.
 
-Allium supports data delivery to multiple [destinations](https://docs.allium.so/integrations/overview), including Snowflake, Bigquery, Databricks, and AWS S3.
+Allium supports data delivery to multiple [destinations](https://docs.allium.so/datashares/overview), including Snowflake, Bigquery, Databricks, and AWS S3.
 
 Documentation:
 
-- [Real-time](https://docs.allium.so/real-time-data/base)
-- [Batch-enriched](https://docs.allium.so/data-tables/base)
+- [Real-time](https://docs.allium.so/api/developer/overview)
+- [Batch-enriched](https://docs.allium.so/historical-data/supported-blockchains/evm/base)
 
 To get started, contact Allium [here](https://www.allium.so/contact).
 
@@ -33,19 +33,18 @@ References:
 
 ## Covalent
 
-[Covalent](https://www.covalenthq.com/?utm_source=base&utm_medium=partner-docs) is a hosted blockchain data solution providing access to historical and current on-chain data for [100+ supported blockchains](https://www.covalenthq.com/docs/networks/?utm_source=base&utm_medium=partner-docs), including [Base](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs).
+[Covalent](https://www.covalenthq.com/?utm_source=base&utm_medium=partner-docs) is a hosted blockchain data solution providing access to historical and current on-chain data for [100+ supported blockchains](https://goldrush.dev/docs/chains), including [Base](https://goldrush.dev/docs/chains/base).
 
 Covalent maintains a full archival copy of every supported blockchain, meaning every balance, transaction, log event, and NFT asset data is available from the genesis block. This data is available via:
 
-1. [Unified API](https://www.covalenthq.com/docs/unified-api/?utm_source=base&utm_medium=partner-docs) - Incorporate blockchain data into your app with a familiar REST API
-2. [Increment](https://www.covalenthq.com/docs/increment/?utm_source=base&utm_medium=partner-docs) - Create and embed custom charts with no-code analytics
+1. [Foundational API](https://goldrush.dev/docs/goldrush-foundational-api/overview) - Incorporate blockchain data into your app with a familiar REST API
 
-To get started, [sign up](https://www.covalenthq.com/platform/?utm_source=base&utm_medium=partner-docs) and visit the [developer documentation](https://www.covalenthq.com/docs/?utm_source=base&utm_medium=partner-docs).
+To get started, [sign up](https://www.covalenthq.com/platform/?utm_source=base&utm_medium=partner-docs) and visit the [developer documentation](https://goldrush.dev/docs).
 
 <HeaderNoToc title="Supported Networks"/>
 
-- [Base Mainnet](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs)
-- [Base Sepolia](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs) (Testnet)
+- [Base Mainnet](https://goldrush.dev/docs/chains/base)
+- [Base Sepolia](https://goldrush.dev/docs/chains/base) (Testnet)
 
 
 
@@ -94,7 +93,7 @@ To get started, you can [sign up for an account](https://app.ghostlogs.xyz/ghost
 
 Our services include data transformations, aggregations, and streamlined data flows, allowing teams to develop their products faster while saving on developer resources, time, and money. Our solution is ideal for teams needing advanced data engineering for modular chain setups, multi-chain products, L1/L2/L3 chains and AI.
 
-To get started contact us [here](https://www.indexing.co/get-in-touch).
+To get started contact us [here](https://www.indexing.co/contact).
 
 <HeaderNoToc title="Supported Networks"/>
 
@@ -113,21 +112,6 @@ To get started with Moralis, you can [sign up for an account](https://moralis.io
 
 - Base Mainnet
 - Base Sepolia (Testnet)
-
-
-
-## Nexandria
-
-[Nexandria](https://www.nexandria.com/?utm_source=base-docs&utm_medium=partner-docs) API offers access to complete historical on-chain data at blazing speeds, arbitrary granularity (as low as block-level) and at viable unit economics (think web2 level costs). Our technology lets you generate subgraphs on the fly, unlocking unique endpoints like a statement of all the balance transfers for all the tokens, or a list of all the neighbors of an address with all the historical interaction details or a portfolio balance graph covering all the tokens across arbitrary time/block ranges.
-
-References:
-
-- [API Documentation](https://docs.nexandria.com/)
-- [Sign-up](https://www.nexandria.com/api)
-
-<HeaderNoToc title="Supported Networks"/>
-
-- Base Mainnet
 
 
 


### PR DESCRIPTION
## Summary
Fixes broken/dead partner links in `docs/get-started/data-indexers.mdx` (repo-wide link audit). All replacements verified HTTP 200.

**Allium** (docs restructured)
- `integrations/overview` → `datashares/overview`
- `real-time-data/base` → `api/developer/overview`
- `data-tables/base` → `historical-data/supported-blockchains/evm/base`

**Covalent → GoldRush** (Covalent rebranded; `covalenthq.com/docs/*` is retired, now `goldrush.dev`)
- `docs/networks/` → `goldrush.dev/docs/chains`
- `docs/networks/base/` → `goldrush.dev/docs/chains/base` (intro + both Supported Networks bullets)
- `docs/unified-api/` → `goldrush.dev/docs/goldrush-foundational-api/overview` (renamed "Unified API" → "Foundational API")
- `docs/developer-docs` → `goldrush.dev/docs`
- Removed the **Increment** entry (product discontinued, no equivalent)

**The Indexing Company**
- `indexing.co/get-in-touch` → `indexing.co/contact`

**Nexandria**
- Section removed entirely — apex domain 404s, docs/app subdomains unreachable; product appears defunct.

### Notes
- The `covalenthq.com` homepage/sign-up links still resolve (200), so I left the brand name/heading as "Covalent" and only swapped the dead `/docs` links. A full Covalent→GoldRush rebrand of the section could be a follow-up.
- Per repo convention, run `/lint` before merge.

Generated with Claude Code