### PR TITLE
docs: update B20 activation status to reflect mainnet delay

### DIFF
--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -8,7 +8,7 @@ B20 is the Base ecosystem's own version of [ERC-20](https://eips.ethereum.org/EI
 To deploy your first B20 token, see the [Launch a B20 Token](/get-started/launch-b20-token) quickstart.
 
 <Warning>
-B20 activation on mainnet is anticipated on **June 26, 2026 at 6pm UTC**. The Activation Registry can take up to ~1 hour to be fully enabled. [Verify the Activation Registry is enabled](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before attempting to deploy.
+B20 activation on mainnet has been delayed — a revised date will be announced shortly. The Activation Registry can take up to ~1 hour to be fully enabled. [Verify the Activation Registry is enabled](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before attempting to deploy.
 </Warning>
 
 B20 supports two variants:

--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -8,7 +8,7 @@ B20 is the Base ecosystem's own version of [ERC-20](https://eips.ethereum.org/EI
 To deploy your first B20 token, see the [Launch a B20 Token](/get-started/launch-b20-token) quickstart.
 
 <Warning>
-B20 activation on mainnet has been delayed — a revised date will be announced shortly. [Verify the Activation Registry is enabled](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before attempting to deploy.
+B20 mainnet activation has been delayed due to an unrelated stability incident. We're pushing back the Activation Registry enablement to ensure a smooth rollout — Sepolia and Vibenet remain on track. We'll share a revised date shortly. [Verify the Activation Registry is enabled](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before attempting to deploy.
 </Warning>
 
 B20 supports two variants:

--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -8,7 +8,7 @@ B20 is the Base ecosystem's own version of [ERC-20](https://eips.ethereum.org/EI
 To deploy your first B20 token, see the [Launch a B20 Token](/get-started/launch-b20-token) quickstart.
 
 <Warning>
-B20 activation on mainnet has been delayed — a revised date will be announced shortly. The Activation Registry can take up to ~1 hour to be fully enabled. [Verify the Activation Registry is enabled](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before attempting to deploy.
+B20 activation on mainnet has been delayed — a revised date will be announced shortly. [Verify the Activation Registry is enabled](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before attempting to deploy.
 </Warning>
 
 B20 supports two variants:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,8 +4,12 @@
   "name": "Base Documentation",
   "banner": {
     "content": "B20 mainnet activation has been delayed due to a stability incident. A revised date will be announced shortly. [Check activation status](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled)",
-    "type": "warning",
-    "dismissible": true
+    "type": "info",
+    "dismissible": true,
+    "color": {
+      "light": "#578BFA",
+      "dark": "#578BFA"
+    }
   },
   "colors": {
     "primary": "#0000ff",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,7 +3,7 @@
   "theme": "aspen",
   "name": "Base Documentation",
   "banner": {
-    "content": "B20 mainnet activation has been delayed due to a stability incident. A revised date will be announced shortly. [Check activation status](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled)",
+    "content": "B20 mainnet activation has been delayed due to an unrelated stability incident. A revised date will be announced shortly. [Check activation status](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled)",
     "type": "info",
     "dismissible": true,
     "color": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,6 +2,11 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "aspen",
   "name": "Base Documentation",
+  "banner": {
+    "content": "B20 mainnet activation has been delayed due to a stability incident. A revised date will be announced shortly. [Check activation status](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled)",
+    "type": "warning",
+    "dismissible": true
+  },
   "colors": {
     "primary": "#0000ff",
     "light": "#578BFA",

--- a/docs/get-started/launch-b20-token.mdx
+++ b/docs/get-started/launch-b20-token.mdx
@@ -25,7 +25,7 @@ You need **Base's Foundry build** (`base-forge`, `base-cast`, [`base-anvil`](htt
 ## Verify the Activation Registry is enabled
 
 <Warning>
-**The Activation Registry must be enabled before you can deploy.** B20 activation on mainnet is anticipated on **June 26, 2026 at 6pm UTC**. After Beryl activates, the Activation Registry can take up to ~1 hour to be fully enabled. Attempting to deploy before it's ready will revert with `FeatureNotActivated`. Run the check for the variant you plan to deploy and confirm it returns `true` before proceeding:
+**The Activation Registry must be enabled before you can deploy.** B20 activation on mainnet has been delayed — a revised date will be announced shortly. After activation, the Activation Registry can take up to ~1 hour to be fully enabled. Attempting to deploy before it's ready will revert with `FeatureNotActivated`. Run the check for the variant you plan to deploy and confirm it returns `true` before proceeding:
 </Warning>
 
 ```bash Terminal theme={null}

--- a/docs/get-started/launch-b20-token.mdx
+++ b/docs/get-started/launch-b20-token.mdx
@@ -25,7 +25,7 @@ You need **Base's Foundry build** (`base-forge`, `base-cast`, [`base-anvil`](htt
 ## Verify the Activation Registry is enabled
 
 <Warning>
-**The Activation Registry must be enabled before you can deploy.** B20 activation on mainnet has been delayed — a revised date will be announced shortly. Attempting to deploy before it's ready will revert with `FeatureNotActivated`. Run the check for the variant you plan to deploy and confirm it returns `true` before proceeding:
+**B20 mainnet activation has been delayed due to an unrelated stability incident.** We're pushing back the Activation Registry enablement to ensure a smooth rollout — Sepolia and Vibenet remain on track. We'll share a revised date shortly. Attempting to deploy before it's ready will revert with `FeatureNotActivated`. Run the check for the variant you plan to deploy and confirm it returns `true` before proceeding:
 </Warning>
 
 ```bash Terminal theme={null}

--- a/docs/get-started/launch-b20-token.mdx
+++ b/docs/get-started/launch-b20-token.mdx
@@ -25,7 +25,7 @@ You need **Base's Foundry build** (`base-forge`, `base-cast`, [`base-anvil`](htt
 ## Verify the Activation Registry is enabled
 
 <Warning>
-**The Activation Registry must be enabled before you can deploy.** B20 activation on mainnet has been delayed — a revised date will be announced shortly. After activation, the Activation Registry can take up to ~1 hour to be fully enabled. Attempting to deploy before it's ready will revert with `FeatureNotActivated`. Run the check for the variant you plan to deploy and confirm it returns `true` before proceeding:
+**The Activation Registry must be enabled before you can deploy.** B20 activation on mainnet has been delayed — a revised date will be announced shortly. Attempting to deploy before it's ready will revert with `FeatureNotActivated`. Run the check for the variant you plan to deploy and confirm it returns `true` before proceeding:
 </Warning>
 
 ```bash Terminal theme={null}


### PR DESCRIPTION
## Summary

- Adds a site-wide warning banner in `docs.json` noting that B20 mainnet activation has been delayed due to today's stability incident, with a link to the activation check steps
- Updates the activation callout in `launch-b20-token.mdx` and `b20.mdx` from the specific June 26 date to "delayed — revised date announced shortly"
- Replaces "After Beryl activates," with "After activation," to be network-agnostic

## Test plan

- [x] Verify warning banner appears site-wide with link to activation check section
- [x] Verify callouts on `/get-started/launch-b20-token` and `/base-chain/specs/upgrades/beryl/b20` reflect the delay messaging
- [x] Remove banner and revert callouts once activation is confirmed