### PR TITLE
remove todos

### DIFF
--- a/docs/base-chain/specs/protocol/consensus/p2p.mdx
+++ b/docs/base-chain/specs/protocol/consensus/p2p.mdx
@@ -111,8 +111,6 @@ Peers may be banned if their performance score is too low, or if an objectively 
 
 Banned peers will be persisted to the same data-store as the peerstore records.
 
-TODO: the connection gater does currently not gate by IP address on the dial Accept-callback.
-
 #### Transport security
 
 [Libp2p-noise][libp2p-noise], `XX` handshake, with the `secp256k1` P2P identity, as popularized in Eth2.
@@ -321,8 +319,6 @@ which resolves the disagreement. Because the L1 published data depends on the ba
 the safe head will be based on whatever the batcher's source's unsafe head is.
 
 #### Block topic scoring parameters
-
-TODO: GossipSub per-topic scoring to fine-tune incentives for ideal propagation delay and bandwidth usage.
 
 ## Req-Resp
 

--- a/docs/base-chain/specs/reference/glossary.mdx
+++ b/docs/base-chain/specs/reference/glossary.mdx
@@ -292,8 +292,6 @@ cf. [Deposits Specification][deposits-spec]
 
 ## Withdrawals
 
-> **TODO** expand this whole section to be clearer
-
 [withdrawals]: glossary#withdrawals
 
 In general, a withdrawal is a transaction sent from L2 to L1 that may transfer data and/or value.
@@ -320,8 +318,6 @@ must elapse before a [withdrawal][withdrawals] can be finalized.
 
 The finalization period is necessary to afford sufficient time for [validators][validator] to make a [fault
 proof][fault-proof].
-
-> **TODO** specify current value for finalization period
 
 
 ## Configuration
@@ -507,9 +503,6 @@ A batcher is a software component (independent program) that is responsible to m
 availability provider. The batcher communicates with the rollup node in order to retrieve the channels. The channels are
 then made available using [batcher transactions][batcher-transaction].
 
-> **TODO** In the future, we might want to make the batcher responsible for constructing the channels, letting it only
-> query the rollup node for L2 block inputs.
-
 ### Batcher Transaction
 
 [batcher-transaction]: glossary#batcher-transaction
@@ -559,8 +552,6 @@ The purpose of channel timeouts is dual:
   section of the L2 Chain Derivation specification for more information.
 
 [reset-channel-buffer]: ../protocol/consensus/derivation#resetting-channel-buffering
-
-> **TODO** specify `CHANNEL_TIMEOUT`
 
 
 ## L2 Output Root Proposals
@@ -746,8 +737,6 @@ behavior.
 
 A rollup node running in validator mode is sometimes called _a replica_.
 
-> **TODO** expand this to include output root submission
-
 See the [rollup node specification][rollup-node-spec] for more information.
 
 ### Rollup Driver
@@ -756,9 +745,6 @@ See the [rollup node specification][rollup-node-spec] for more information.
 
 The rollup driver is the [rollup node][rollup-node] component responsible for [deriving the L2 chain][derivation]
 from the L1 chain (L1 [blocks][block] and their associated [receipts][receipt]).
-
-> **TODO** delete this entry, alongside its reference — can be replaced by "derivation process" or "derivation logic"
-> where needed
 
 ### L1 Attributes Predeployed Contract
 


### PR DESCRIPTION
**What changed? Why?**
Removes various TODOs lingering in the docs from the upstream spec migration

**Notes to reviewers**

**How has it been tested?**
Locally