### PR TITLE
fix: remove mdBook-style .html extensions from specs overview diagram links

### DIFF
--- a/docs/base-chain/specs/protocol/overview.mdx
+++ b/docs/base-chain/specs/protocol/overview.mdx
@@ -89,9 +89,9 @@ The following diagram shows how the major protocol components interact across L1
 ```mermaid
 graph LR
     subgraph "Ethereum L1"
-        OptimismPortal(<a href="./bridging/withdrawals.html#the-optimism-portal-contract">OptimismPortal</a>)
-        BatchInbox(<a href="../reference/glossary.html#batcher-transaction">Batch Inbox Address</a>)
-        DisputeGameFactory(<a href="./proofs/contracts.html#disputegamefactory">DisputeGameFactory</a>)
+        OptimismPortal(<a href="./bridging/withdrawals#the-optimism-portal-contract">OptimismPortal</a>)
+        BatchInbox(<a href="../reference/glossary#batcher-transaction">Batch Inbox Address</a>)
+        DisputeGameFactory(<a href="./proofs/contracts#disputegamefactory">DisputeGameFactory</a>)
     end
 
     subgraph "L2 Node"
@@ -99,7 +99,7 @@ graph LR
         ExecutionEngine(<a href="./execution/">Execution Engine</a>)
     end
 
-    Batcher(<a href="./batcher.html">Batcher</a>)
+    Batcher(<a href="./batcher">Batcher</a>)
     Proposers(Proposers)
     Challengers(Challengers)
     Users(Users)
@@ -220,8 +220,8 @@ any validator to independently reconstruct the L2 chain from L1.
 ```mermaid
 graph LR
     Sequencer(Sequencer)
-    Batcher(<a href="./batcher.html">Batcher</a>)
-    BatchInbox(<a href="../reference/glossary.html#batcher-transaction">Batch Inbox Address</a>)
+    Batcher(<a href="./batcher">Batcher</a>)
+    BatchInbox(<a href="../reference/glossary#batcher-transaction">Batch Inbox Address</a>)
     RollupNode(<a href="./consensus/">Rollup Node</a>)
 
     Sequencer -->|L2 blocks| Batcher
@@ -248,10 +248,10 @@ challengers can dispute invalid claims. Valid withdrawals can only be finalized 
 ```mermaid
 graph LR
     Proposer(Proposer)
-    DGF(<a href="./proofs/contracts.html#disputegamefactory">DisputeGameFactory</a>)
-    Game(<a href="./proofs/contracts.html#aggregateverifier">AggregateVerifier game</a>)
+    DGF(<a href="./proofs/contracts#disputegamefactory">DisputeGameFactory</a>)
+    Game(<a href="./proofs/contracts#aggregateverifier">AggregateVerifier game</a>)
     Challengers(Challengers)
-    OP(<a href="./bridging/withdrawals.html#the-optimism-portal-contract">OptimismPortal</a>)
+    OP(<a href="./bridging/withdrawals#the-optimism-portal-contract">OptimismPortal</a>)
 
     Proposer -->|submit checkpoint proof| DGF
     DGF -->|create game| Game
@@ -275,8 +275,8 @@ The following diagram demonstrates this interaction and key Base protocol compon
 ```mermaid
 graph TD
     subgraph "Ethereum L1"
-        OptimismPortal(<a href="./bridging/withdrawals.html#the-optimism-portal-contract">OptimismPortal</a>)
-        BatchInbox(<a href="../reference/glossary.html#batcher-transaction">Batch Inbox Address</a>)
+        OptimismPortal(<a href="./bridging/withdrawals#the-optimism-portal-contract">OptimismPortal</a>)
+        BatchInbox(<a href="../reference/glossary#batcher-transaction">Batch Inbox Address</a>)
     end
 
     Sequencer(Sequencer)
@@ -313,10 +313,10 @@ proof game contract that proposes the state of the L2 at a given point in time.
 ```mermaid
 graph LR
     subgraph "Ethereum L1"
-        BatchInbox(<a href="../reference/glossary.html#batcher-transaction">Batch Inbox Address</a>)
-        DisputeGameFactory(<a href="./proofs/contracts.html#disputegamefactory">DisputeGameFactory</a>)
-        ProofGame(<a href="./proofs/contracts.html#aggregateverifier">AggregateVerifier game</a>)
-        OptimismPortal(<a href="./bridging/withdrawals.html#the-optimism-portal-contract">OptimismPortal</a>)
+        BatchInbox(<a href="../reference/glossary#batcher-transaction">Batch Inbox Address</a>)
+        DisputeGameFactory(<a href="./proofs/contracts#disputegamefactory">DisputeGameFactory</a>)
+        ProofGame(<a href="./proofs/contracts#aggregateverifier">AggregateVerifier game</a>)
+        OptimismPortal(<a href="./bridging/withdrawals#the-optimism-portal-contract">OptimismPortal</a>)
         ExternalContracts(External Contracts)
     end
 


### PR DESCRIPTION
**What changed? Why?**

The Mermaid architecture diagrams on the [protocol specs overview page](https://docs.base.org/base-chain/specs/protocol/overview) contain 15 links that still use mdBook-style `.html` paths, left over from the specs migration (#1335). These paths don't resolve on the docs site, so every one of these links currently returns a 404:

| Link in diagrams | Status |
|---|---|
| `./batcher.html` | 404 |
| `./bridging/withdrawals.html#the-optimism-portal-contract` | 404 |
| `../reference/glossary.html#batcher-transaction` | 404 |
| `./proofs/contracts.html#disputegamefactory` | 404 |
| `./proofs/contracts.html#aggregateverifier` | 404 |

This PR drops the `.html` extension from each href so they match the working links already used in the same diagrams (e.g. `./consensus/`, `./execution/`).

**Notes to reviewers**

- Only `href` values inside the Mermaid diagrams changed; no diagram structure or prose was touched.
- All five destination pages exist, and the anchor headings (`The Optimism Portal Contract`, `Batcher Transaction`, `DisputeGameFactory`, `AggregateVerifier`) are present in the target pages.

**How has it been tested?**

- Confirmed each old `.html` URL returns 404 on docs.base.org and each corrected URL returns 200.
- Searched the repo for any other internal `.html` links; this file was the only one remaining.