### PR TITLE
docs: name the factory precompile B20Factory, not IB20Factory

### DIFF
--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -14,7 +14,7 @@ B20 supports two variants:
 
 ## ERC-20 Compatibility
 
-B20 tokens are implemented as **Rust precompiles** rather than EVM smart contracts, making them faster, cheaper, and more native to the chain. All tokens are deployed via the singleton `IB20Factory` precompile.
+B20 tokens are implemented as **Rust precompiles** rather than EVM smart contracts, making them faster, cheaper, and more native to the chain. All tokens are deployed via the singleton B20Factory precompile.
 
 <Check>
 B20 implements the full ERC-20 standard surface with complete selector parity - it is a drop-in replacement for existing tooling and integrations.
@@ -168,7 +168,7 @@ B20 implements ERC-2612 (signed approvals) using an EIP-712 domain shaped as `(n
 
 ## Factory
 
-All B20 tokens are created through the singleton `IB20Factory` precompile via `createB20(variant, salt, params, initCalls)`.
+All B20 tokens are created through the singleton B20Factory precompile via `createB20(variant, salt, params, initCalls)`.
 
 | Parameter | Description |
 |-----------|-------------|


### PR DESCRIPTION
**What changed? Why?**

The B20 doc referred to the deployed factory precompile as `IB20Factory` in two places. `IB20Factory` is the Solidity *interface*; the singleton precompile itself is **B20Factory**. This renames the two prose references so the precompile and its interface aren't conflated.

```diff
- All tokens are deployed via the singleton `IB20Factory` precompile.
+ All tokens are deployed via the singleton B20Factory precompile.

- All B20 tokens are created through the singleton `IB20Factory` precompile via `createB20(...)`.
+ All B20 tokens are created through the singleton B20Factory precompile via `createB20(...)`.
```

This matches how the same doc already names the other two precompiles — `PolicyRegistry` and `ActivationRegistry` (plain, no `I` prefix). The interface name `IB20Factory` is still reachable via the base-std link at the top of the page.

**Notes to reviewers**

Naming/prose only — no signature or behavior changes.

**How has it been tested?**

`grep` confirms no remaining `IB20Factory` precompile references in `docs/`. MDX structure unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
