### PR TITLE
docs(agents): add Perplexity to MCP quickstart

### DIFF
--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Get Started with Base MCP"
 description: "Connect Base MCP to your agent in under 5 minutes"
-keywords: ["Base MCP quickstart", "mcp.base.org setup", "Claude Desktop MCP", "ChatGPT MCP", "Claude Code MCP wallet", "Cursor MCP", "Codex MCP", "Hermes MCP"]
+keywords: ["Base MCP quickstart", "mcp.base.org setup", "Claude Desktop MCP", "ChatGPT MCP", "Perplexity MCP", "Claude Code MCP wallet", "Cursor MCP", "Codex MCP", "Hermes MCP"]
 ---
 
 import { WalletSetupDemo } from "/snippets/WalletSetupDemo.jsx"
@@ -55,6 +55,17 @@ import { TruncatedPrompt } from "/snippets/TruncatedPrompt.jsx"
         4. Check **I understand and want to continue** on the risk warning
         5. Click **Create**
         6. You will be automatically redirected to Base Account. Click **Allow** once to authorize.
+      </Tab>
+      <Tab title="Perplexity">
+        <a href="https://www.perplexity.ai/computer/connectors" target="_blank" rel="noopener noreferrer">
+          <img src="https://img.shields.io/badge/Add%20to%20Perplexity-1F1F1F?style=for-the-badge" alt="Add to Perplexity" noZoom />
+        </a>
+
+        Click the button above, or open [**Connectors**](https://www.perplexity.ai/computer/connectors) manually. Then:
+
+        1. Search for `Base` to find the **Base by Coinbase** connector
+        2. Click to add it
+        3. Approve the connection in Base Account. Click **Allow** once to authorize.
       </Tab>
       <Tab title="Claude Code">
         Run this in your terminal to add the server to the current project:
@@ -188,6 +199,17 @@ import { TruncatedPrompt } from "/snippets/TruncatedPrompt.jsx"
         3. Enable the skill for the conversations where you want it active
 
         See [Skills in ChatGPT](https://help.openai.com/en/articles/20001066-skills-in-chatgpt) for details.
+      </Tab>
+      <Tab title="Perplexity">
+        <a href="https://github.com/base/skills/releases/download/base-mcp-v0.2.0/base-mcp.zip" target="_blank" rel="noopener noreferrer">
+          <img src="https://img.shields.io/badge/Download%20skill-1F1F1F?style=for-the-badge&logo=download&logoColor=white" alt="Download for Perplexity" noZoom />
+        </a>
+
+        Click the button above to download `base-mcp.zip`, then:
+
+        1. In Perplexity, open [**Skills**](https://www.perplexity.ai/computer/skills)
+        2. Click **Create skill** and upload the downloaded `base-mcp.zip`
+        3. Enable the skill for the conversations where you want it active
       </Tab>
       <Tab title="Claude Code">
         ```bash Terminal


### PR DESCRIPTION
## Summary
Adds **Perplexity** as an option (after ChatGPT) in the agents quickstart, in both the "Connect the MCP" and "Install the skill" steps.

- **Connect the MCP**: Open [Perplexity Connectors](https://www.perplexity.ai/computer/connectors) and search for `Base` to find the **Base by Coinbase** connector, then approve in Base Account.
- **Install the skill**: Download `base-mcp.zip`, go to [Perplexity Skills](https://www.perplexity.ai/computer/skills), click **Create skill**, and upload the zip.
- Added `Perplexity MCP` to the page keywords.

## Test plan
- [ ] Verify tabs render correctly in `mintlify dev`
- [ ] Confirm links resolve