### PR TITLE
docs: add required --broadcast flag to forge create in deploy quickstart

### DIFF
--- a/docs/get-started/deploy-smart-contracts.mdx
+++ b/docs/get-started/deploy-smart-contracts.mdx
@@ -101,23 +101,35 @@ Never share or commit your private key. Always keep it secure and handle with ca
 
 Now that your environment is set up, let's deploy your contracts to Base Sepolia.
 
-1. Use the following command to compile and deploy your contract
+1. (Optional) Perform a dry run to simulate the deployment and verify your configuration:
 
 ```bash
 forge create ./src/Counter.sol:Counter --rpc-url $BASE_SEPOLIA_RPC_URL --account deployer
 ```
 
+This simulates the deployment without broadcasting the transaction to the network.
+
+2. Deploy your contract by adding the `--broadcast` flag:
+
+```bash
+forge create ./src/Counter.sol:Counter --rpc-url $BASE_SEPOLIA_RPC_URL --account deployer --broadcast
+```
+
+<Tip>
+The `--broadcast` flag is **required** to actually deploy your contract to the network. Without it, Foundry only performs a dry run simulation.
+</Tip>
+
 Note the format of the contract being deployed is `<contract-path>:<contract-name>`.
 
-2. After successful deployment, the transaction hash will be printed to the console output
+3. After successful deployment, the transaction hash and deployed contract address will be printed to the console output
 
-3. Copy the deployed contract address and add it to your `.env` file
+4. Copy the deployed contract address and add it to your `.env` file
 
 ```bash
 COUNTER_CONTRACT_ADDRESS="0x..."
 ```
 
-4. Load the new environment variable
+5. Load the new environment variable
 
 ```bash
 source .env


### PR DESCRIPTION
## Summary

The **Deploy Smart Contracts** quickstart (`docs/get-started/deploy-smart-contracts.mdx`) runs `forge create` **without** the `--broadcast` flag:

```bash
forge create ./src/Counter.sol:Counter --rpc-url $BASE_SEPOLIA_RPC_URL --account deployer
```

Since Foundry v1.0, `forge create` performs a **dry run by default** and does not broadcast the deployment transaction unless `--broadcast` is passed. Following the guide as written therefore does **not** deploy the contract — yet the next step states "the transaction hash will be printed to the console output", so a reader believes they deployed when they did not.

## Fix

Align this page with the already-corrected sibling guide `docs/apps/quickstart/deploy-on-base.mdx`, which already documents this exact pattern:

- Keep the flagless command as an **optional dry run** step.
- Add the real deploy step with `--broadcast`.
- Add a `<Tip>` noting the flag is required.
- Renumber the following steps (add address to `.env`, `source .env`).

No other content changed.

## Reference

Foundry [`forge create` reference](https://www.getfoundry.sh/reference/forge/create): "If you do not pass the `--broadcast` flag your transaction is a dry-run."

## Test plan

- [ ] `mint dev` renders the updated **Deploy Your Contracts** section with the dry-run + broadcast steps and the tip.
- [ ] Commands are consistent with `docs/apps/quickstart/deploy-on-base.mdx`.