### PR TITLE
remove b20 activation delay dates, banner

### DIFF
--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -8,7 +8,7 @@ B20 is the Base ecosystem's own version of [ERC-20](https://eips.ethereum.org/EI
 To deploy your first B20 token, see the [Launch a B20 Token](/get-started/launch-b20-token) quickstart.
 
 <Warning>
-B20 mainnet Activation Registry is scheduled for **July 8, 2026 at 18:00 UTC**. [Verify the Activation Registry is enabled](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before attempting to deploy.
+[Verify the Activation Registry is enabled](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before attempting to deploy.
 </Warning>
 
 B20 supports two variants:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,15 +2,6 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "aspen",
   "name": "Base Documentation",
-  "banner": {
-    "content": "B20 mainnet Activation Registry is scheduled for July 8, 2026 at 18:00 UTC. [Check activation status](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled)",
-    "type": "info",
-    "dismissible": true,
-    "color": {
-      "light": "#578BFA",
-      "dark": "#578BFA"
-    }
-  },
   "colors": {
     "primary": "#0000ff",
     "light": "#578BFA",

--- a/docs/get-started/launch-b20-token.mdx
+++ b/docs/get-started/launch-b20-token.mdx
@@ -25,7 +25,7 @@ You need **Base's Foundry build** (`base-forge`, `base-cast`, [`base-anvil`](htt
 ## Verify the Activation Registry is enabled
 
 <Warning>
-**B20 mainnet Activation Registry is scheduled for July 8, 2026 at 18:00 UTC.** Attempting to deploy before it's ready will revert with `FeatureNotActivated`. Run the check for the variant you plan to deploy and confirm it returns `true` before proceeding:
+Attempting to deploy before the Activation Registry is enabled will revert with `FeatureNotActivated`. Run the check for the variant you plan to deploy and confirm it returns `true` before proceeding:
 </Warning>
 
 ```bash Terminal theme={null}


### PR DESCRIPTION
**What changed? Why?**
Removes the b20 activation delay dates, banner

**Notes to reviewers**

**How has it been tested?**
Locally