### PR TITLE
docs: update B20 activation warning to note — registry is now enabled on mainnet

### DIFF
--- a/docs/base-chain/specs/upgrades/beryl/b20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20.mdx
@@ -7,9 +7,9 @@ B20 is the Base ecosystem's own version of [ERC-20](https://eips.ethereum.org/EI
 
 To deploy your first B20 token, see the [Launch a B20 Token](/get-started/launch-b20-token) quickstart.
 
-<Warning>
-[Verify the Activation Registry is enabled](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before attempting to deploy.
-</Warning>
+<Note>
+The B20 Activation Registry is enabled on mainnet. [Verify activation status](/get-started/launch-b20-token#verify-the-activation-registry-is-enabled) before deploying to other networks.
+</Note>
 
 B20 supports two variants:
 

--- a/docs/get-started/launch-b20-token.mdx
+++ b/docs/get-started/launch-b20-token.mdx
@@ -24,9 +24,9 @@ You need **Base's Foundry build** (`base-forge`, `base-cast`, [`base-anvil`](htt
 
 ## Verify the Activation Registry is enabled
 
-<Warning>
-Attempting to deploy before the Activation Registry is enabled will revert with `FeatureNotActivated`. Run the check for the variant you plan to deploy and confirm it returns `true` before proceeding:
-</Warning>
+<Note>
+The B20 Activation Registry is enabled on mainnet. Run the check below to confirm the variant you plan to deploy returns `true` before proceeding:
+</Note>
 
 ```bash Terminal theme={null}
 REG=0x8453000000000000000000000000000000000001  # Activation Registry precompile


### PR DESCRIPTION
Verified on-chain that both base.b20_asset and base.b20_stablecoin return true from the Activation Registry precompile on mainnet. The Warning blocks said deploying before activation would revert with FeatureNotActivated, which is no longer the case. Updated both to Notes confirming the registry is enabled on mainnet while still pointing to the verify step for other networks.