### PR TITLE
fix: remove .mdx extension from signInWithEthereum capability link

### DIFF
--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 


### PR DESCRIPTION
The link to the `signInWithEthereum` capability page in `wallet_connect.mdx` includes the `.mdx` file extension, so it points to `/base-account/reference/core/capabilities/signInWithEthereum.mdx` and 404s on the live docs site. Mintlify routes are extensionless. This removes the extension so the link resolves to the existing page at `/base-account/reference/core/capabilities/signInWithEthereum`.

You can verify: https://docs.base.org/base-account/reference/core/capabilities/signInWithEthereum loads, while the same URL with .mdx appended does not.