### PR TITLE
docs: add Base app builder prompt

### DIFF
--- a/docs/get-started/prompt-library.mdx
+++ b/docs/get-started/prompt-library.mdx
@@ -7,3 +7,35 @@ description: Learn practical AI prompting techniques to enhance your coding work
 import AiPrompt from "/snippets/prompt-library.mdx";
 
 <AiPrompt/>
+
+## Base app builder prompt
+
+Use this prompt when you want an AI coding assistant to build a complete Base app instead of stopping at a demo.
+
+**Ready-to-Use Prompt for Building on Base:**
+
+<pre><code>{`Use the official Base docs, llms.txt, and this repository as your source of truth.
+
+I want to build this on Base:
+[describe idea]
+
+First inspect the repository. Then turn the idea into a complete Base Sepolia implementation plan and build it.
+
+Include:
+1. Frontend and backend requirements
+2. Smart contracts if needed
+3. Wallet integration with wagmi, viem, and Base Account where appropriate
+4. Server-side payment verification if the app accepts payments
+5. Builder Code attribution for transaction-sending flows
+6. Environment variables
+7. Tests, typechecks, and build commands
+8. Deployment steps, addresses, and explorer links
+
+Rules:
+- Default to Base Sepolia unless I explicitly ask for Base Mainnet.
+- Do not expose private keys or server secrets in frontend code.
+- Do not trust frontend-only payment success.
+- Verify wallet capabilities before batching, paymasters, sub-accounts, or spend permissions.
+- Run the relevant checks before finalizing.`}</code></pre>
+
+Before accepting the output, check that the assistant inspected the repository, used Base Sepolia for development, linked to the relevant Base docs, kept secrets out of client-side code, verified payments server-side, included tests or explained why they could not run, and returned deployment details with remaining risks.


### PR DESCRIPTION
## Summary

Adds a Base-specific app builder prompt to the prompt library.

The prompt helps builders guide AI coding assistants through a complete Base app workflow: repository inspection, Base Sepolia defaults, wallet integration, smart contracts when needed, server-side payment verification, Builder Code attribution, tests, and deployment notes.

## Why

The prompt library has general AI prompting guidance, but it does not yet include a Base-native prompt for building complete apps. This gives builders a reusable starting point that keeps common Base guardrails visible.

## Validation

- `node scripts/lint-mdx.js docs/get-started/prompt-library.mdx`
- `git diff --check`