### PR TITLE
Update USDC yield prompt copy in agents quickstart demo

### DIFF
--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -236,7 +236,7 @@ import { TruncatedPrompt } from "/snippets/TruncatedPrompt.jsx"
     ```
 
     ```text
-    Find the best USDC vault on Base by APY and deposit 100 USDC
+    Find the highest paying USDC yield on Base by APY and deposit 100 USDC
     ```
 
     Every send, swap, or sign operation will give you an approval link. Open it, review the action in Base Account, and confirm.

--- a/docs/snippets/WalletSetupDemo.jsx
+++ b/docs/snippets/WalletSetupDemo.jsx
@@ -532,7 +532,7 @@ export const WalletSetupDemo = () => {
       ],
     },
     {
-      prompt: "Find the best USDC yield on Base and deposit 100",
+      prompt: "Find the highest paying USDC yield on Base and deposit 100",
       events: [
         { delay: 380, type: "thinking" },
         { delay: 600, type: "tool", tool: { server: "morpho", action: "query_vaults", args: { chain: "base", asset: "USDC", sort: "apy_desc" } } },


### PR DESCRIPTION
## Summary
- Changes "Find the best USDC yield" to "Find the highest paying USDC yield" in the `WalletSetupDemo.jsx` snippet used by the agents quickstart page

## Test plan
- [ ] Verify the updated prompt text renders correctly in the agents quickstart demo component