### PR TITLE
fix(docs): add noopener to verify redirect example

### DIFF
--- a/docs/base-account/guides/verify-social-accounts.mdx
+++ b/docs/base-account/guides/verify-social-accounts.mdx
@@ -428,7 +428,7 @@ function redirectToVerifyMiniApp(provider: string) {
   const miniAppUrl = `${config.baseVerifyMiniAppUrl}?${params.toString()}`
 
   const deepLink = `cbwallet://miniapp?url=${encodeURIComponent(miniAppUrl)}`
-  window.open(deepLink, '_blank')
+window.open(deepLink, '_blank', 'noopener,noreferrer')
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds `noopener,noreferrer` to the `window.open(..., '_blank')` example in the Base Verify redirect flow.

## Why

The current example opens a new browsing context without explicitly preventing opener access. Adding `noopener,noreferrer` makes the copied example safer for production use.

Fixes #1470.

## Test plan

- Verified this PR only updates `docs/base-account/guides/verify-social-accounts.mdx`
- Confirmed the code example still opens the Base Verify deep link in a new tab/window