### PR TITLE
Add base2sol interactive frontend to Base-Solana bridge docs

### DIFF
--- a/docs/base-chain/quickstart/base-solana-bridge.mdx
+++ b/docs/base-chain/quickstart/base-solana-bridge.mdx
@@ -79,6 +79,29 @@ You can access the full repository here:
   </Card>
 </CardGroup>
 
+## Try an interactive frontend
+
+If you want to try the token registration and transfer flows in a browser, use
+[base2sol](https://base2sol.xyz), a community-maintained, non-custodial frontend
+for the Base-Solana bridge. It supports first-time token registration for Base
+ERC20s and Solana SPL or Token-2022 mints, then guides users through
+Base-to-Solana and Solana-to-Base transfers with browser wallet signatures.
+
+<CardGroup cols={2}>
+  <Card title="base2sol frontend" icon="globe" href="https://base2sol.xyz">
+    Open the interactive bridge frontend.
+  </Card>
+  <Card title="base2sol source" icon="github" href="https://github.com/mrtdlgc/base2sol">
+    Review the Next.js implementation that uses the Base Bridge SDK.
+  </Card>
+</CardGroup>
+
+<Warning>
+Always verify token contract addresses, Solana mint addresses, recipients, and
+wallet prompts before signing. base2sol is a frontend and does not custody funds
+or verify token legitimacy.
+</Warning>
+
 ## Solana to Base
 
 **Flow:** Lock SOL/SPL → (Optional) Pay for relay → Validators approve → Mint + execute on Base


### PR DESCRIPTION
## Summary

- Adds a "Try an interactive frontend" section to the Base-Solana bridge quickstart.
- Links to the deployed base2sol frontend and source repository.
- Notes that base2sol is community-maintained and non-custodial.
- Adds a safety reminder to verify token contract addresses, Solana mint addresses, recipients, and wallet prompts before signing.

## Contribution fit

This keeps the change inside the existing Base-Solana bridge quickstart instead of adding a new top-level section or standalone third-party guide. The addition is focused on the existing Base-Solana bridge flow and links to source for review.

## Validation

- Verified `https://base2sol.xyz` returns HTTP 200.
- Verified `https://base2sol.xyz/skill.md` is served.
- Ran `git diff --check`.