### PR TITLE
fix(docs): update stale "Future (~Fall 2025)" column header in migration guide

### DIFF
--- a/docs/base-account/guides/migration-guide.mdx
+++ b/docs/base-account/guides/migration-guide.mdx
@@ -15,7 +15,7 @@ Driving this change is a transition of our mobile app: the Coinbase Wallet app i
 
 Below is a table of existing users and how they will connect to apps now and in the future:
 
-| User Type | Today | Future (~Fall 2025) |
+| User Type | Today | Current |
 |-----------|-------|---------------------|
 | Smart Wallet users (web and mobile app) | Automatically have a Base Account, can use "Sign in with Base" | No change |
 | New Base app users | Automatically have a Base Account, can use "Sign in with Base" | No change |


### PR DESCRIPTION
## Summary

Closes #1315

The migration guide table header at `docs/base-account/guides/migration-guide.mdx:18` referenced "Future (~Fall 2025)" which has already passed (we are now in mid-2026). The header was misleading readers about the migration timeline.

Updated the column header from `Future (~Fall 2025)` to `Current` to reflect the actual present-day state of the migration.

---

## Diff

| Before | After |
|---|---|
| `\| User Type \| Today \| Future (~Fall 2025) \|` | `\| User Type \| Today \| Current \|` |

---

## Verification

- Read `docs/base-account/guides/migration-guide.mdx` in full to ensure the change is self-contained (only the header row was touched).
- The "Today" / "Current" semantics now match: both columns describe the current state, as the originally future-projected Fall 2025 deadline has passed.

---

## Checklist

- [x] Documentation-only change (no code, no config, no images)
- [x] Verified no other references to "Fall 2025" in the same file
- [x] `git diff --stat` shows 1 file, +1/-1

---

## Risk & Impact

**None.** Single-line documentation header fix. No code, config, or behavior changes.

**Type:** 📝 Documentation
**Closes:** #1315