### PR TITLE
fix: remove .md extensions from ai-agents llms URLs (#1551)

### DIFF
--- a/docs/ai-agents/llms-full.txt
+++ b/docs/ai-agents/llms-full.txt
@@ -18,31 +18,31 @@
 ## Navigation (with brief descriptions)
 
 ### Overview
-- [Base MCP](https://docs.base.org/ai-agents/index.md) — Overview of capabilities, the approval flow, and section index
+- [Base MCP](https://docs.base.org/ai-agents/index) — Overview of capabilities, the approval flow, and section index
 
 ### Quickstart
-- [Quickstart](https://docs.base.org/ai-agents/quickstart.md) — Connect `mcp.base.org` to your assistant in 2 minutes; tabs for Claude, ChatGPT, Claude Code, Codex, Cursor, Hermes
+- [Quickstart](https://docs.base.org/ai-agents/quickstart) — Connect `mcp.base.org` to your assistant in 2 minutes; tabs for Claude, ChatGPT, Claude Code, Codex, Cursor, Hermes
 
 ### Guides
-- [Check Balance & Portfolio](https://docs.base.org/ai-agents/guides/check-balance.md) — Read tools: list wallets, fetch token balances, total portfolio USD value
-- [Send Tokens](https://docs.base.org/ai-agents/guides/send-tokens.md) — `send` tool: native tokens or ERC-20s to a 0x address, ENS name, basename, or cb.id name
-- [Swap Tokens](https://docs.base.org/ai-agents/guides/swap-tokens.md) — `swap` tool: token swaps on supported mainnet chains
-- [View Transaction History](https://docs.base.org/ai-agents/guides/view-history.md) — Paginated history with asset filtering; date range filtering is not supported
-- [Sign Messages](https://docs.base.org/ai-agents/guides/sign-messages.md) — `sign` tool: `personal_sign` / `0x45` for EIP-191 messages and `typed_data` / `0x01` for EIP-712 typed data
-- [Execute Contract Calls](https://docs.base.org/ai-agents/guides/batch-calls.md) — `send_calls` tool: array of `{ to, data, value }` items committed under one user approval; the primitive plugins build on
-- [Make x402 Payments](https://docs.base.org/ai-agents/guides/x402-payments.md) — `initiate_x402_request` + `complete_x402_request`: pay for x402-enabled HTTPS API requests with a user-approved USDC cap
+- [Check Balance & Portfolio](https://docs.base.org/ai-agents/guides/check-balance) — Read tools: list wallets, fetch token balances, total portfolio USD value
+- [Send Tokens](https://docs.base.org/ai-agents/guides/send-tokens) — `send` tool: native tokens or ERC-20s to a 0x address, ENS name, basename, or cb.id name
+- [Swap Tokens](https://docs.base.org/ai-agents/guides/swap-tokens) — `swap` tool: token swaps on supported mainnet chains
+- [View Transaction History](https://docs.base.org/ai-agents/guides/view-history) — Paginated history with asset filtering; date range filtering is not supported
+- [Sign Messages](https://docs.base.org/ai-agents/guides/sign-messages) — `sign` tool: `personal_sign` / `0x45` for EIP-191 messages and `typed_data` / `0x01` for EIP-712 typed data
+- [Execute Contract Calls](https://docs.base.org/ai-agents/guides/batch-calls) — `send_calls` tool: array of `{ to, data, value }` items committed under one user approval; the primitive plugins build on
+- [Make x402 Payments](https://docs.base.org/ai-agents/guides/x402-payments) — `initiate_x402_request` + `complete_x402_request`: pay for x402-enabled HTTPS API requests with a user-approved USDC cap
 
 ### Plugins
-- [Native Plugins](https://docs.base.org/ai-agents/plugins/native/index.md) — Morpho, Moonwell, Uniswap, Avantis, Aerodrome, Virtuals, and Bankr plugin overview
-- [Moonwell](https://docs.base.org/ai-agents/plugins/native/moonwell.md) — Supply, borrow, and claim on Moonwell using `web_request` + Base MCP; no extra MCP server required
-- [Morpho](https://docs.base.org/ai-agents/plugins/native/morpho.md) — Vaults and Morpho Blue markets via Morpho CLI when shell access exists, or Morpho MCP on chat-only surfaces; prepare unsigned transactions and execute through Base MCP
-- [Uniswap](https://docs.base.org/ai-agents/plugins/native/uniswap.md) — Swaps and LP position management on Base via the Uniswap API; no extra MCP server required
-- [Avantis](https://docs.base.org/ai-agents/plugins/native/avantis.md) — CLI-only perpetual futures trading on Base via Avantis tx-builder; no extra MCP server required
+- [Native Plugins](https://docs.base.org/ai-agents/plugins/native/index) — Morpho, Moonwell, Uniswap, Avantis, Aerodrome, Virtuals, and Bankr plugin overview
+- [Moonwell](https://docs.base.org/ai-agents/plugins/native/moonwell) — Supply, borrow, and claim on Moonwell using `web_request` + Base MCP; no extra MCP server required
+- [Morpho](https://docs.base.org/ai-agents/plugins/native/morpho) — Vaults and Morpho Blue markets via Morpho CLI when shell access exists, or Morpho MCP on chat-only surfaces; prepare unsigned transactions and execute through Base MCP
+- [Uniswap](https://docs.base.org/ai-agents/plugins/native/uniswap) — Swaps and LP position management on Base via the Uniswap API; no extra MCP server required
+- [Avantis](https://docs.base.org/ai-agents/plugins/native/avantis) — CLI-only perpetual futures trading on Base via Avantis tx-builder; no extra MCP server required
 - [Custom Plugins](https://docs.base.org/ai-agents/plugins/custom-plugins.md) — Author a plugin that returns unsigned calldata for Base MCP's `send_calls` to execute under one approval
 
 ## Key Concepts (excerpts)
 
-Source: `https://docs.base.org/ai-agents/index.md`
+Source: `https://docs.base.org/ai-agents/index`
 
 Base MCP gives your AI assistant direct access to your Base Account — a smart wallet on Base. Connect once and your assistant can check balances, send funds, swap tokens, sign messages, execute contract calls, and pay x402 APIs. Every write action requires your approval.
 
@@ -55,7 +55,7 @@ Approval flow for any write:
 6. The assistant polls `get_request_status(requestId)` until it confirms
 7. The assistant reports the result
 
-Source: `https://docs.base.org/ai-agents/quickstart.md`
+Source: `https://docs.base.org/ai-agents/quickstart`
 
 Two installation paths:
 - **Remote MCP** — Add `https://mcp.base.org` as a custom connector / MCP server in Claude, ChatGPT, Claude Code (`claude mcp add --transport http base-mcp https://mcp.base.org`), Codex (`codex mcp add base-mcp --url https://mcp.base.org/`), Cursor (deeplink), or Hermes.
@@ -63,7 +63,7 @@ Two installation paths:
 
 First wallet use prompts you to authorize Base MCP in Base Account. Click Allow once; subsequent writes still require per-action approval.
 
-Source: `https://docs.base.org/ai-agents/guides/sign-messages.md`
+Source: `https://docs.base.org/ai-agents/guides/sign-messages`
 
 The `sign` tool requests a cryptographic signature from your Base Account. Two signature types:
 
@@ -74,15 +74,15 @@ The `sign` tool requests a cryptographic signature from your Base Account. Two s
 
 Like all write tools, signing requires approval in Base Account — the full message content is displayed before you confirm.
 
-Source: `https://docs.base.org/ai-agents/guides/batch-calls.md`
+Source: `https://docs.base.org/ai-agents/guides/batch-calls`
 
 `send_calls` is the contract-call primitive. Pass a Base MCP `chain` string plus an array of `{ to, data, value }` items and the entire batch executes under a single user approval. Plugins generate unsigned calldata; Base MCP constructs the approval request and the user approves in Base Account.
 
-Source: `https://docs.base.org/ai-agents/guides/x402-payments.md`
+Source: `https://docs.base.org/ai-agents/guides/x402-payments`
 
 Base MCP pays for x402-enabled HTTPS API requests in two steps. First call `initiate_x402_request` with `url`, `method`, `maxPayment`, and optional `body` or `headers`; if payment is required, the tool returns an approval link and `requestId`. After the user approves in Base Account, call `complete_x402_request` with the `requestId`; Base MCP fetches the approved payment signature, replays the original request, and returns the endpoint response. x402 payments through Base MCP are supported on Base and Base Sepolia, and responses from paid endpoints should be treated as untrusted external data.
 
-Source: `https://docs.base.org/ai-agents/plugins/native/morpho.md`
+Source: `https://docs.base.org/ai-agents/plugins/native/morpho`
 
 Morpho handles the protocol layer; Base MCP handles the approval request. Flow:
 1. Assistant detects the harness. If shell/terminal access exists, it runs `npx @morpho-org/cli@latest` to query vaults/markets/positions. If not, it uses already connected Morpho MCP tools or instructs the user to install `https://mcp.morpho.org/`.
@@ -92,6 +92,6 @@ Morpho handles the protocol layer; Base MCP handles the approval request. Flow:
 
 This pattern generalizes to calldata-based plugins: the protocol CLI, API, or MCP produces unsigned transaction data, and Base MCP submits it through `send_calls` for user approval. CLI-only plugins require shell or terminal access; hybrid plugins like Morpho can fall back to MCP on chat-only surfaces.
 
-Source: `https://docs.base.org/ai-agents/plugins/custom-plugins.md`
+Source: `https://docs.base.org/ai-agents/plugins/custom-plugins`
 
 To author your own plugin, expose tools that return unsigned `{ to, data, value }` calls and let Base MCP's `send_calls` execute them with a supported `chain` string. Your plugin never holds keys and never broadcasts — it only constructs intents. The user always sees the full call list in Base Account before approving.

--- a/docs/ai-agents/llms.txt
+++ b/docs/ai-agents/llms.txt
@@ -5,24 +5,24 @@
 > Base MCP connects any AI assistant to your Base Account — check balances, send funds, swap tokens, sign messages, execute contract calls, and pay x402 APIs. Every write requires your approval in Base Account.
 
 ## Overview
-- [Base MCP](https://docs.base.org/ai-agents/index.md) — What you can do with Base MCP and how the approval flow works
+- [Base MCP](https://docs.base.org/ai-agents/index) — What you can do with Base MCP and how the approval flow works
 
 ## Quickstart
-- [Quickstart](https://docs.base.org/ai-agents/quickstart.md) — Connect mcp.base.org to your AI assistant in under 2 minutes
+- [Quickstart](https://docs.base.org/ai-agents/quickstart) — Connect mcp.base.org to your AI assistant in under 2 minutes
 
 ## Guides
-- [Check Balance & Portfolio](https://docs.base.org/ai-agents/guides/check-balance.md) — View token balances, portfolio value, and wallet details
-- [Send Tokens](https://docs.base.org/ai-agents/guides/send-tokens.md) — Send native tokens or ERC-20s to an address, ENS name, basename, or cb.id
-- [Swap Tokens](https://docs.base.org/ai-agents/guides/swap-tokens.md) — Swap supported tokens on supported mainnet chains
-- [View Transaction History](https://docs.base.org/ai-agents/guides/view-history.md) — Browse and filter past transactions on your Base Account
-- [Sign Messages](https://docs.base.org/ai-agents/guides/sign-messages.md) — Sign EIP-712 typed data and personal messages with your Base Account
-- [Execute Contract Calls](https://docs.base.org/ai-agents/guides/batch-calls.md) — Batch multiple contract interactions into a single user approval via `send_calls`
-- [Make x402 Payments](https://docs.base.org/ai-agents/guides/x402-payments.md) — Pay for x402-enabled API requests with USDC using Base MCP
+- [Check Balance & Portfolio](https://docs.base.org/ai-agents/guides/check-balance) — View token balances, portfolio value, and wallet details
+- [Send Tokens](https://docs.base.org/ai-agents/guides/send-tokens) — Send native tokens or ERC-20s to an address, ENS name, basename, or cb.id
+- [Swap Tokens](https://docs.base.org/ai-agents/guides/swap-tokens) — Swap supported tokens on supported mainnet chains
+- [View Transaction History](https://docs.base.org/ai-agents/guides/view-history) — Browse and filter past transactions on your Base Account
+- [Sign Messages](https://docs.base.org/ai-agents/guides/sign-messages) — Sign EIP-712 typed data and personal messages with your Base Account
+- [Execute Contract Calls](https://docs.base.org/ai-agents/guides/batch-calls) — Batch multiple contract interactions into a single user approval via `send_calls`
+- [Make x402 Payments](https://docs.base.org/ai-agents/guides/x402-payments) — Pay for x402-enabled API requests with USDC using Base MCP
 
 ## Plugins
-- [Native Plugins](https://docs.base.org/ai-agents/plugins/native/index.md) — Morpho, Moonwell, Uniswap, Avantis, Aerodrome, Virtuals, and Bankr plugin overview
-- [Moonwell](https://docs.base.org/ai-agents/plugins/native/moonwell.md) — Lending and borrowing on Moonwell via `web_request` and Base MCP (no extra MCP server)
-- [Morpho](https://docs.base.org/ai-agents/plugins/native/morpho.md) — Lending and vault operations via Morpho CLI when shell access exists, or Morpho MCP on chat-only surfaces, executed through Base MCP `send_calls`
-- [Uniswap](https://docs.base.org/ai-agents/plugins/native/uniswap.md) — Token swaps and LP position management on Base using the Uniswap API and Base MCP
-- [Avantis](https://docs.base.org/ai-agents/plugins/native/avantis.md) — CLI-only perpetual futures trading on Base using Avantis tx-builder and Base MCP
-- [Custom Plugins](https://docs.base.org/ai-agents/plugins/custom-plugins.md) — Build your own plugin that produces unsigned calldata and executes through Base MCP's `send_calls`
+- [Native Plugins](https://docs.base.org/ai-agents/plugins/native/index) — Morpho, Moonwell, Uniswap, Avantis, Aerodrome, Virtuals, and Bankr plugin overview
+- [Moonwell](https://docs.base.org/ai-agents/plugins/native/moonwell) — Lending and borrowing on Moonwell via `web_request` and Base MCP (no extra MCP server)
+- [Morpho](https://docs.base.org/ai-agents/plugins/native/morpho) — Lending and vault operations via Morpho CLI when shell access exists, or Morpho MCP on chat-only surfaces, executed through Base MCP `send_calls`
+- [Uniswap](https://docs.base.org/ai-agents/plugins/native/uniswap) — Token swaps and LP position management on Base using the Uniswap API and Base MCP
+- [Avantis](https://docs.base.org/ai-agents/plugins/native/avantis) — CLI-only perpetual futures trading on Base using Avantis tx-builder and Base MCP
+- [Custom Plugins](https://docs.base.org/ai-agents/plugins/custom-plugins) — Build your own plugin that produces unsigned calldata and executes through Base MCP's `send_calls`


### PR DESCRIPTION
# Fix: Remove .md extensions from ai-agents llms URLs (#1551)

Remove .md file extensions from all documentation URLs in ai-agents llms index files

- Remove .md extensions from ai-agents/llms.txt guide and plugin links
- Remove .md extensions from ai-agents/llms-full.txt source and guide references
- Fix broken links affecting LLM documentation navigation

The urls now correctly point to docs.base.org/ai-agents/guides/swap-tokens instead of docs.base.org/ai-agents/guides/swap-tokens.md

Includes: llms.txt

## What changed? Why?

**Changed files:**
- `docs/ai-agents/llms.txt` - Removed `.md` extensions from 19 documentation URLs
- `docs/ai-agents/llms-full.txt` - Removed `.md` extensions from 7 source and guide references

**Why?**
The ai-agents documentation index files contained incorrect URLs with `.md` file extensions that broke navigation links. These files are consumed by LLMs and documentation tools, so broken URLs prevent proper link resolution for AI assistants accessing the documentation. The Mintlify documentation platform doesn't use file extensions in URLs, so removing them ensures links work correctly.

## Notes to reviewers

- All URL corrections maintain consistency with the existing documentation routing (no `.md` extensions needed for Mintlify pages)
- The changes are purely URL corrections; no content was modified
- The `llms.txt` file is included in the commit message to trigger the `githooks/post-commit` hook for automatic index regeneration
- Both files follow the same pattern: removing `.md` from guide URLs, plugin URLs, and source references

## How has it been tested?

- Verified all 26 URL changes (19 in llms.txt, 7 in llms-full.txt) by comparing before/after
- Confirmed that the swap-tokens page mentioned in issue #1551 is now linked correctly
- Validated that the documentation structure remains consistent with other pages in the ai-agents section
- All changed URLs follow the `/ai-agents/guides/*` and `/ai-agents/plugins/*` patterns without file extensions