### PR TITLE
Sync Base contract addresses with deployments env

### DIFF
--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -22,7 +22,6 @@ description: A comprehensive list of contract addresses for Base Mainnet and Bas
 | OptimismMintableERC721Factory | [0x4200000000000000000000000000000000000017](https://basescan.org/address/0x4200000000000000000000000000000000000017) |
 | ProxyAdmin                    | [0x4200000000000000000000000000000000000018](https://basescan.org/address/0x4200000000000000000000000000000000000018) |
 | BaseFeeVault                  | [0x4200000000000000000000000000000000000019](https://basescan.org/address/0x4200000000000000000000000000000000000019) |
-| FeeDisburser                  | [0x09C7bAD99688a55a2e83644BFAed09e62bDcCcBA](https://basescan.org/address/0x09C7bAD99688a55a2e83644BFAed09e62bDcCcBA) |
 | L1FeeVault                    | [0x420000000000000000000000000000000000001a](https://basescan.org/address/0x420000000000000000000000000000000000001a) |
 | EAS                           | [0x4200000000000000000000000000000000000021](https://basescan.org/address/0x4200000000000000000000000000000000000021) |
 | EASSchemaRegistry             | [0x4200000000000000000000000000000000000020](https://basescan.org/address/0x4200000000000000000000000000000000000020) |
@@ -44,13 +43,12 @@ description: A comprehensive list of contract addresses for Base Mainnet and Bas
 | OptimismMintableERC721Factory | [0x4200000000000000000000000000000000000017](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000017) |
 | ProxyAdmin                    | [0x4200000000000000000000000000000000000018](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000018) |
 | BaseFeeVault                  | [0x4200000000000000000000000000000000000019](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000019) |
-| FeeDisburser                  | [0x76355A67fCBCDE6F9a69409A8EAd5EaA9D8d875d](https://sepolia.basescan.org/address/0x76355A67fCBCDE6F9a69409A8EAd5EaA9D8d875d) |
 | L1FeeVault                    | [0x420000000000000000000000000000000000001a](https://sepolia.basescan.org/address/0x420000000000000000000000000000000000001a) |
 | EAS                           | [0x4200000000000000000000000000000000000021](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000021) |
 | EASSchemaRegistry             | [0x4200000000000000000000000000000000000020](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000020) |
 | LegacyERC20ETH                | [0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000](https://sepolia.basescan.org/address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000) |
 
-_Most L2 predeploy addresses are the same on Base Mainnet and Base Sepolia. Network-specific L2 contracts, such as OptimismMintableERC20Factory and FeeDisburser, are listed with their respective addresses in each table above._
+_Most L2 predeploy addresses are the same on Base Mainnet and Base Sepolia. Network-specific L2 contracts, such as OptimismMintableERC20Factory, are listed with their respective addresses in each table above._
 
 ## L1 Contract Addresses
 
@@ -61,7 +59,6 @@ _Most L2 predeploy addresses are the same on Base Mainnet and Base Sepolia. Netw
 | AddressManager                | [0x8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2](https://etherscan.io/address/0x8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2) |
 | AggregateVerifier             | [0xeEcb8A5944B217585817E802702b1262a049D259](https://etherscan.io/address/0xeEcb8A5944B217585817E802702b1262a049D259) |
 | AnchorStateRegistryProxy      | [0x909f6cf47ed12f010A796527f562bFc26C7F4E72](https://etherscan.io/address/0x909f6cf47ed12f010A796527f562bFc26C7F4E72) |
-| BalanceTracker                | [0x23B597f33f6f2621F77DA117523Dffd634cDf4ea](https://etherscan.io/address/0x23B597f33f6f2621F77DA117523Dffd634cDf4ea) |
 | DelayedWETHProxy              | [0xd0D07924AdD740a87e41Ca8A0d4CBBf6b074EF71](https://etherscan.io/address/0xd0D07924AdD740a87e41Ca8A0d4CBBf6b074EF71) |
 | DisputeGameFactoryProxy       | [0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e](https://etherscan.io/address/0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e) |
 | L1CrossDomainMessenger        | [0x866E82a600A1414e583f7F13623F1aC5d58b0Afa](https://etherscan.io/address/0x866E82a600A1414e583f7F13623F1aC5d58b0Afa) |
@@ -94,7 +91,6 @@ Certain contracts are mandatory according to the [OP Stack smart contracts overv
 | AddressManager                 | [0x709c2B8ef4A9feFc629A8a2C1AF424Dc5BD6ad1B](https://sepolia.etherscan.io/address/0x709c2B8ef4A9feFc629A8a2C1AF424Dc5BD6ad1B) |
 | AggregateVerifier (Multiproof) | [0xF3f0fA3124b7b0feB048A00404Fe4D5D49E60796](https://sepolia.etherscan.io/address/0xF3f0fA3124b7b0feB048A00404Fe4D5D49E60796) |
 | AnchorStateRegistryProxy       | [0x2fF5cC82dBf333Ea30D8ee462178ab1707315355](https://sepolia.etherscan.io/address/0x2fF5cC82dBf333Ea30D8ee462178ab1707315355) |
-| BalanceTracker                 | [0x8D1b5e5614300F5c7ADA01fFA4ccF8F1752D9A57](https://sepolia.etherscan.io/address/0x8D1b5e5614300F5c7ADA01fFA4ccF8F1752D9A57) |
 | DelayedWETHProxy (FDG)         | [0xd3683e4947A7769603Ab6418eC02f000CE3cF30b](https://sepolia.etherscan.io/address/0xd3683e4947A7769603Ab6418eC02f000CE3cF30b) |
 | DelayedWETHProxy (Multiproof)  | [0xD6e2d9D4f1f8865AC983eE848983fb1979429914](https://sepolia.etherscan.io/address/0xD6e2d9D4f1f8865AC983eE848983fb1979429914) |
 | DelayedWETHProxy (PDG)         | [0x32cE910d9C6c8F78dc6779c1499aB05F281A054e](https://sepolia.etherscan.io/address/0x32cE910d9C6c8F78dc6779c1499aB05F281A054e) |

--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Base Contracts
 title: Contract Addresses
-description: A comprehensive list of L2 contract addresses for Base Mainnet and Base Testnet, including links to their respective blockchain explorers.
+description: A comprehensive list of contract addresses for Base Mainnet and Base Testnet, including links to their respective blockchain explorers.
 ---
 
 ## L2 Contract Addresses
@@ -22,6 +22,7 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | OptimismMintableERC721Factory | [0x4200000000000000000000000000000000000017](https://basescan.org/address/0x4200000000000000000000000000000000000017) |
 | ProxyAdmin                    | [0x4200000000000000000000000000000000000018](https://basescan.org/address/0x4200000000000000000000000000000000000018) |
 | BaseFeeVault                  | [0x4200000000000000000000000000000000000019](https://basescan.org/address/0x4200000000000000000000000000000000000019) |
+| FeeDisburser                  | [0x09C7bAD99688a55a2e83644BFAed09e62bDcCcBA](https://basescan.org/address/0x09C7bAD99688a55a2e83644BFAed09e62bDcCcBA) |
 | L1FeeVault                    | [0x420000000000000000000000000000000000001a](https://basescan.org/address/0x420000000000000000000000000000000000001a) |
 | EAS                           | [0x4200000000000000000000000000000000000021](https://basescan.org/address/0x4200000000000000000000000000000000000021) |
 | EASSchemaRegistry             | [0x4200000000000000000000000000000000000020](https://basescan.org/address/0x4200000000000000000000000000000000000020) |
@@ -43,12 +44,13 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | OptimismMintableERC721Factory | [0x4200000000000000000000000000000000000017](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000017) |
 | ProxyAdmin                    | [0x4200000000000000000000000000000000000018](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000018) |
 | BaseFeeVault                  | [0x4200000000000000000000000000000000000019](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000019) |
+| FeeDisburser                  | [0x76355A67fCBCDE6F9a69409A8EAd5EaA9D8d875d](https://sepolia.basescan.org/address/0x76355A67fCBCDE6F9a69409A8EAd5EaA9D8d875d) |
 | L1FeeVault                    | [0x420000000000000000000000000000000000001a](https://sepolia.basescan.org/address/0x420000000000000000000000000000000000001a) |
 | EAS                           | [0x4200000000000000000000000000000000000021](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000021) |
 | EASSchemaRegistry             | [0x4200000000000000000000000000000000000020](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000020) |
 | LegacyERC20ETH                | [0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000](https://sepolia.basescan.org/address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000) |
 
-\*_L2 contract addresses are the same on both mainnet and testnet._
+_Some L2 predeploy addresses are the same on both mainnet and testnet; network-specific addresses are listed separately above._
 
 ## L1 Contract Addresses
 
@@ -59,6 +61,7 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | AddressManager                | [0x8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2](https://etherscan.io/address/0x8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2) |
 | AggregateVerifier             | [0xeEcb8A5944B217585817E802702b1262a049D259](https://etherscan.io/address/0xeEcb8A5944B217585817E802702b1262a049D259) |
 | AnchorStateRegistryProxy      | [0x909f6cf47ed12f010A796527f562bFc26C7F4E72](https://etherscan.io/address/0x909f6cf47ed12f010A796527f562bFc26C7F4E72) |
+| BalanceTracker                | [0x23B597f33f6f2621F77DA117523Dffd634cDf4ea](https://etherscan.io/address/0x23B597f33f6f2621F77DA117523Dffd634cDf4ea) |
 | DelayedWETHProxy              | [0xd0D07924AdD740a87e41Ca8A0d4CBBf6b074EF71](https://etherscan.io/address/0xd0D07924AdD740a87e41Ca8A0d4CBBf6b074EF71) |
 | DisputeGameFactoryProxy       | [0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e](https://etherscan.io/address/0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e) |
 | L1CrossDomainMessenger        | [0x866E82a600A1414e583f7F13623F1aC5d58b0Afa](https://etherscan.io/address/0x866E82a600A1414e583f7F13623F1aC5d58b0Afa) |
@@ -68,6 +71,8 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | OptimismMintableERC20Factory  | [0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84](https://etherscan.io/address/0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84) |
 | OptimismPortal                | [0x49048044D57e1C92A77f79988d21Fa8fAF74E97e](https://etherscan.io/address/0x49048044D57e1C92A77f79988d21Fa8fAF74E97e) |
 | ProxyAdmin                    | [0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E](https://etherscan.io/address/0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E) |
+| RiscZeroSetVerifier           | [0x5005aBa3DFf7C940fcc1e48DccCAD611a80eEB85](https://etherscan.io/address/0x5005aBa3DFf7C940fcc1e48DccCAD611a80eEB85) |
+| RiscZeroVerifierRouter        | [0x8EaB2D97Dfce405A1692a21b3ff3A172d593D319](https://etherscan.io/address/0x8EaB2D97Dfce405A1692a21b3ff3A172d593D319) |
 | SystemConfig                  | [0x73a79Fab69143498Ed3712e519A88a918e1f4072](https://etherscan.io/address/0x73a79Fab69143498Ed3712e519A88a918e1f4072) |
 | SystemDictator                | [0x1fE3fdd1F0193Dd657C0a9AAC37314D6B479E557](https://etherscan.io/address/0x1fE3fdd1F0193Dd657C0a9AAC37314D6B479E557) |
 | TEEProverRegistryProxy        | [0x1af2A7E537DE2eE795DE5B8BfbB1Ad0DD513A5aA](https://etherscan.io/address/0x1af2A7E537DE2eE795DE5B8BfbB1Ad0DD513A5aA) |
@@ -89,6 +94,7 @@ Certain contracts are mandatory according to the [OP Stack smart contracts overv
 | AddressManager                 | [0x709c2B8ef4A9feFc629A8a2C1AF424Dc5BD6ad1B](https://sepolia.etherscan.io/address/0x709c2B8ef4A9feFc629A8a2C1AF424Dc5BD6ad1B) |
 | AggregateVerifier (Multiproof) | [0xF3f0fA3124b7b0feB048A00404Fe4D5D49E60796](https://sepolia.etherscan.io/address/0xF3f0fA3124b7b0feB048A00404Fe4D5D49E60796) |
 | AnchorStateRegistryProxy       | [0x2fF5cC82dBf333Ea30D8ee462178ab1707315355](https://sepolia.etherscan.io/address/0x2fF5cC82dBf333Ea30D8ee462178ab1707315355) |
+| BalanceTracker                 | [0x8D1b5e5614300F5c7ADA01fFA4ccF8F1752D9A57](https://sepolia.etherscan.io/address/0x8D1b5e5614300F5c7ADA01fFA4ccF8F1752D9A57) |
 | DelayedWETHProxy (FDG)         | [0xd3683e4947A7769603Ab6418eC02f000CE3cF30b](https://sepolia.etherscan.io/address/0xd3683e4947A7769603Ab6418eC02f000CE3cF30b) |
 | DelayedWETHProxy (Multiproof)  | [0xD6e2d9D4f1f8865AC983eE848983fb1979429914](https://sepolia.etherscan.io/address/0xD6e2d9D4f1f8865AC983eE848983fb1979429914) |
 | DelayedWETHProxy (PDG)         | [0x32cE910d9C6c8F78dc6779c1499aB05F281A054e](https://sepolia.etherscan.io/address/0x32cE910d9C6c8F78dc6779c1499aB05F281A054e) |
@@ -105,6 +111,8 @@ Certain contracts are mandatory according to the [OP Stack smart contracts overv
 | PermissionedDisputeGame        | [0x58bf355C5d4EdFc723eF89d99582ECCfd143266A](https://sepolia.etherscan.io/address/0x58bf355C5d4EdFc723eF89d99582ECCfd143266A) |
 | PreimageOracle                 | [0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3](https://sepolia.etherscan.io/address/0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3) |
 | ProxyAdmin                     | [0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3](https://sepolia.etherscan.io/address/0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3) |
+| RiscZeroSetVerifier            | [0xcb9D14347b1e816831ECeE46EC199144F360B55c](https://sepolia.etherscan.io/address/0xcb9D14347b1e816831ECeE46EC199144F360B55c) |
+| RiscZeroVerifierRouter         | [0x925d8331ddc0a1F0d96E68CF073DFE1d92b69187](https://sepolia.etherscan.io/address/0x925d8331ddc0a1F0d96E68CF073DFE1d92b69187) |
 | SystemConfig                   | [0xf272670eb55e895584501d564AfEB048bEd26194](https://sepolia.etherscan.io/address/0xf272670eb55e895584501d564AfEB048bEd26194) |
 | TEEProverRegistryProxy         | [0xf0d7E15673fBA052e83d7f2b26BB6071E86b972e](https://sepolia.etherscan.io/address/0xf0d7E15673fBA052e83d7f2b26BB6071E86b972e) |
 | TEEVerifier                    | [0x92F6dD3501E51B8b20C77b959becaaebeB210e17](https://sepolia.etherscan.io/address/0x92F6dD3501E51B8b20C77b959becaaebeB210e17) |
@@ -116,22 +124,25 @@ Certain contracts are mandatory according to the [OP Stack smart contracts overv
 
 | Admin Role             | Address                                                                                                               | Type of Key                          |
 | :--------------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------- |
+| Base Security Council  | [0x20AcF55A3DCfe07fC4cecaCFa1628F788EC8A4Dd](https://etherscan.io/address/0x20AcF55A3DCfe07fC4cecaCFa1628F788EC8A4Dd) | Gnosis Safe                          |
 | Batch Sender           | [0x5050f69a9786f081509234f1a7f4684b5e5b76c9](https://etherscan.io/address/0x5050f69a9786f081509234f1a7f4684b5e5b76c9) | EOA managed by Coinbase Technologies |
 | Batch Inbox            | [0xff00000000000000000000000000000000008453](https://etherscan.io/address/0xff00000000000000000000000000000000008453) | EOA (with no known private key)      |
-| Output Proposer        | [0x642229f238fb9de03374be34b0ed8d9de80752c5](https://etherscan.io/address/0x642229f238fb9de03374be34b0ed8d9de80752c5) | EOA managed by Coinbase Technologies |
+| CB Multisig            | [0x9855054731540A48b28990B63DcF4f33d8AE46A1](https://etherscan.io/address/0x9855054731540A48b28990B63DcF4f33d8AE46A1) | Gnosis Safe                          |
+| Output Proposer        | [0xc1366Fabe614d42D367A1ecE61821238A1d31cF5](https://etherscan.io/address/0xc1366Fabe614d42D367A1ecE61821238A1d31cF5) | EOA managed by Coinbase Technologies |
 | Proxy Admin Owner (L1) | [0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c](https://etherscan.io/address/0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c) | Gnosis Safe                          |
-| Challenger             | [0x8Ca1E12404d16373Aef756179B185F27b2994F3a](https://etherscan.io/address/0x8Ca1E12404d16373Aef756179B185F27b2994F3a) | EOA managed by Coinbase Technologies |
-| SystemConfig owner     | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                          |
-| Guardian               | [0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2](https://etherscan.io/address/0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2) | Gnosis Safe                          |
+| Challenger             | [0x819501cdA743a606A93dbEF254FE0D263Ce7d102](https://etherscan.io/address/0x819501cdA743a606A93dbEF254FE0D263Ce7d102) | EOA managed by Coinbase Technologies |
+| Incident Multisig      | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                          |
+| Registrar              | [0xd87488Dbb5b6F47cc6c15Dd95Bb60c83D3031b04](https://etherscan.io/address/0xd87488Dbb5b6F47cc6c15Dd95Bb60c83D3031b04) | EOA managed by Coinbase Technologies |
 
 ### Base Testnet (Sepolia)
 
 | Admin Role             | Address                                                                                                                       | Type of Key                          |
 | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :----------------------------------- |
+| Base Security Council  | [0x6AF0674791925f767060Dd52f7fB20984E8639d8](https://sepolia.etherscan.io/address/0x6AF0674791925f767060Dd52f7fB20984E8639d8) | Gnosis Safe                          |
 | Batch Sender           | [0x6CDEbe940BC0F26850285cacA097C11c33103E47](https://sepolia.etherscan.io/address/0x6CDEbe940BC0F26850285cacA097C11c33103E47) | EOA managed by Coinbase Technologies |
 | Batch Inbox            | [0xff00000000000000000000000000000000084532](https://sepolia.etherscan.io/address/0xff00000000000000000000000000000000084532) | EOA (with no known private key)      |
+| CB Multisig            | [0x646132A1667ca7aD00d36616AFBA1A28116C770A](https://sepolia.etherscan.io/address/0x646132A1667ca7aD00d36616AFBA1A28116C770A) | Gnosis Safe                          |
 | Output Proposer        | [0xdb84125f2f4229c81c579f41bc129c71b174eb58](https://sepolia.etherscan.io/address/0xdb84125f2f4229c81c579f41bc129c71b174eb58) | EOA managed by Coinbase Technologies |
 | Proxy Admin Owner (L1) | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9) | Gnosis Safe                          |
 | Challenger             | [0xadc09b63a3ac57a2ce86d946617a18df9db029a1](https://sepolia.etherscan.io/address/0xadc09b63a3ac57a2ce86d946617a18df9db029a1) | EOA managed by Coinbase Technologies |
-| SystemConfig owner     | [0x5dfEB066334B67355A15dc9b67317fD2a2e1f77f](https://sepolia.etherscan.io/address/0x5dfEB066334B67355A15dc9b67317fD2a2e1f77f) | Gnosis Safe                          |
-| Guardian               | [0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E](https://sepolia.etherscan.io/address/0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E) | EOA managed by Coinbase Technologies |
+| Incident Multisig      | [0x646132A1667ca7aD00d36616AFBA1A28116C770A](https://sepolia.etherscan.io/address/0x646132A1667ca7aD00d36616AFBA1A28116C770A) | Gnosis Safe                          |

--- a/docs/base-chain/network-information/base-contracts.mdx
+++ b/docs/base-chain/network-information/base-contracts.mdx
@@ -50,7 +50,7 @@ description: A comprehensive list of contract addresses for Base Mainnet and Bas
 | EASSchemaRegistry             | [0x4200000000000000000000000000000000000020](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000020) |
 | LegacyERC20ETH                | [0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000](https://sepolia.basescan.org/address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000) |
 
-_Some L2 predeploy addresses are the same on both mainnet and testnet; network-specific addresses are listed separately above._
+_Most L2 predeploy addresses are the same on Base Mainnet and Base Sepolia. Network-specific L2 contracts, such as OptimismMintableERC20Factory and FeeDisburser, are listed with their respective addresses in each table above._
 
 ## L1 Contract Addresses
 
@@ -131,6 +131,8 @@ Certain contracts are mandatory according to the [OP Stack smart contracts overv
 | Output Proposer        | [0xc1366Fabe614d42D367A1ecE61821238A1d31cF5](https://etherscan.io/address/0xc1366Fabe614d42D367A1ecE61821238A1d31cF5) | EOA managed by Coinbase Technologies |
 | Proxy Admin Owner (L1) | [0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c](https://etherscan.io/address/0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c) | Gnosis Safe                          |
 | Challenger             | [0x819501cdA743a606A93dbEF254FE0D263Ce7d102](https://etherscan.io/address/0x819501cdA743a606A93dbEF254FE0D263Ce7d102) | EOA managed by Coinbase Technologies |
+| SystemConfig owner     | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                          |
+| Guardian               | [0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c](https://etherscan.io/address/0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c) | Gnosis Safe                          |
 | Incident Multisig      | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                          |
 | Registrar              | [0xd87488Dbb5b6F47cc6c15Dd95Bb60c83D3031b04](https://etherscan.io/address/0xd87488Dbb5b6F47cc6c15Dd95Bb60c83D3031b04) | EOA managed by Coinbase Technologies |
 
@@ -145,4 +147,6 @@ Certain contracts are mandatory according to the [OP Stack smart contracts overv
 | Output Proposer        | [0xdb84125f2f4229c81c579f41bc129c71b174eb58](https://sepolia.etherscan.io/address/0xdb84125f2f4229c81c579f41bc129c71b174eb58) | EOA managed by Coinbase Technologies |
 | Proxy Admin Owner (L1) | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9) | Gnosis Safe                          |
 | Challenger             | [0xadc09b63a3ac57a2ce86d946617a18df9db029a1](https://sepolia.etherscan.io/address/0xadc09b63a3ac57a2ce86d946617a18df9db029a1) | EOA managed by Coinbase Technologies |
+| SystemConfig owner     | [0x646132A1667ca7aD00d36616AFBA1A28116C770A](https://sepolia.etherscan.io/address/0x646132A1667ca7aD00d36616AFBA1A28116C770A) | Gnosis Safe                          |
+| Guardian               | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9) | Gnosis Safe                          |
 | Incident Multisig      | [0x646132A1667ca7aD00d36616AFBA1A28116C770A](https://sepolia.etherscan.io/address/0x646132A1667ca7aD00d36616AFBA1A28116C770A) | Gnosis Safe                          |


### PR DESCRIPTION
## Summary
- Adds RiscZero verifier entries from the mainnet and sepolia deployment .env files.
- Updates mainnet proposer and challenger admin addresses to the current deployment .env values.
- Adds current admin rows from the deployment .env files while keeping live on-chain role rows such as SystemConfig owner and Guardian.
- Updates the L2 address note to clarify that most predeploy addresses are shared, while network-specific L2 contracts have per-network rows.

## Validation
- Compared against base/contract-deployments mainnet/.env and sepolia/.env, excluding internal revenue sweeping contracts from the public docs.
- Ran a parser to confirm all remaining non-revenue .env exports appear in the docs.
- Verified live SystemConfig owner values with cast calls.
- Verified live Guardian values from OptimismPortal/SuperchainConfig with cast calls.