### PR TITLE
Preview use-case-first docs navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,54 +29,54 @@
     "tabs": [
       {
         "tab": "Get Started",
+        "icon": "rocket",
         "groups": [
           {
             "group": "Introduction",
-            "pages": ["get-started/base"]
-          },
-          {
-            "group": "Quickstart",
             "pages": [
-              "get-started/resources-for-ai-agents",
-              "get-started/build-app",
-              "get-started/launch-b20-token",
-              "get-started/launch-token",
-              "get-started/deploy-smart-contracts",
-              "get-started/learning-resources"
+              "get-started/base"
             ]
           },
           {
-            "group": "Builder Support",
+            "group": "Build an app",
             "pages": [
-              "get-started/get-funded",
-              "get-started/base-services-hub",
-              "get-started/base-mentorship-program",
-              "get-started/country-leads-and-ambassadors"
+              "apps/quickstart/build-app",
+              "get-started/deploy-smart-contracts",
+              "apps/quickstart/deploy-on-base",
+              "apps/guides/migrate-to-standard-web-app",
+              "apps/technical-guides/base-notifications"
             ]
           },
           {
             "group": "Build with AI",
             "pages": [
+              "get-started/resources-for-ai-agents",
               "get-started/docs-mcp",
               "get-started/docs-llms",
               "get-started/prompt-library"
             ]
           },
           {
-            "group": "Developer Tools",
+            "group": "Developer tools",
             "pages": [
               "get-started/block-explorers",
               "get-started/data-indexers"
+            ]
+          },
+          {
+            "group": "Grow",
+            "pages": [
+              "get-started/learning-resources",
+              "get-started/get-funded",
+              "get-started/base-services-hub",
+              "get-started/base-mentorship-program",
+              "get-started/country-leads-and-ambassadors",
+              "apps/growth/rewards"
             ]
           }
         ],
         "global": {
           "anchors": [
-            {
-              "anchor": "Status",
-              "href": "https://status.base.org/",
-              "icon": "signal-bars"
-            },
             {
               "anchor": "Faucet",
               "href": "https://docs.base.org/base-chain/network-information/network-faucets",
@@ -86,128 +86,207 @@
               "anchor": "Bridge",
               "href": "https://docs.base.org/base-chain/network-information/ecosystem-bridges",
               "icon": "coin"
-            },
-            {
-              "anchor": "Blog",
-              "href": "https://blog.base.dev/",
-              "icon": "scroll"
             }
           ]
         }
       },
       {
-        "tab": "Chain",
+        "tab": "Trading",
+        "icon": "arrow-right-arrow-left",
         "groups": [
           {
-            "group": "Beryl Upgrade",
-            "tag": "New",
+            "group": "Bridging",
             "pages": [
-              "base-chain/specs/upgrades/beryl/overview"
+              "base-chain/network-information/bridging-and-withdrawals",
+              "base-chain/network-information/base-solana-bridge",
+              "base-chain/network-information/ecosystem-bridges"
             ]
           },
           {
-            "group": "Introduction",
+            "group": "Launch & create tokens",
             "pages": [
-              "base-chain/overview"
+              "get-started/launch-token",
+              "get-started/launch-b20-token"
             ]
           },
           {
-            "group": "Core Concepts",
+            "group": "Private trading",
+            "pages": [
+              "ledgers/overview",
+              "ledgers/how-it-works",
+              "ledgers/deposit-flow",
+              "ledgers/withdraw-flow"
+            ]
+          },
+          {
+            "group": "Build",
+            "pages": [
+              {
+                "group": "Sign in with Base",
+                "pages": [
+                  "base-account/guides/authenticate-users",
+                  "base-account/guides/verify-social-accounts",
+                  "base-account/guides/sign-and-verify-typed-data"
+                ]
+              },
+              {
+                "group": "Basenames",
+                "pages": [
+                  "base-account/basenames/basenames-faq",
+                  "base-account/basenames/basename-transfer"
+                ]
+              },
+              {
+                "group": "Wallet UX",
+                "pages": [
+                  "base-account/improve-ux/batch-transactions",
+                  "base-account/improve-ux/sub-accounts",
+                  "base-account/improve-ux/spend-permissions"
+                ]
+              },
+              {
+                "group": "Sponsor gas (Paymaster)",
+                "pages": [
+                  "base-account/improve-ux/sponsor-gas/paymasters",
+                  "base-account/improve-ux/sponsor-gas/erc20-paymasters"
+                ]
+              },
+              {
+                "group": "Builder Codes",
+                "pages": [
+                  "apps/builder-codes/builder-codes",
+                  "apps/builder-codes/app-developers",
+                  "apps/builder-codes/wallet-developers",
+                  "apps/builder-codes/agent-developers"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Payments",
+        "icon": "credit-card",
+        "groups": [
+          {
+            "group": "Accept payments",
+            "pages": [
+              "base-account/guides/accept-payments",
+              "apps/guides/accept-b20-payments"
+            ]
+          },
+          {
+            "group": "Recurring & subscriptions",
+            "pages": [
+              "base-account/guides/accept-recurring-payments"
+            ]
+          },
+          {
+            "group": "x402 payments",
+            "pages": [
+              "agents/guides/x402-payments"
+            ]
+          },
+          {
+            "group": "Private payments",
+            "pages": [
+              "ledgers/overview",
+              "ledgers/how-it-works",
+              "ledgers/deposit-flow",
+              "ledgers/withdraw-flow"
+            ]
+          },
+          {
+            "group": "Build",
+            "pages": [
+              {
+                "group": "Sign in with Base",
+                "pages": [
+                  "base-account/guides/authenticate-users",
+                  "base-account/guides/verify-social-accounts",
+                  "base-account/guides/sign-and-verify-typed-data"
+                ]
+              },
+              {
+                "group": "Basenames",
+                "pages": [
+                  "base-account/basenames/basenames-faq",
+                  "base-account/basenames/basename-transfer"
+                ]
+              },
+              {
+                "group": "Wallet UX",
+                "pages": [
+                  "base-account/improve-ux/batch-transactions",
+                  "base-account/improve-ux/sub-accounts",
+                  "base-account/improve-ux/spend-permissions"
+                ]
+              },
+              {
+                "group": "Sponsor gas (Paymaster)",
+                "pages": [
+                  "base-account/improve-ux/sponsor-gas/paymasters",
+                  "base-account/improve-ux/sponsor-gas/erc20-paymasters"
+                ]
+              },
+              {
+                "group": "Builder Codes",
+                "pages": [
+                  "apps/builder-codes/builder-codes",
+                  "apps/builder-codes/app-developers",
+                  "apps/builder-codes/wallet-developers",
+                  "apps/builder-codes/agent-developers"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Protocol",
+        "icon": "cube",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "base-chain/overview",
+              "base-chain/quickstart/connecting-to-base"
+            ]
+          },
+          {
+            "group": "Network information",
             "pages": [
               "base-chain/network-information/transaction-ordering",
               "base-chain/network-information/transaction-finality",
               "base-chain/network-information/throughput-and-limits",
               "base-chain/network-information/network-fees",
-              "base-chain/network-information/bridging-and-withdrawals"
+              "base-chain/network-information/base-contracts",
+              "base-chain/network-information/network-faucets",
+              "base-chain/network-information/troubleshooting-transactions",
+              "base-chain/network-information/configuration-changelog",
+              "base-chain/network-information/bridging-and-withdrawals",
+              "base-chain/network-information/base-solana-bridge",
+              "base-chain/network-information/ecosystem-bridges"
             ]
           },
           {
-            "group": "Node Operators",
+            "group": "Node operators",
             "pages": [
               "base-chain/node-operators/run-a-base-node",
               "base-chain/node-operators/performance-tuning",
               "base-chain/node-operators/snapshots",
-              "base-chain/node-operators/troubleshooting"
+              "base-chain/node-operators/troubleshooting",
+              "base-chain/node-operators/node-providers"
             ]
           },
           {
-            "group": "Network Reference",
+            "group": "Flashblocks",
             "pages": [
-              "base-chain/quickstart/connecting-to-base",
-              "base-chain/node-operators/node-providers",
-              "base-chain/network-information/base-contracts",
-              {
-                "group": "Bridges",
-                "pages": [
-                  "base-chain/network-information/base-solana-bridge",
-                  "base-chain/network-information/ecosystem-bridges"
-                ]
-              },
-              "base-chain/network-information/network-faucets",
-              "base-chain/flashblocks/faq",
-              "base-chain/network-information/troubleshooting-transactions",
-              "base-chain/network-information/configuration-changelog"
+              "base-chain/flashblocks/faq"
             ]
           },
           {
-            "group": "API Reference",
-            "pages": [
-              "base-chain/api-reference/rpc-overview",
-              {
-                "group": "Ethereum JSON-RPC API",
-                "pages": [
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_blockNumber",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_call",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_chainId",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_estimateGas",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_feeHistory",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_gasPrice",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getBalance",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockByHash",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockByNumber",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockReceipts",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockTransactionCountByHash",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockTransactionCountByNumber",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getCode",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getStorageAt",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByBlockHashAndIndex",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByBlockNumberAndIndex",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByHash",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionCount",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionReceipt",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_maxPriorityFeePerGas",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_sendRawTransaction",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_syncing",
-                  "base-chain/api-reference/ethereum-json-rpc-api/eth_unsubscribe",
-                  "base-chain/api-reference/ethereum-json-rpc-api/net_version",
-                  "base-chain/api-reference/ethereum-json-rpc-api/web3_clientVersion"
-                ]
-              },
-              {
-                "group": "Flashblocks API",
-                "pages": [
-                  "base-chain/api-reference/flashblocks-api/flashblocks-api-overview",
-                  "base-chain/api-reference/flashblocks-api/base_transactionStatus",
-                  "base-chain/api-reference/flashblocks-api/eth_simulateV1",
-                  "base-chain/api-reference/flashblocks-api/newFlashblockTransactions",
-                  "base-chain/api-reference/flashblocks-api/newFlashblocks",
-                  "base-chain/api-reference/flashblocks-api/pendingLogs"
-                ]
-              },
-              {
-                "group": "Debug API",
-                "pages": [
-                  "base-chain/api-reference/debug-api/debug_traceTransaction",
-                  "base-chain/api-reference/debug-api/debug_traceBlockByHash",
-                  "base-chain/api-reference/debug-api/debug_traceBlockByNumber"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Protocol Specifications",
+            "group": "Protocol specifications",
             "pages": [
               "base-chain/specs/overview",
               {
@@ -253,108 +332,103 @@
                       "base-chain/specs/protocol/proofs/zk-prover",
                       "base-chain/specs/protocol/proofs/contracts"
                     ]
-                  }
-                ]
-              },
-              {
-                "group": "Upgrades",
-                "pages": [
-                  {
-                    "group": "Beryl",
-                    "pages": [
-                      "base-chain/specs/upgrades/beryl/overview",
-                      "base-chain/specs/upgrades/beryl/b20"
-                    ]
                   },
                   {
-                    "group": "Azul",
+                    "group": "Reference",
                     "pages": [
-                      "base-chain/specs/upgrades/azul/overview",
-                      "base-chain/specs/upgrades/azul/node-upgrade",
-                      "base-chain/specs/upgrades/azul/exec-engine",
-                      "base-chain/specs/upgrades/azul/proofs"
-                    ]
-                  },
-                  {
-                    "group": "Optimism",
-                    "pages": [
-                      {
-                        "group": "Jovian",
-                        "pages": [
-                          "base-chain/specs/upgrades/jovian/overview",
-                          "base-chain/specs/upgrades/jovian/exec-engine",
-                          "base-chain/specs/upgrades/jovian/derivation",
-                          "base-chain/specs/upgrades/jovian/l1-attributes",
-                          "base-chain/specs/upgrades/jovian/system-config"
-                        ]
-                      },
-                      {
-                        "group": "Isthmus",
-                        "pages": [
-                          "base-chain/specs/upgrades/isthmus/overview",
-                          "base-chain/specs/upgrades/isthmus/exec-engine",
-                          "base-chain/specs/upgrades/isthmus/derivation",
-                          "base-chain/specs/upgrades/isthmus/l1-attributes",
-                          "base-chain/specs/upgrades/isthmus/predeploys",
-                          "base-chain/specs/upgrades/isthmus/system-config"
-                        ]
-                      },
-                      {
-                        "group": "Holocene",
-                        "pages": [
-                          "base-chain/specs/upgrades/holocene/overview",
-                          "base-chain/specs/upgrades/holocene/exec-engine",
-                          "base-chain/specs/upgrades/holocene/derivation",
-                          "base-chain/specs/upgrades/holocene/system-config"
-                        ]
-                      },
-                      {
-                        "group": "Granite",
-                        "pages": [
-                          "base-chain/specs/upgrades/granite/overview",
-                          "base-chain/specs/upgrades/granite/exec-engine",
-                          "base-chain/specs/upgrades/granite/derivation"
-                        ]
-                      },
-                      {
-                        "group": "Fjord",
-                        "pages": [
-                          "base-chain/specs/upgrades/fjord/overview",
-                          "base-chain/specs/upgrades/fjord/exec-engine",
-                          "base-chain/specs/upgrades/fjord/derivation",
-                          "base-chain/specs/upgrades/fjord/predeploys"
-                        ]
-                      },
-                      {
-                        "group": "Ecotone",
-                        "pages": [
-                          "base-chain/specs/upgrades/ecotone/overview",
-                          "base-chain/specs/upgrades/ecotone/derivation",
-                          "base-chain/specs/upgrades/ecotone/l1-attributes"
-                        ]
-                      },
-                      {
-                        "group": "Delta",
-                        "pages": [
-                          "base-chain/specs/upgrades/delta/overview",
-                          "base-chain/specs/upgrades/delta/span-batches"
-                        ]
-                      },
-                      {
-                        "group": "Canyon",
-                        "pages": [
-                          "base-chain/specs/upgrades/canyon/overview"
-                        ]
-                      }
+                      "base-chain/specs/reference/glossary",
+                      "base-chain/specs/reference/configurability"
                     ]
                   }
                 ]
+              }
+            ]
+          },
+          {
+            "group": "Upgrades",
+            "pages": [
+              {
+                "group": "Beryl",
+                "pages": [
+                  "base-chain/specs/upgrades/beryl/overview",
+                  "base-chain/specs/upgrades/beryl/b20"
+                ]
               },
               {
-                "group": "Reference",
+                "group": "Azul",
                 "pages": [
-                  "base-chain/specs/reference/glossary",
-                  "base-chain/specs/reference/configurability"
+                  "base-chain/specs/upgrades/azul/overview",
+                  "base-chain/specs/upgrades/azul/node-upgrade",
+                  "base-chain/specs/upgrades/azul/exec-engine",
+                  "base-chain/specs/upgrades/azul/proofs"
+                ]
+              },
+              {
+                "group": "Jovian",
+                "pages": [
+                  "base-chain/specs/upgrades/jovian/overview",
+                  "base-chain/specs/upgrades/jovian/exec-engine",
+                  "base-chain/specs/upgrades/jovian/derivation",
+                  "base-chain/specs/upgrades/jovian/l1-attributes",
+                  "base-chain/specs/upgrades/jovian/system-config"
+                ]
+              },
+              {
+                "group": "Isthmus",
+                "pages": [
+                  "base-chain/specs/upgrades/isthmus/overview",
+                  "base-chain/specs/upgrades/isthmus/exec-engine",
+                  "base-chain/specs/upgrades/isthmus/derivation",
+                  "base-chain/specs/upgrades/isthmus/l1-attributes",
+                  "base-chain/specs/upgrades/isthmus/predeploys",
+                  "base-chain/specs/upgrades/isthmus/system-config"
+                ]
+              },
+              {
+                "group": "Holocene",
+                "pages": [
+                  "base-chain/specs/upgrades/holocene/overview",
+                  "base-chain/specs/upgrades/holocene/exec-engine",
+                  "base-chain/specs/upgrades/holocene/derivation",
+                  "base-chain/specs/upgrades/holocene/system-config"
+                ]
+              },
+              {
+                "group": "Granite",
+                "pages": [
+                  "base-chain/specs/upgrades/granite/overview",
+                  "base-chain/specs/upgrades/granite/exec-engine",
+                  "base-chain/specs/upgrades/granite/derivation"
+                ]
+              },
+              {
+                "group": "Fjord",
+                "pages": [
+                  "base-chain/specs/upgrades/fjord/overview",
+                  "base-chain/specs/upgrades/fjord/exec-engine",
+                  "base-chain/specs/upgrades/fjord/derivation",
+                  "base-chain/specs/upgrades/fjord/predeploys"
+                ]
+              },
+              {
+                "group": "Ecotone",
+                "pages": [
+                  "base-chain/specs/upgrades/ecotone/overview",
+                  "base-chain/specs/upgrades/ecotone/derivation",
+                  "base-chain/specs/upgrades/ecotone/l1-attributes"
+                ]
+              },
+              {
+                "group": "Delta",
+                "pages": [
+                  "base-chain/specs/upgrades/delta/overview",
+                  "base-chain/specs/upgrades/delta/span-batches"
+                ]
+              },
+              {
+                "group": "Canyon",
+                "pages": [
+                  "base-chain/specs/upgrades/canyon/overview"
                 ]
               }
             ]
@@ -399,37 +473,20 @@
         }
       },
       {
-        "tab": "Account",
+        "tab": "SDKs",
+        "icon": "code",
         "groups": [
           {
-            "group": "Introduction",
-            "pages": ["base-account/overview/what-is-base-account"]
-          },
-          {
-            "group": "Quickstart",
+            "group": "Get started",
             "pages": [
+              "base-account/overview/what-is-base-account",
               "base-account/quickstart/web",
               "base-account/quickstart/web-react",
               "base-account/quickstart/mobile-integration"
             ]
           },
           {
-            "group": "Guides",
-            "pages": [
-              "base-account/guides/authenticate-users",
-              "base-account/guides/accept-payments",
-              "base-account/guides/accept-recurring-payments",
-              "base-account/improve-ux/batch-transactions",
-              "base-account/improve-ux/sponsor-gas/paymasters",
-              "base-account/improve-ux/sub-accounts",
-              "base-account/improve-ux/spend-permissions",
-              "base-account/guides/verify-social-accounts",
-              "base-account/guides/sign-and-verify-typed-data",
-              "base-account/improve-ux/sponsor-gas/erc20-paymasters"
-            ]
-          },
-          {
-            "group": "Framework Integrations",
+            "group": "Framework integrations",
             "pages": [
               {
                 "group": "Wagmi/Viem",
@@ -456,164 +513,137 @@
             ]
           },
           {
-            "group": "Reference",
+            "group": "Core",
             "pages": [
-              {
-                "group": "Account SDK",
-                "pages": [
-                  "base-account/reference/core/createBaseAccount",
-                  "base-account/reference/core/getProvider",
-                  "base-account/reference/spend-permission-utilities/requestSpendPermission",
-                  "base-account/reference/spend-permission-utilities/prepareSpendCallData",
-                  "base-account/reference/spend-permission-utilities/fetchPermissions",
-                  "base-account/reference/spend-permission-utilities/fetchPermission",
-                  "base-account/reference/spend-permission-utilities/getPermissionStatus",
-                  "base-account/reference/spend-permission-utilities/requestRevoke",
-                  "base-account/reference/spend-permission-utilities/prepareRevokeCallData",
-                  "base-account/reference/core/generateKeyPair",
-                  "base-account/reference/core/getKeypair",
-                  "base-account/reference/core/getCryptoKeyAccount",
-                  {
-                    "group": "Base Pay",
-                    "pages": [
-                      "base-account/reference/base-pay/pay",
-                      "base-account/reference/base-pay/getPaymentStatus"
-                    ]
-                  },
-                  {
-                    "group": "Subscriptions",
-                    "pages": [
-                      "base-account/reference/base-pay/subscriptions-overview",
-                      "base-account/reference/base-pay/subscribe",
-                      "base-account/reference/base-pay/getStatus",
-                      "base-account/reference/base-pay/charge",
-                      "base-account/reference/base-pay/revoke",
-                      "base-account/reference/base-pay/getOrCreateSubscriptionOwnerWallet",
-                      "base-account/reference/base-pay/prepareCharge",
-                      "base-account/reference/base-pay/prepareRevoke"
-                    ]
-                  },
-                  {
-                    "group": "Prolink Utilities",
-                    "pages": [
-                      "base-account/reference/prolink-utilities/encodeProlink",
-                      "base-account/reference/prolink-utilities/decodeProlink",
-                      "base-account/reference/prolink-utilities/createProlinkUrl"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Provider",
-                "pages": [
-                  {
-                    "group": "Methods",
-                    "pages": [
-                      "base-account/reference/core/provider-rpc-methods/request-overview",
-                      "base-account/reference/core/provider-rpc-methods/wallet_connect",
-                      "base-account/reference/core/provider-rpc-methods/wallet_sendCalls",
-                      "base-account/reference/core/provider-rpc-methods/wallet_getCallsStatus",
-                      "base-account/reference/core/provider-rpc-methods/wallet_getCapabilities",
-                      "base-account/reference/core/provider-rpc-methods/wallet_addSubAccount",
-                      "base-account/reference/core/provider-rpc-methods/wallet_getSubAccounts",
-                      "base-account/reference/core/provider-rpc-methods/coinbase_fetchPermissions",
-                      "base-account/reference/core/provider-rpc-methods/coinbase_fetchPermission",
-                      "base-account/reference/core/provider-rpc-methods/eth_accounts",
-                      "base-account/reference/core/provider-rpc-methods/eth_requestAccounts",
-                      "base-account/reference/core/provider-rpc-methods/eth_chainId",
-                      "base-account/reference/core/provider-rpc-methods/eth_blockNumber",
-                      "base-account/reference/core/provider-rpc-methods/eth_coinbase",
-                      "base-account/reference/core/provider-rpc-methods/eth_getBalance",
-                      "base-account/reference/core/provider-rpc-methods/eth_getTransactionCount",
-                      "base-account/reference/core/provider-rpc-methods/eth_getTransactionByHash",
-                      "base-account/reference/core/provider-rpc-methods/eth_getTransactionReceipt",
-                      "base-account/reference/core/provider-rpc-methods/eth_getBlockByNumber",
-                      "base-account/reference/core/provider-rpc-methods/eth_getBlockByHash",
-                      "base-account/reference/core/provider-rpc-methods/eth_getBlockTransactionCountByNumber",
-                      "base-account/reference/core/provider-rpc-methods/eth_getBlockTransactionCountByHash",
-                      "base-account/reference/core/provider-rpc-methods/eth_sendTransaction",
-                      "base-account/reference/core/provider-rpc-methods/eth_sendRawTransaction",
-                      "base-account/reference/core/provider-rpc-methods/eth_estimateGas",
-                      "base-account/reference/core/provider-rpc-methods/eth_gasPrice",
-                      "base-account/reference/core/provider-rpc-methods/eth_feeHistory",
-                      "base-account/reference/core/provider-rpc-methods/eth_getCode",
-                      "base-account/reference/core/provider-rpc-methods/eth_getStorageAt",
-                      "base-account/reference/core/provider-rpc-methods/eth_getLogs",
-                      "base-account/reference/core/provider-rpc-methods/eth_getProof",
-                      "base-account/reference/core/provider-rpc-methods/personal_sign",
-                      "base-account/reference/core/provider-rpc-methods/eth_signTypedData_v4",
-                      "base-account/reference/core/provider-rpc-methods/wallet_addEthereumChain",
-                      "base-account/reference/core/provider-rpc-methods/wallet_switchEthereumChain",
-                      "base-account/reference/core/provider-rpc-methods/wallet_watchAsset",
-                      "base-account/reference/core/provider-rpc-methods/eth_getTransactionByBlockHashAndIndex",
-                      "base-account/reference/core/provider-rpc-methods/eth_getTransactionByBlockNumberAndIndex",
-                      "base-account/reference/core/provider-rpc-methods/eth_getUncleCountByBlockHash",
-                      "base-account/reference/core/provider-rpc-methods/eth_getUncleCountByBlockNumber",
-                      "base-account/reference/core/provider-rpc-methods/web3_clientVersion"
-                    ]
-                  },
-                  {
-                    "group": "Capabilities",
-                    "pages": [
-                      "base-account/reference/core/capabilities/overview",
-                      "base-account/reference/core/capabilities/signInWithEthereum",
-                      "base-account/reference/core/capabilities/atomic",
-                      "base-account/reference/core/capabilities/flowControl",
-                      "base-account/reference/core/capabilities/paymasterService",
-                      "base-account/reference/core/capabilities/auxiliaryFunds",
-                      "base-account/reference/core/capabilities/datacallback",
-                      "base-account/reference/core/capabilities/dataSuffix",
-                      "base-account/reference/core/capabilities/gasLimitOverride"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "UI Elements",
-                "pages": [
-                  "base-account/reference/ui-elements/base-pay-button",
-                  "base-account/reference/ui-elements/sign-in-with-base-button",
-                  "base-account/reference/ui-elements/brand-guidelines"
-                ]
-              },
-              {
-                "group": "Onchain Contracts",
-                "pages": [
-                  "base-account/reference/onchain-contracts/spend-permissions",
-                  "base-account/reference/onchain-contracts/smart-wallet",
-                  "base-account/reference/onchain-contracts/basenames"
-                ]
-              }
+              "base-account/reference/core/createBaseAccount",
+              "base-account/reference/core/getProvider",
+              "base-account/reference/core/generateKeyPair",
+              "base-account/reference/core/getKeypair",
+              "base-account/reference/core/getCryptoKeyAccount"
             ]
           },
           {
-            "group": "More",
+            "group": "Provider RPC methods",
             "pages": [
-              {
-                "group": "Troubleshooting",
-                "pages": [
-                  "base-account/more/troubleshooting/usage-details/popups",
-                  "base-account/more/troubleshooting/usage-details/gas-usage",
-                  "base-account/more/troubleshooting/usage-details/unsupported-calls",
-                  "base-account/more/troubleshooting/usage-details/simulations",
-                  "base-account/more/troubleshooting/usage-details/wallet-library-support"
-                ]
-              },
+              "base-account/reference/core/provider-rpc-methods/request-overview",
+              "base-account/reference/core/provider-rpc-methods/wallet_connect",
+              "base-account/reference/core/provider-rpc-methods/wallet_sendCalls",
+              "base-account/reference/core/provider-rpc-methods/wallet_getCallsStatus",
+              "base-account/reference/core/provider-rpc-methods/wallet_getCapabilities",
+              "base-account/reference/core/provider-rpc-methods/wallet_addSubAccount",
+              "base-account/reference/core/provider-rpc-methods/wallet_getSubAccounts",
+              "base-account/reference/core/provider-rpc-methods/coinbase_fetchPermissions",
+              "base-account/reference/core/provider-rpc-methods/coinbase_fetchPermission",
+              "base-account/reference/core/provider-rpc-methods/eth_accounts",
+              "base-account/reference/core/provider-rpc-methods/eth_requestAccounts",
+              "base-account/reference/core/provider-rpc-methods/eth_chainId",
+              "base-account/reference/core/provider-rpc-methods/eth_blockNumber",
+              "base-account/reference/core/provider-rpc-methods/eth_coinbase",
+              "base-account/reference/core/provider-rpc-methods/eth_getBalance",
+              "base-account/reference/core/provider-rpc-methods/eth_getTransactionCount",
+              "base-account/reference/core/provider-rpc-methods/eth_getTransactionByHash",
+              "base-account/reference/core/provider-rpc-methods/eth_getTransactionReceipt",
+              "base-account/reference/core/provider-rpc-methods/eth_getBlockByNumber",
+              "base-account/reference/core/provider-rpc-methods/eth_getBlockByHash",
+              "base-account/reference/core/provider-rpc-methods/eth_getBlockTransactionCountByNumber",
+              "base-account/reference/core/provider-rpc-methods/eth_getBlockTransactionCountByHash",
+              "base-account/reference/core/provider-rpc-methods/eth_sendTransaction",
+              "base-account/reference/core/provider-rpc-methods/eth_sendRawTransaction",
+              "base-account/reference/core/provider-rpc-methods/eth_estimateGas",
+              "base-account/reference/core/provider-rpc-methods/eth_gasPrice",
+              "base-account/reference/core/provider-rpc-methods/eth_feeHistory",
+              "base-account/reference/core/provider-rpc-methods/eth_getCode",
+              "base-account/reference/core/provider-rpc-methods/eth_getStorageAt",
+              "base-account/reference/core/provider-rpc-methods/eth_getLogs",
+              "base-account/reference/core/provider-rpc-methods/eth_getProof",
+              "base-account/reference/core/provider-rpc-methods/personal_sign",
+              "base-account/reference/core/provider-rpc-methods/eth_signTypedData_v4",
+              "base-account/reference/core/provider-rpc-methods/wallet_addEthereumChain",
+              "base-account/reference/core/provider-rpc-methods/wallet_switchEthereumChain",
+              "base-account/reference/core/provider-rpc-methods/wallet_watchAsset",
+              "base-account/reference/core/provider-rpc-methods/eth_getTransactionByBlockHashAndIndex",
+              "base-account/reference/core/provider-rpc-methods/eth_getTransactionByBlockNumberAndIndex",
+              "base-account/reference/core/provider-rpc-methods/eth_getUncleCountByBlockHash",
+              "base-account/reference/core/provider-rpc-methods/eth_getUncleCountByBlockNumber",
+              "base-account/reference/core/provider-rpc-methods/web3_clientVersion"
+            ]
+          },
+          {
+            "group": "Capabilities",
+            "pages": [
+              "base-account/reference/core/capabilities/overview",
+              "base-account/reference/core/capabilities/signInWithEthereum",
+              "base-account/reference/core/capabilities/atomic",
+              "base-account/reference/core/capabilities/flowControl",
+              "base-account/reference/core/capabilities/paymasterService",
+              "base-account/reference/core/capabilities/auxiliaryFunds",
+              "base-account/reference/core/capabilities/datacallback",
+              "base-account/reference/core/capabilities/dataSuffix",
+              "base-account/reference/core/capabilities/gasLimitOverride"
+            ]
+          },
+          {
+            "group": "Base Pay methods",
+            "pages": [
+              "base-account/reference/base-pay/pay",
+              "base-account/reference/base-pay/getPaymentStatus",
+              "base-account/reference/base-pay/subscriptions-overview",
+              "base-account/reference/base-pay/subscribe",
+              "base-account/reference/base-pay/getStatus",
+              "base-account/reference/base-pay/charge",
+              "base-account/reference/base-pay/revoke",
+              "base-account/reference/base-pay/getOrCreateSubscriptionOwnerWallet",
+              "base-account/reference/base-pay/prepareCharge",
+              "base-account/reference/base-pay/prepareRevoke"
+            ]
+          },
+          {
+            "group": "Spend permission utilities",
+            "pages": [
+              "base-account/reference/spend-permission-utilities/requestSpendPermission",
+              "base-account/reference/spend-permission-utilities/prepareSpendCallData",
+              "base-account/reference/spend-permission-utilities/fetchPermissions",
+              "base-account/reference/spend-permission-utilities/fetchPermission",
+              "base-account/reference/spend-permission-utilities/getPermissionStatus",
+              "base-account/reference/spend-permission-utilities/requestRevoke",
+              "base-account/reference/spend-permission-utilities/prepareRevokeCallData"
+            ]
+          },
+          {
+            "group": "Prolink utilities",
+            "pages": [
+              "base-account/reference/prolink-utilities/encodeProlink",
+              "base-account/reference/prolink-utilities/decodeProlink",
+              "base-account/reference/prolink-utilities/createProlinkUrl"
+            ]
+          },
+          {
+            "group": "UI elements",
+            "pages": [
+              "base-account/reference/ui-elements/base-pay-button",
+              "base-account/reference/ui-elements/sign-in-with-base-button",
+              "base-account/reference/ui-elements/brand-guidelines"
+            ]
+          },
+          {
+            "group": "Onchain contracts",
+            "pages": [
+              "base-account/reference/onchain-contracts/spend-permissions",
+              "base-account/reference/onchain-contracts/smart-wallet",
+              "base-account/reference/onchain-contracts/basenames"
+            ]
+          },
+          {
+            "group": "Resources",
+            "pages": [
+              "base-account/guides/migration-guide",
               "base-account/more/base-gasless-campaign",
               "base-account/more/telemetry",
-              "base-account/guides/migration-guide"
-            ]
-          },
-          {
-            "group": "Basenames",
-            "pages": [
-              "base-account/basenames/basenames-faq",
-              "base-account/basenames/basename-transfer"
-            ]
-          },
-          {
-            "group": "Contribute",
-            "pages": [
+              "base-account/more/troubleshooting/usage-details/popups",
+              "base-account/more/troubleshooting/usage-details/gas-usage",
+              "base-account/more/troubleshooting/usage-details/unsupported-calls",
+              "base-account/more/troubleshooting/usage-details/simulations",
+              "base-account/more/troubleshooting/usage-details/wallet-library-support",
               "base-account/contribute/contribute-to-base-account-docs",
               "base-account/contribute/security-and-bug-bounty"
             ]
@@ -635,126 +665,67 @@
         }
       },
       {
-        "tab": "Ledgers",
+        "tab": "APIs",
+        "icon": "plug",
         "groups": [
           {
             "group": "Overview",
-            "pages": ["ledgers/overview"]
+            "pages": [
+              "base-chain/api-reference/rpc-overview"
+            ]
           },
           {
-            "group": "Ledgers",
+            "group": "Ethereum JSON-RPC API",
             "pages": [
-              "ledgers/how-it-works",
-              "ledgers/deposit-flow",
-              "ledgers/withdraw-flow"
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_blockNumber",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_call",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_chainId",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_estimateGas",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_feeHistory",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_gasPrice",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getBalance",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockByHash",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockByNumber",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockReceipts",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockTransactionCountByHash",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getBlockTransactionCountByNumber",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getCode",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getStorageAt",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByBlockHashAndIndex",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByBlockNumberAndIndex",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionByHash",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionCount",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_getTransactionReceipt",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_maxPriorityFeePerGas",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_sendRawTransaction",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_subscribe",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_syncing",
+              "base-chain/api-reference/ethereum-json-rpc-api/eth_unsubscribe",
+              "base-chain/api-reference/ethereum-json-rpc-api/net_version",
+              "base-chain/api-reference/ethereum-json-rpc-api/web3_clientVersion"
+            ]
+          },
+          {
+            "group": "Flashblocks API",
+            "pages": [
+              "base-chain/api-reference/flashblocks-api/flashblocks-api-overview",
+              "base-chain/api-reference/flashblocks-api/base_transactionStatus",
+              "base-chain/api-reference/flashblocks-api/eth_simulateV1",
+              "base-chain/api-reference/flashblocks-api/newFlashblockTransactions",
+              "base-chain/api-reference/flashblocks-api/newFlashblocks",
+              "base-chain/api-reference/flashblocks-api/pendingLogs"
+            ]
+          },
+          {
+            "group": "Debug API",
+            "pages": [
+              "base-chain/api-reference/debug-api/debug_traceTransaction",
+              "base-chain/api-reference/debug-api/debug_traceBlockByHash",
+              "base-chain/api-reference/debug-api/debug_traceBlockByNumber"
             ]
           }
         ]
-      },
-      {
-        "tab": "Apps",
-        "groups": [
-          {
-            "group": "Quickstart",
-            "pages": [
-              "apps/quickstart/build-app",
-              "apps/quickstart/deploy-on-base"
-            ]
-          },
-          {
-            "group": "Guides",
-            "pages": [
-              "apps/technical-guides/base-notifications",
-              "apps/guides/migrate-to-standard-web-app",
-              "apps/guides/accept-b20-payments"
-            ]
-          },
-          {
-            "group": "Growth",
-            "pages": ["apps/growth/rewards"]
-          },
-          {
-            "group": "Builder Codes",
-            "pages": [
-              "apps/builder-codes/builder-codes",
-              "apps/builder-codes/app-developers",
-              "apps/builder-codes/wallet-developers",
-              "apps/builder-codes/agent-developers"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Agents",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": ["agents/index"]
-          },
-          {
-            "group": "Quickstart",
-            "pages": ["agents/quickstart"]
-          },
-          {
-            "group": "Guides",
-            "pages": [
-              "agents/guides/check-balance",
-              "agents/guides/send-tokens",
-              "agents/guides/swap-tokens",
-              "agents/guides/view-history",
-              "agents/guides/sign-messages",
-              "agents/guides/batch-calls",
-              "agents/guides/x402-payments"
-            ]
-          },
-          {
-            "group": "Skill & Plugins",
-            "pages": [
-              "agents/plugins/index",
-              {
-                "group": "Native Plugins",
-                "pages": [
-                  "agents/plugins/native/index",
-                  "agents/plugins/native/aerodrome",
-                  "agents/plugins/native/avantis",
-                  "agents/plugins/native/balancer",
-                  "agents/plugins/native/bankr",
-                  "agents/plugins/native/bitrefill",
-                  "agents/plugins/native/brickken",
-                  "agents/plugins/native/clawnch",
-                  "agents/plugins/native/flaunch",
-                  "agents/plugins/native/gmgn",
-                  "agents/plugins/native/hydrex",
-                  "agents/plugins/native/kyberswap",
-                  "agents/plugins/native/moonwell",
-                  "agents/plugins/native/morpho",
-                  "agents/plugins/native/o1-exchange",
-                  "agents/plugins/native/opensea",
-                  "agents/plugins/native/printr",
-                  "agents/plugins/native/uniswap",
-                  "agents/plugins/native/venice",
-                  "agents/plugins/native/virtuals",
-                  "agents/plugins/native/yo"
-                ]
-              },
-              "agents/plugins/custom-plugins"
-            ]
-          }
-        ],
-        "global": {
-          "anchors": [
-            {
-              "anchor": "Skills",
-              "href": "https://github.com/base/skills",
-              "icon": "github"
-            },
-            {
-              "anchor": "Support",
-              "href": "https://discord.com/invite/buildonbase",
-              "icon": "discord"
-            }
-          ]
-        }
       }
     ]
   },


### PR DESCRIPTION
## Summary

This is a navigation-only preview of a use-case-first Base docs IA for team review. It updates `docs/docs.json` so the visible top-level tabs are:

- Get Started
- Trading
- Payments
- Protocol
- SDKs
- APIs

No `.mdx` files are moved, renamed, edited, or deleted, and no redirects are added.

<img width="1476" height="749" alt="Screenshot 2026-07-13 at 18 54 02" src="https://github.com/user-attachments/assets/e50411bd-ae04-450f-a24b-0b087413540c" />


## IA notes

- Dissolves the previous Apps tab into use-case buckets.
- Removes Agents as a top-level tab while keeping the files on disk and direct URLs intact.
- Surfaces `agents/guides/x402-payments` under Payments because x402 is a payments use case.
- Cross-lists Ledgers pages under both Trading and Payments.
- Cross-lists the shared Build group under both Trading and Payments:
  - Sign in with Base
  - Basenames
  - Wallet UX
  - Sponsor gas (Paymaster)
  - Builder Codes
- Splits reference into SDKs for importable client libraries and APIs for HTTP/RPC endpoints.

## Verification

- `npx mintlify dev --port 3004`
  - Preview started successfully.
  - No missing navigation page warnings after the final nav update.
- `npx mintlify broken-links`
  - Command exited 0.
  - It still reports 43 existing broken links under `AGENTS.md` and `agents/skills/*`; none are from the new navigation paths.
- Custom JSON/path checks:
  - Only `navigation.tabs` changed outside formatting.
  - All nav page references resolve to existing `.mdx` files.
  - Agents tab is absent.
  - `agents/guides/x402-payments` appears under Payments.
  - Shared Build groups in Trading and Payments are identical.
  - Ledgers pages appear in both Trading and Payments.

## Open items before production

- Swaps has no standalone guide in the visible nav. The current swap guide lives under the now-hidden Agents section at `agents/guides/swap-tokens`; decide whether to author a general swaps guide or surface that page under Trading.
- Builder Codes and Paymaster/sponsor gas are cross-listed in both Trading and Payments per reviewer feedback; confirm this reads well or choose a primary home before production.
- `get-started/deploy-smart-contracts` and `apps/quickstart/deploy-on-base` are related but distinct, so both are kept under Get Started -> Build an app.
- Base MCP / Agents may leave this repo entirely; the hidden-but-present treatment is interim.
- The brief calls for `get-started/build-app` as the canonical Build an app quickstart, but this checkout does not contain `docs/get-started/build-app.mdx`. To keep Mintlify preview clean without moving files in this preview PR, the nav uses the existing `apps/quickstart/build-app` page. The production pass should add/move the canonical page and redirects as part of the URL cleanup.

## Follow-up

File moves, canonical URLs, and redirects are intentionally left for a later production pass.
