### PR TITLE
Point /base-account link to canonical landing page in agents overview

### DIFF
--- a/docs/agents/index.mdx
+++ b/docs/agents/index.mdx
@@ -6,7 +6,7 @@ keywords: ["Base MCP", "AI agent wallet", "mcp.base.org", "AI assistant wallet",
 
 import { WalletSetupDemo } from "/snippets/WalletSetupDemo.jsx"
 
-Base MCP gives your AI assistant direct access to your [Base Account](/base-account) (the smart wallet powering the Base App). Connect once and your assistant can check balances, send funds, swap tokens, sign messages, execute contract calls, and pay x402-enabled APIs across multiple networks. Every write action requires your approval.
+Base MCP gives your AI assistant direct access to your [Base Account](/base-account/overview/what-is-base-account) (the smart wallet powering the Base App). Connect once and your assistant can check balances, send funds, swap tokens, sign messages, execute contract calls, and pay x402-enabled APIs across multiple networks. Every write action requires your approval.
 
 <Visibility for="agents">
   If you're looking for the canonical machine-readable docs index, fetch the uppercase `AGENTS.md` at https://docs.base.org/AGENTS.md — note the uppercase filename (`AGENTS.md`, not `agents.md`). It's a compact, directory-grouped index of the entire Base documentation, built for agents to navigate before generating code.


### PR DESCRIPTION
Updates the Base Account link in docs/agents/index.mdx to point directly to the canonical landing page (/base-account/overview/what-is-base-account) instead of /base-account, which has no page or explicit redirect in docs.json and only resolves via Mintlify's implicit redirect behavior.