### PR TITLE
fix: correct branch in thirdweb template links (main -> master)

### DIFF
--- a/docs/base-account/framework-integrations/thirdweb.mdx
+++ b/docs/base-account/framework-integrations/thirdweb.mdx
@@ -22,11 +22,11 @@ By the end of this guide, you will:
 - Have Base Account available as a wallet option alongside email authentication
 - Use Thirdweb's `ConnectButton` for a polished wallet connection experience
 
-You can jump ahead and use the [Base Account Thirdweb Template](https://github.com/base/demos/tree/main/base-account/base-account-thirdweb-template) to get started.
+You can jump ahead and use the [Base Account Thirdweb Template](https://github.com/base/demos/tree/master/base-account/base-account-thirdweb-template) to get started.
 
 <GithubRepoCard
   title="Base Account Thirdweb Template"
-  githubUrl="https://github.com/base/demos/tree/main/base-account/base-account-thirdweb-template"
+  githubUrl="https://github.com/base/demos/tree/master/base-account/base-account-thirdweb-template"
 />
 
 ## Installation


### PR DESCRIPTION
**What changed? Why?**

The Thirdweb integration guide links to the `base-account-thirdweb-template` in the `base/demos` repo using a `/tree/main/` URL, but that repo's default branch is `master`, so both links 404:

- `https://github.com/base/demos/tree/main/base-account/base-account-thirdweb-template` → **404**
- `https://github.com/base/demos/tree/master/base-account/base-account-thirdweb-template` → **200**

This updates both occurrences in `docs/base-account/framework-integrations/thirdweb.mdx` (the inline link and the `GithubRepoCard`) from `main` to `master`.

**Notes to reviewers**

- The other 9 `base/demos/tree/...` links across the docs already correctly use `master`; these two were the only ones on `main`.
- Confirmed `base/demos` default branch is `master` and the template directory exists at that path.

**How has it been tested?**

- Verified the `/tree/main/` URL returns 404 and the `/tree/master/` URL returns 200.
- Swept the whole docs tree for `base/demos/(blob|tree|raw)/main`; these two links were the only matches.