### PR TITLE
chore: update supported chains (add Abstract, Hyperliquid, Ink, Mantle)

### DIFF
--- a/docs/snippets/supported-chains.mdx
+++ b/docs/snippets/supported-chains.mdx
@@ -8,7 +8,7 @@
 - **Testnet:** Base Sepolia • Sepolia
 
 {/* DYNAMIC_CHAINS_START */}
-**Basic support:** Monad • Unichain • ZKsync
+**Basic support:** Abstract • Hyperliquid • Ink • Mantle • Monad • Unichain • ZKsync
 
 Basic support only includes transfers through the [Base Account Web](https://account.base.app) surface for select tokens.
 {/* DYNAMIC_CHAINS_END */}


### PR DESCRIPTION
Run `scripts/update-supported-chains.sh` to pull latest basic chains from prod API.

Added: Abstract, Hyperliquid, Ink, Mantle
Existing: Monad, Unichain, ZKsync