### PR TITLE
Add NodeFlare to node providers

### DIFF
--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -103,6 +103,14 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 - Base Mainnet
 - Base Sepolia (Testnet)
 
+## NodeFlare
+
+[NodeFlare](https://nodeflare.app/chains/base) provides free public Base Mainnet endpoints (no API key required) and a [free keyed tier](https://nodeflare.app/pricing) with higher rate limits, `eth_getLogs` and debug/trace support — served from NodeFlare's own multi-region bare-metal nodes (US, EU, UK, Asia) with automatic failover.
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+
 ## NodeReal
 
 [NodeReal](https://nodereal.io/) is a blockchain infrastructure and services provider that provides instant and easy-access to Base node APIs.


### PR DESCRIPTION
Adds NodeFlare to the Base node-providers list — free public Base Mainnet RPC (no API key) plus a free keyed tier with eth_getLogs and debug/trace, from NodeFlare's own multi-region bare-metal nodes with automatic failover. https://nodeflare.app/chains/base