### PR TITLE
fix(docs): remove outdated "Fall 2025" future date from migration guide

### DIFF
--- a/docs/base-account/guides/migration-guide.mdx
+++ b/docs/base-account/guides/migration-guide.mdx
@@ -15,7 +15,7 @@ Driving this change is a transition of our mobile app: the Coinbase Wallet app i
 
 Below is a table of existing users and how they will connect to apps now and in the future:
 
-| User Type | Today | Future (~Fall 2025) |
+| User Type | Today | Future |
 |-----------|-------|---------------------|
 | Smart Wallet users (web and mobile app) | Automatically have a Base Account, can use "Sign in with Base" | No change |
 | New Base app users | Automatically have a Base Account, can use "Sign in with Base" | No change |


### PR DESCRIPTION
The migration guide table lists "Future (~Fall 2025)" as an upcoming state,  but Fall 2025 has already passed. This is misleading to readers checking  current migration status. Removed the stale date reference.

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
