### PR TITLE
docs: clarify EOA wallet limitations for Base MCP onboarding

### DIFF
--- a/docs/ai-agents/index.mdx
+++ b/docs/ai-agents/index.mdx
@@ -41,3 +41,41 @@ sequenceDiagram
     AI->>MCP: get_request_status(requestId)
     MCP-->>AI: confirmed
     AI-->>User: "Done — 10 USDC sent"
+```
+
+## What you can do
+
+<CardGroup cols={2}>
+  <Card title="Send & receive" icon="paper-plane">
+    Send native tokens or ERC-20 tokens to addresses, ENS names, basenames, and cb.id names.
+  </Card>
+  <Card title="Swap tokens" icon="arrows-rotate">
+    Swap supported tokens on supported mainnet chains directly from your assistant.
+  </Card>
+  <Card title="Sign messages and typed data" icon="pen-nib">
+    Sign EIP-712 typed data and plain messages for authentication and protocol interactions.
+  </Card>
+  <Card title="Execute contract calls" icon="code">
+    Batch multiple contract interactions into a single user approval.
+  </Card>
+  <Card title="Pay x402 APIs" icon="credit-card">
+    Pay for x402-enabled API requests with USDC on Base or Base Sepolia.
+  </Card>
+</CardGroup>
+
+## Get started
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="bolt" href="/ai-agents/quickstart">
+    Connect mcp.base.org to your AI assistant in under 5 minutes.
+  </Card>
+  <Card title="Guides" icon="book-open" href="/ai-agents/guides">
+    Step-by-step guides for sending, swapping, checking balance, and more.
+  </Card>
+  <Card title="Plugins" icon="puzzle-piece" href="/ai-agents/plugins">
+    How the Base MCP skill works and how plugins like Morpho, Moonwell, Uniswap, Avantis, Aerodrome, Virtuals, and Bankr extend it.
+  </Card>
+  <Card title="Custom plugins" icon="puzzle-piece" href="/ai-agents/plugins/custom-plugins">
+    Build your own plugin that produces unsigned calldata and executes through Base MCP's send_calls.
+  </Card>
+</CardGroup>

--- a/docs/ai-agents/index.mdx
+++ b/docs/ai-agents/index.mdx
@@ -8,6 +8,14 @@ import { WalletSetupDemo } from "/snippets/WalletSetupDemo.jsx"
 
 Base MCP gives your AI assistant direct access to your [Base Account](/base-account) (the smart wallet powering the Base App). Connect once and your assistant can check balances, send funds, swap tokens, sign messages, execute contract calls, and pay x402-enabled APIs across multiple networks. Every write action requires your approval.
 
+<Warning>
+  **Wallet compatibility:** Base MCP supports only native Base Smart Wallet accounts created through the email or passkey authentication flow. Standard Externally Owned Accounts (EOAs) cannot connect directly.
+
+  Native Base Smart Wallets are initialized with a 13-word recovery phrase and a device passkey configuration. Standard EOAs use a 12–24 word recovery phrase and do not produce the passkey configuration Base MCP expects, which results in schema errors.
+
+  Upgrading an existing EOA to a Smart Wallet does **not** resolve this: the account keeps its original recovery-phrase structure and will not generate the 13-word phrase or passkey configuration required to connect.
+</Warning>
+
 ## Demo
 
 <Visibility for="humans">
@@ -33,41 +41,3 @@ sequenceDiagram
     AI->>MCP: get_request_status(requestId)
     MCP-->>AI: confirmed
     AI-->>User: "Done — 10 USDC sent"
-```
-
-## What you can do
-
-<CardGroup cols={2}>
-  <Card title="Send & receive" icon="paper-plane">
-    Send native tokens or ERC-20 tokens to addresses, ENS names, basenames, and cb.id names.
-  </Card>
-  <Card title="Swap tokens" icon="arrows-rotate">
-    Swap supported tokens on supported mainnet chains directly from your assistant.
-  </Card>
-  <Card title="Sign messages and typed data" icon="pen-nib">
-    Sign EIP-712 typed data and plain messages for authentication and protocol interactions.
-  </Card>
-  <Card title="Execute contract calls" icon="code">
-    Batch multiple contract interactions into a single user approval.
-  </Card>
-  <Card title="Pay x402 APIs" icon="credit-card">
-    Pay for x402-enabled API requests with USDC on Base or Base Sepolia.
-  </Card>
-</CardGroup>
-
-## Get started
-
-<CardGroup cols={2}>
-  <Card title="Quickstart" icon="bolt" href="/ai-agents/quickstart">
-    Connect mcp.base.org to your AI assistant in under 5 minutes.
-  </Card>
-  <Card title="Guides" icon="book-open" href="/ai-agents/guides">
-    Step-by-step guides for sending, swapping, checking balance, and more.
-  </Card>
-  <Card title="Plugins" icon="puzzle-piece" href="/ai-agents/plugins">
-    How the Base MCP skill works and how plugins like Morpho, Moonwell, Uniswap, Avantis, Aerodrome, Virtuals, and Bankr extend it.
-  </Card>
-  <Card title="Custom plugins" icon="puzzle-piece" href="/ai-agents/plugins/custom-plugins">
-    Build your own plugin that produces unsigned calldata and executes through Base MCP's send_calls.
-  </Card>
-</CardGroup>


### PR DESCRIPTION
**What changed? Why?**

Closes #1558

Adds a `<Warning>` block to the Base MCP overview clarifying wallet compatibility. The documentation previously stated only that Base MCP provides access to a "Base Account" without explaining that standard EOAs are not supported. This adds explicit guidance that:

- Base MCP supports only native Base Smart Wallet accounts created via email or passkey auth
- Standard EOAs (12–24 word recovery phrase, no passkey configuration) cannot connect directly and cause schema errors
- Upgrading an existing EOA to a Smart Wallet does not resolve this, since the original recovery-phrase structure is preserved

**Notes to reviewers**

Single additive change to `docs/ai-agents/index.mdx` — one `<Warning>` block inserted after the intro paragraph. No existing content was modified or removed.

**How has it been tested?**

Documentation-only change. Verified the `<Warning>` block placement and MDX syntax against the surrounding components in the file.