### PR TITLE
fix: broken partner documentation links (CDP, Dynamic)

### DIFF
--- a/docs/base-account/framework-integrations/cdp.mdx
+++ b/docs/base-account/framework-integrations/cdp.mdx
@@ -608,8 +608,8 @@ We are actively working on native Base Account integration with CDP Embedded Wal
 
 ## Resources
 
-- [CDP Embedded Wallets Documentation](https://docs.cdp.coinbase.com/embedded-wallets/)
-- [CDP React Components Documentation](https://docs.cdp.coinbase.com/embedded-wallets/components)
+- [CDP Embedded Wallets Documentation](https://docs.cdp.coinbase.com/embedded-wallets/welcome)
+- [CDP React Components Documentation](https://docs.cdp.coinbase.com/embedded-wallets/react-components)
 - [Base Account Wagmi Setup](/base-account/framework-integrations/wagmi/setup)
 - [CDP Portal](https://portal.cdp.coinbase.com/)
 - [Wagmi Documentation](https://wagmi.sh/)

--- a/docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx
+++ b/docs/base-account/more/troubleshooting/usage-details/wallet-library-support.mdx
@@ -7,7 +7,7 @@ Below are some popular wallet libraries and what we know of their plans for day 
 
 | Name                                                                               | Support |
 | ---------------------------------------------------------------------------------- | ------- |
-| [Dynamic](https://docs.dynamic.xyz/wallets/advanced-wallets/coinbase-smart-wallet) | ✅      |
+| [Dynamic](https://www.dynamic.xyz/docs/react/wallets/external-wallets/coinbase-smart-wallet) | ✅      |
 | [Privy](https://docs.privy.io/guide/react/recipes/misc/coinbase-smart-wallets)     | ✅      |
 | [ThirdWeb](http://portal.thirdweb.com/connect)                                     | ✅      |
 | [ConnectKit](https://docs.family.co/connectkit)                                    | ✅      |

--- a/docs/snippets/ai-instructions/langchain-replit.mdx
+++ b/docs/snippets/ai-instructions/langchain-replit.mdx
@@ -24,7 +24,7 @@
   <Warning>
   **Security of wallets on Replit**
 
-  Every agent comes with an associated wallet. Wallet data is read from wallet_data.txt, and if that file does not exist, this repl will create a new wallet and persist it in a new file. Please note that this contains your wallet's private key and should not be used in production environments. Refer to the [CDP docs](https://docs.cdp.coinbase.com/wallet-api/docs/wallets#securing-a-wallet) on how to secure your wallets.
+  Every agent comes with an associated wallet. Wallet data is read from wallet_data.txt, and if that file does not exist, this repl will create a new wallet and persist it in a new file. Please note that this contains your wallet's private key and should not be used in production environments. Refer to the [CDP docs](https://docs.cdp.coinbase.com/server-wallets/v2/introduction/security) on how to secure your wallets.
   </Warning>
   </Step>
 </Steps>


### PR DESCRIPTION
## Summary
Fixes broken (HTTP 404) partner-documentation links (repo-wide link audit). All replacements verified HTTP 200.

| File | Old | New |
|------|-----|-----|
| `framework-integrations/cdp.mdx` | `docs.cdp.coinbase.com/embedded-wallets/` | `/embedded-wallets/welcome` |
| `framework-integrations/cdp.mdx` | `docs.cdp.coinbase.com/embedded-wallets/components` | `/embedded-wallets/react-components` |
| `snippets/ai-instructions/langchain-replit.mdx` | `docs.cdp.coinbase.com/wallet-api/docs/wallets#securing-a-wallet` | `/server-wallets/v2/introduction/security` |
| `more/troubleshooting/usage-details/wallet-library-support.mdx` | `docs.dynamic.xyz/wallets/advanced-wallets/coinbase-smart-wallet` | `www.dynamic.xyz/docs/react/wallets/external-wallets/coinbase-smart-wallet` |

CDP restructured its docs (Wallet API → Server Wallets v2; Embedded Wallets reorganized). Dynamic moved docs from `docs.dynamic.xyz` to `www.dynamic.xyz/docs`.

Generated with Claude Code