### PR TITLE
docs(node-providers): reference OpenChainBench for live Base RPC latency

### DIFF
--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -5,6 +5,10 @@ description: Documentation for Node Providers for the Base network. Including de
 
 import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 
+<Tip>
+For a live latency comparison of Base public no-key RPC endpoints, see the [OpenChainBench Base RPC benchmark](https://openchainbench.com/benchmarks/base-rpc). Endpoints are probed from three regions every minute with p50, p95 and p99 latency published under an open methodology.
+</Tip>
+
 ## Coinbase Developer Platform (CDP)
 
 [CDP](https://portal.cdp.coinbase.com/) provides an RPC endpoint that runs on the same node infrastructure that powers Coinbase's retail exchange, meaning you get the rock solid reliability of our retail exchange as a developer. CDP gives you a free, rate limited RPC endpoint to begin building on Base.


### PR DESCRIPTION
## Summary

Adds a short `<Tip>` block at the top of `docs/base-chain/node-operators/node-providers.mdx` pointing readers to the [OpenChainBench Base RPC benchmark](https://openchainbench.com/benchmarks/base-rpc) for a live third-party latency view of the public no-key endpoints.

## Why

The Node Providers page lists every provider self describing their performance. Developers picking an endpoint currently have no neutral datapoint. OpenChainBench probes the public Base endpoints from three regions every minute and publishes p50, p95 and p99 latency under an open methodology. Data license is CC BY 4.0.

- Live Base benchmark: https://openchainbench.com/benchmarks/base-rpc
- Methodology: https://openchainbench.com/methodology
- No affiliation with Coinbase or the Base team

Happy to reword, move to a different section, or drop if this does not fit the docs' tone.

## Test plan

- [x] Uses the existing `<Tip>` component (Mintlify) to match surrounding docs style
- [x] Placed above the first provider heading so readers see it before scrolling
- [x] External link verified