### PR TITLE
docs: fix redirects to app quickstart

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1956,7 +1956,7 @@
     },
     {
       "source": "/mini-apps/overview",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/features/wallet",
@@ -2316,27 +2316,27 @@
     },
     {
       "source": "/cookbook/growth/cast-actions",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/deploy-to-vercel",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/email-campaigns",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/gating-and-redirects",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/hyperframes",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/retaining-users",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/payments/build-ecommerce-app",
@@ -2348,19 +2348,19 @@
     },
     {
       "source": "/cookbook/social/convert-farcaster-frame",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/social/farcaster-nft-minting-guide",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/social/farcaster-no-code-nft-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/cast-actions",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/commerce/build-an-ecommerce-app",
@@ -2368,35 +2368,35 @@
     },
     {
       "source": "/cookbook/use-case-guides/create-email-campaigns",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/creator/convert-farcaster-frame-to-open-frame",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/deploy-to-vercel",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/gating-and-redirects",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/hyperframes",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/nft-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/no-code-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/retaining-users",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/transactions",
@@ -2808,7 +2808,7 @@
     },
     {
       "source": "/use-cases/decentralize-social-app",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/use-cases/defi-your-app",
@@ -2856,11 +2856,11 @@
     },
     {
       "source": "/base-app/introduction/what-are-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/introduction/why-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/overview",
@@ -2880,11 +2880,11 @@
     },
     {
       "source": "/base-app/miniapps/quickstart",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/build-with-minikit/quickstart",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/existing-apps/:slug*",
@@ -2896,15 +2896,15 @@
     },
     {
       "source": "/mini-apps/quickstart/new-apps/:slug*",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/build-with-minikit/mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/search-and-discovery",
@@ -2964,15 +2964,15 @@
     },
     {
       "source": "/mini-apps/quickstart/new-apps/install",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/new-apps/deploy",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/new-apps/create-manifest",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/design-ux/:slug*",
@@ -3068,7 +3068,7 @@
     },
     {
       "source": "/cookbook/onchain-social",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/defi-your-app",
@@ -3096,11 +3096,11 @@
     },
     {
       "source": "/cookbook/introduction-to-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/ai-powered-development-fundamentals",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/mastering-ai-prompt-engineering",
@@ -3108,7 +3108,7 @@
     },
     {
       "source": "/cookbook/essential-documentation-resources",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/ai-assisted-documentation-reading",
@@ -3120,7 +3120,7 @@
     },
     {
       "source": "/cookbook/minikit/build-your-mini-app-with-prompt",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/converting-customizing-mini-apps",
@@ -3220,7 +3220,7 @@
     },
     {
       "source": "/mini-apps/quickstart/create-new-miniapp",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/growth/build-viral-mini-apps",


### PR DESCRIPTION
## Summary

Updates redirects that pointed to the missing `/apps/quickstart/create-new-app` route so they now point to the existing app quickstart page at `/apps/quickstart/build-app`.

Closes #1423.

## Why

`/apps/quickstart/create-new-app` is not present in the current docs tree, while `/apps/quickstart/build-app` exists and is already listed under Apps > Quickstart.

## Validation

- `jq empty docs/docs.json`
- `git diff --check`
- Confirmed `docs/apps/quickstart/build-app.mdx` exists
- Confirmed no redirects to `/apps/quickstart/create-new-app` remain