### PR TITLE
docs: clarify public fallback RPC limitations

### DIFF
--- a/docs/apps/quickstart/build-app.mdx
+++ b/docs/apps/quickstart/build-app.mdx
@@ -154,9 +154,9 @@ Base is a fast, low-cost Ethereum L2 built to bring the next billion users oncha
     BASE_SEPOLIA_RPC_URL="https://sepolia.base.org"
     ```
 
-    <Note>
-    If `https://sepolia.base.org` is unreachable, use an alternative public endpoint such as `https://base-sepolia-rpc.publicnode.com`. For production apps, use a dedicated RPC provider.
-    </Note>
+    <Warning>
+    `https://sepolia.base.org` and fallback endpoints such as `https://base-sepolia-rpc.publicnode.com` are public RPC endpoints. Use them for local development, tutorials, and testnet experiments only. Public endpoints can be rate-limited or unavailable under load. For production apps, use a dedicated RPC provider or your own Base node.
+    </Warning>
 
     Load the variable and import your deployer key securely.
 


### PR DESCRIPTION
## Summary

Clarifies that the Base Sepolia public RPC and suggested PublicNode fallback RPC are intended for local development, tutorials, and testnet experiments, not production traffic.

Closes #1356.

## Why

The build app guide suggests a fallback public RPC endpoint when `https://sepolia.base.org` is unreachable. This update makes the same reliability limitation explicit for both public endpoints so builders do not treat the fallback as production infrastructure.

## Validation

- Docs-only change
- No navigation changes
- Existing internal links unchanged