### PR TITLE
fix(docs): update native plugin reference links

### DIFF
--- a/docs/ai-agents/plugins/native/aerodrome.mdx
+++ b/docs/ai-agents/plugins/native/aerodrome.mdx
@@ -38,6 +38,6 @@ The public `https://mainnet.base.org` RPC enforces a 10-call-per-batch limit and
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/aerodrome.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/aerodrome.md">
   Setup, RPC compatibility patches, calldata-bridge code, swap/LP orchestration patterns, and what works vs. what doesn't on the public RPC.
 </Card>

--- a/docs/ai-agents/plugins/native/avantis.mdx
+++ b/docs/ai-agents/plugins/native/avantis.mdx
@@ -59,6 +59,6 @@ No additional MCP server is required. View-only Avantis APIs are reached through
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/avantis.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/avantis.md">
   Endpoint inventory, parameters, unit/scaling rules, batching guidance, chat-only UI fallback, and error handling.
 </Card>

--- a/docs/ai-agents/plugins/native/bankr.mdx
+++ b/docs/ai-agents/plugins/native/bankr.mdx
@@ -38,6 +38,6 @@ The Bankr feed is unfiltered. Listed tokens are not vetted, audited, or endorsed
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/bankr.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/bankr.md">
   API response shape, orchestration steps, symbol-collision and adversarial-metadata safety notes for new launches.
 </Card>

--- a/docs/ai-agents/plugins/native/moonwell.mdx
+++ b/docs/ai-agents/plugins/native/moonwell.mdx
@@ -34,6 +34,6 @@ The Moonwell API returns an ordered `transactions[]` array — `approve`, `enter
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/moonwell.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/moonwell.md">
   Endpoint inventory, response shapes, mToken notes, and health factor guide.
 </Card>

--- a/docs/ai-agents/plugins/native/morpho.mdx
+++ b/docs/ai-agents/plugins/native/morpho.mdx
@@ -47,6 +47,6 @@ In chat-only harnesses, use Morpho MCP tools for the same vault/market reads and
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/morpho.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/morpho.md">
   Environment detection, CLI and MCP paths, response shapes, safety checks, and orchestration details.
 </Card>

--- a/docs/ai-agents/plugins/native/uniswap.mdx
+++ b/docs/ai-agents/plugins/native/uniswap.mdx
@@ -34,6 +34,6 @@ Swap flow is three calls — `/check_approval`, `/quote`, `/swap` — batched in
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/uniswap.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/uniswap.md">
   Endpoint inventory, headers, response shapes, and orchestration for swap and LP flows.
 </Card>

--- a/docs/ai-agents/plugins/native/virtuals.mdx
+++ b/docs/ai-agents/plugins/native/virtuals.mdx
@@ -57,6 +57,6 @@ claude mcp add virtuals --transport http https://mcp.acp.virtuals.io/
 
 ## Reference
 
-<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/main/skills/base-mcp/plugins/virtuals.md">
+<Card title="Full plugin spec on GitHub" icon="github" href="https://github.com/base/skills/blob/master/skills/base-mcp/plugins/virtuals.md">
   Step-by-step SIWE auth flow, troubleshooting for the six common signature-verification failure modes, and orchestration recipes for agent / card / email operations.
 </Card>


### PR DESCRIPTION
## Summary

Updates the native AI agent plugin reference links to point to the current `master` branch in `base/skills`.

## Why

The native plugin docs currently link to files under:

`https://github.com/base/skills/blob/main/...`

But `base/skills` uses `master` as its default branch, so those GitHub reference cards resolve to broken links.

Fixes #1531.

## Verification

- Updated only files under `docs/ai-agents/plugins/native`
- Replaced the broken `blob/main` skill reference links with `blob/master`
- Verified the branch diff only touches the native plugin reference links