### PR TITLE
fix: remove stale get-started/build-app entry from navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,7 +47,6 @@
             "group": "Quickstart",
             "pages": [
               "get-started/resources-for-ai-agents",
-              "get-started/build-app",
               "get-started/launch-b20-token",
               "get-started/launch-token",
               "get-started/deploy-smart-contracts",


### PR DESCRIPTION
docs/get-started/build-app.mdx was removed in #1363, which moved the page to apps/quickstart/build-app and added redirects for the old URL — but the old path was left behind in the Get Started > Quickstart navigation group in docs.json, so the nav references a page that no longer exists.

This removes the dangling nav entry. The page remains reachable in the Apps tab (apps/quickstart/build-app is still in the navigation) and old links keep working via the existing redirects, which are untouched.