### PR TITLE
docs(node-operators): add Deployment Tools section with Chainstack Self-Hosted

### DIFF
--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -105,6 +105,14 @@ You'll also know that the sync hasn't completed if you get `Error: nonce has alr
 
 ---
 
+## Deployment Tools
+
+If you'd rather not run the manual setup above yourself, a self-hosted deployment tool can run Base clients on your own infrastructure:
+
+- **[Chainstack Self-Hosted](https://docs.chainstack.com/docs/self-hosted/introduction)** — web UI and CLI for deploying Base execution (base-reth) and consensus (base-node) clients on your own Kubernetes cluster, cloud, or on-prem hardware. Built-in monitoring included. Free. No Chainstack account required. Built by Chainstack.
+
+---
+
 ## Enable Flashblocks
 
 Once your node is synced, you can enable Flashblocks to serve 200ms preconfirmations to your applications.


### PR DESCRIPTION
Adds a "Deployment Tools" section to the run-a-base-node page for self-hosted node-deployment tooling, starting with Chainstack Self-Hosted — a free web UI and CLI that deploys the Base clients (base-reth + base-node) on your own infrastructure, with built-in monitoring and no account required.

Base is a supported deployment in Chainstack Self-Hosted (Base-Reth + Base-Node): https://docs.chainstack.com/docs/self-hosted/supported-clients-and-protocols

This mirrors the "Guided setup" section on ethereum.org's run-a-node page. It documents deploying Base's own clients via an ops tool, not a third-party product guide.

Disclosure: I work at Chainstack; this is Chainstack's tooling. If you'd prefer, I'm happy to instead add it under a distinct heading on the Node Providers page.
