### PR TITLE
fix(docs): remove .mdx extension from signInWithEthereum link in wallet_connect

### DIFF
--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 


### PR DESCRIPTION
## Summary

Closes #1311

The internal link at `docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx:193` included a `.mdx` file extension which caused the rendered Mintlify docs site to return 404 when clicked. Mintlify resolves bare paths to their target pages automatically — the extension is not required and trips the URL.

Removed the trailing `.mdx` from the `signInWithEthereum` link target.

---

## Verification

- `grep -n signInWithEthereum` on the file shows only line 193 holds an `/.../signInWithEthereum.mdx` style link — the rest are code-block references, `ParamField` definitions, or JSON examples that don't carry the `.mdx` extension.
- Reproduced from the report: the live docs site 404s on `…/signInWithEthereum.mdx` and returns 200 on `…/signInWithEthereum` (no extension).
- Mintlify docs.site/build/config behavior: extensionless routes are the canonical form for internal cross-references.

---

## Checklist

- [x] Documentation-only change (no code, no config, no images)
- [x] Single-line, scoped fix — no other surfaces touched
- [x] `git diff --stat` shows 1 file, +1/-1
- [ ] Pre-merge: verify the link resolves on `https://docs.base.org/base-account/reference/core/provider-rpc-methods/wallet_connect` (Mintlify preview build)

---

## Risk & Impact

**None.** Single-line documentation link fix. No code, config, or behavior changes.

**Type:** 📝 Documentation
**Closes:** #1311