### PR TITLE
docs: fix broken links returning 404

### DIFF
--- a/docs/base-account/framework-integrations/thirdweb.mdx
+++ b/docs/base-account/framework-integrations/thirdweb.mdx
@@ -22,11 +22,11 @@ By the end of this guide, you will:
 - Have Base Account available as a wallet option alongside email authentication
 - Use Thirdweb's `ConnectButton` for a polished wallet connection experience
 
-You can jump ahead and use the [Base Account Thirdweb Template](https://github.com/base/demos/tree/main/base-account/base-account-thirdweb-template) to get started.
+You can jump ahead and use the [Base Account Thirdweb Template](https://github.com/base/demos/tree/master/base-account/base-account-thirdweb-template) to get started.
 
 <GithubRepoCard
   title="Base Account Thirdweb Template"
-  githubUrl="https://github.com/base/demos/tree/main/base-account/base-account-thirdweb-template"
+  githubUrl="https://github.com/base/demos/tree/master/base-account/base-account-thirdweb-template"
 />
 
 ## Installation

--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 

--- a/docs/get-started/base-mentorship-program.mdx
+++ b/docs/get-started/base-mentorship-program.mdx
@@ -32,7 +32,7 @@ Base Mentors are experienced founders, operators, and subject matter experts acr
 | Jack Gorman | Variant |
 | Jacob Frantz | [Opyn (acq. Coinbase)](https://x.com/therealjfrantz) |
 | Jai Prasad | [Definitive](https://x.com/jai_prasad17) |
-| Jakub Rusiecki | [1kx](https://1kx.network/team/jakub-rusiecki) |
+| Jakub Rusiecki | [1kx](https://1kx.network/team) |
 | Jay Drain Jr | a16z crypto |
 | Jonathan Wu | [Asylum Ventures](https://www.asylum.vc/) |
 | Kaito Cunningham | [Utopia Labs (acq. Coinbase)](https://x.com/kaycidot) |


### PR DESCRIPTION
**What changed? Why?**

Fixed three broken links that currently return 404:

1. `base-account/framework-integrations/thirdweb`: the Base Account Thirdweb Template links point to `base/demos/tree/main/...`, but the default branch of `base/demos` is `master`, so both links (inline + `GithubRepoCard`) 404. Updated to `/tree/master/`.
2. `base-account/reference/core/provider-rpc-methods/wallet_connect`: the `signInWithEthereum` link includes the `.mdx` extension, which 404s on the live site (the extensionless URL works). Removed the extension.
3. `get-started/base-mentorship-program`: `1kx.network/team/jakub-rusiecki` no longer exists. Linked to the 1kx team page instead, matching how other entries in the table link to team pages.

**Notes to reviewers**

Link-only changes, no content changes.

**How has it been tested?**

Verified each URL before/after with curl:
- https://github.com/base/demos/tree/main/base-account/base-account-thirdweb-template → 404, /tree/master/ → 200
- https://docs.base.org/base-account/reference/core/capabilities/signInWithEthereum.mdx → 404, extensionless → 200
- https://1kx.network/team/jakub-rusiecki → 404, https://1kx.network/team → 200