### PR TITLE
docs: fix broken internal links (404s)

### DIFF
--- a/docs/agents/index.mdx
+++ b/docs/agents/index.mdx
@@ -6,7 +6,7 @@ keywords: ["Base MCP", "AI agent wallet", "mcp.base.org", "AI assistant wallet",
 
 import { WalletSetupDemo } from "/snippets/WalletSetupDemo.jsx"
 
-Base MCP gives your AI assistant direct access to your [Base Account](/base-account) (the smart wallet powering the Base App). Connect once and your assistant can check balances, send funds, swap tokens, sign messages, execute contract calls, and pay x402-enabled APIs across multiple networks. Every write action requires your approval.
+Base MCP gives your AI assistant direct access to your [Base Account](/base-account/overview/what-is-base-account) (the smart wallet powering the Base App). Connect once and your assistant can check balances, send funds, swap tokens, sign messages, execute contract calls, and pay x402-enabled APIs across multiple networks. Every write action requires your approval.
 
 <Visibility for="agents">
   If you're looking for the canonical machine-readable docs index, fetch the uppercase `AGENTS.md` at https://docs.base.org/AGENTS.md — note the uppercase filename (`AGENTS.md`, not `agents.md`). It's a compact, directory-grouped index of the entire Base documentation, built for agents to navigate before generating code.

--- a/docs/agents/skills/SKILL.md
+++ b/docs/agents/skills/SKILL.md
@@ -14,9 +14,9 @@ version: 0.1.0
 
 ## Detection
 
-The Base MCP exposes its tools to the harness when connected. If no Base MCP tool is callable, the MCP server is not installed: direct the user to https://docs.base.org/ai-agents/quickstart (or load [references/install.md](references/install.md) for app-specific steps) and stop.
+The Base MCP exposes its tools to the harness when connected. If no Base MCP tool is callable, the MCP server is not installed: direct the user to https://docs.base.org/agents/quickstart (or load [references/install.md](references/install.md) for app-specific steps) and stop.
 
-If Base MCP tools are available, load [references/tone.md](references/tone.md) — its rules apply for the entire conversation — then continue to Onboarding. If — and only if — sibling files aren't readable (e.g. you were handed just this `SKILL.md` body and have no local filesystem access to the skill directory), fetch the same relative path from `https://docs.base.org/ai-agents/skills/references/tone.md` using the `web_request` tool from Base MCP. The same fallback applies to every other reference and plugin link in this file (see "Loading referenced files" below).
+If Base MCP tools are available, load [references/tone.md](references/tone.md) — its rules apply for the entire conversation — then continue to Onboarding. If — and only if — sibling files aren't readable (e.g. you were handed just this `SKILL.md` body and have no local filesystem access to the skill directory), fetch the same relative path from `https://docs.base.org/agents/skills/references/tone.md` using the `web_request` tool from Base MCP. The same fallback applies to every other reference and plugin link in this file (see "Loading referenced files" below).
 
 ## Onboarding
 
@@ -47,7 +47,7 @@ Two patterns deserve their own references because they span multiple tools:
 ### Loading referenced files
 
 - **Default — local.** Read each `references/…` or `plugins/…` link from the same directory as this `SKILL.md` (filesystem read, e.g. `Read`/`cat`). This is the canonical source — always try this first.
-- **Fallback — web (only when local read fails).** If — and only if — the local file is genuinely unreadable (e.g. you were handed `SKILL.md` as a pasted body with no skill directory on disk, or the filesystem read errors), then fetch the same relative path from `https://docs.base.org/ai-agents/skills/<path>` (replace `<path>` with the relative link, e.g. `references/tone.md`, `plugins/morpho.md`). Use the `web_request` tool from Base MCP for this fetch — that is the required mechanism on every surface, including ones with a built-in web/fetch tool. Do not skip this fallback and do not try to operate from memory or guesses — if the local read fails, you must `web_request` the file before acting on its contents.
+- **Fallback — web (only when local read fails).** If — and only if — the local file is genuinely unreadable (e.g. you were handed `SKILL.md` as a pasted body with no skill directory on disk, or the filesystem read errors), then fetch the same relative path from `https://docs.base.org/agents/skills/<path>` (replace `<path>` with the relative link, e.g. `references/tone.md`, `plugins/morpho.md`). Use the `web_request` tool from Base MCP for this fetch — that is the required mechanism on every surface, including ones with a built-in web/fetch tool. Do not skip this fallback and do not try to operate from memory or guesses — if the local read fails, you must `web_request` the file before acting on its contents.
 - **Lazy.** Only load a reference or plugin when the conversation actually needs it. Don't preload the catalog.
 
 ## Plugins

--- a/docs/agents/skills/references/install.md
+++ b/docs/agents/skills/references/install.md
@@ -5,7 +5,7 @@ description: "Skill reference for installing the Base MCP server in Claude, Chat
 
 # Installing Base MCP
 
-> Canonical source: **[https://docs.base.org/ai-agents/quickstart](https://docs.base.org/ai-agents/quickstart)**. That page is kept up to date with the latest one-click install links, deep-links, and connector flows for each surface. Send the user there first; the instructions below are a backup so the agent can still walk a user through install without leaving the chat.
+> Canonical source: **[https://docs.base.org/agents/quickstart](https://docs.base.org/agents/quickstart)**. That page is kept up to date with the latest one-click install links, deep-links, and connector flows for each surface. Send the user there first; the instructions below are a backup so the agent can still walk a user through install without leaving the chat.
 
 The MCP server URL is the same everywhere: **`https://mcp.base.org`**
 
@@ -117,7 +117,7 @@ Restart Cursor, then **Settings → MCP** to confirm `base-mcp` is active.
 Hand the agent the quickstart and let it install itself:
 
 ```
-Install the Base MCP server from https://docs.base.org/ai-agents/quickstart
+Install the Base MCP server from https://docs.base.org/agents/quickstart
 ```
 
 Manual install — edit `~/.hermes/config.yaml`:
@@ -156,4 +156,4 @@ If it replies with a wallet address, the MCP is connected. If it says it doesn't
 | "Integration not found" / "Tool not available" | Restart the app — the server may not have finished loading. |
 | Integrations / Connectors tab missing | App version is too old — update to the latest. |
 | `web_request` rejects a hostname | The hostname isn't in the allowlist. For native HTTP plugins, use the harness HTTP tool if one is available; for custom plugins see [custom-plugins.md](custom-plugins.md). CLI-only plugins do not use `web_request`. |
-| Anything else | Send the user to [https://docs.base.org/ai-agents/quickstart](https://docs.base.org/ai-agents/quickstart). |
+| Anything else | Send the user to [https://docs.base.org/agents/quickstart](https://docs.base.org/agents/quickstart). |

--- a/docs/base-account/framework-integrations/rainbowkit.mdx
+++ b/docs/base-account/framework-integrations/rainbowkit.mdx
@@ -393,7 +393,7 @@ function NetworkSwitcher() {
 Now that you have RainbowKit configured with Base Account, you can:
 
 <CardGroup cols={2}>
-  <Card title="Explore Base Account Features" icon="code" href="https://docs.base.org/base-account">
+  <Card title="Explore Base Account Features" icon="code" href="https://docs.base.org/base-account/overview/what-is-base-account">
     Learn more about Base Account and its features
   </Card>
   <Card title="Explore RainbowKit Docs" icon="code" href="https://www.rainbowkit.com/docs/introduction">

--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 

--- a/docs/base-chain/specs/reference/configurability.mdx
+++ b/docs/base-chain/specs/reference/configurability.mdx
@@ -47,7 +47,7 @@ There are four categories of Base configuration:
 | L1 Proxy Admin | `ProxyAdmin` from the latest `op-contracts` release, authorized to upgrade L1 contracts | L1 contracts |
 | L1 ProxyAdmin Owner | Authorized to update the L1 Proxy Admin. [0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A](https://etherscan.io/address/0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A) | [L1 Proxy Admin](#admin-roles) |
 | L2 Proxy Admin | `ProxyAdmin` at `0x4200000000000000000000000000000000000018`, authorized to upgrade L2 contracts | [Predeploys](../protocol/execution/evm/predeploys#overview) |
-| L2 ProxyAdmin Owner | [Aliased](./glossary.mdx#address-aliasing) L1 ProxyAdmin Owner; upgrades L2 contracts via `ProxyAdmin`. [0x6B1BAE59D09fCcbdDB6C6cceb07B7279367C4E3b](https://optimistic.etherscan.io/address/0x6B1BAE59D09fCcbdDB6C6cceb07B7279367C4E3b) | [L2 Proxy Admin](#admin-roles) |
+| L2 ProxyAdmin Owner | [Aliased](./glossary#address-aliasing) L1 ProxyAdmin Owner; upgrades L2 contracts via `ProxyAdmin`. [0x6B1BAE59D09fCcbdDB6C6cceb07B7279367C4E3b](https://optimistic.etherscan.io/address/0x6B1BAE59D09fCcbdDB6C6cceb07B7279367C4E3b) | [L2 Proxy Admin](#admin-roles) |
 | [System Config Owner](../protocol/consensus/derivation#system-configuration) | Authorized to change values in the `SystemConfig` contract | [Batch Submitter](#service-roles), [Sequencer P2P Signer](#service-roles), Fee Scalar, Gas Limit |
 
 ## Service Roles


### PR DESCRIPTION
Fix five verified internal link issues that resolve to 404 in the rendered Mintlify site. Each was verified against the repository filesystem (target files/paths and `docs.json` redirects).

- **`/base-account`** had no index page; point to `/base-account/overview/what-is-base-account` — `agents/index.mdx`, `base-account/framework-integrations/rainbowkit.mdx`
- **`/ai-agents/*`** paths don't exist (the directory is `/agents`, and there's no redirect); correct 6 links in the Base MCP skill files — `agents/skills/SKILL.md`, `agents/skills/references/install.md`
- Drop stray **`.mdx`** extension from the `signInWithEthereum` link — `base-account/reference/core/provider-rpc-methods/wallet_connect.mdx` (other references to the same page already omit it)
- Drop stray **`.mdx`** extension from the glossary anchor link, matching the other glossary links in the same file — `base-chain/specs/reference/configurability.mdx`

6 files changed, 10 insertions(+), 10 deletions(-).