### PR TITLE
Add NodeFlare to node providers

### DIFF
--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -103,6 +103,14 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 - Base Mainnet
 - Base Sepolia (Testnet)
 
+## NodeFlare
+
+[NodeFlare](https://nodeflare.app/chains/base) provides free public Base Mainnet endpoints (no API key required) and a [free keyed tier](https://nodeflare.app/pricing) with higher rate limits, `eth_getLogs` and debug/trace support — served from NodeFlare's own multi-region bare-metal nodes (US, EU, UK, Asia) with automatic failover.
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+
 ## NodeReal
 
 [NodeReal](https://nodereal.io/) is a blockchain infrastructure and services provider that provides instant and easy-access to Base node APIs.


### PR DESCRIPTION
Adds NodeFlare to the node providers list (alphabetical placement, same format as existing entries).

NodeFlare serves Base Mainnet from its own multi-region bare-metal nodes (5 regions) with a free public endpoint (`https://rpc.nodeflare.app/base/public`, no API key) and a free keyed tier including `eth_getLogs` and debug/trace methods. Live and verifiable via `eth_chainId` → `0x2105`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)