### PR TITLE
fix(docs): warn that client-side SIWE nonce provides no replay protection

### DIFF
--- a/docs/apps/guides/migrate-to-standard-web-app.mdx
+++ b/docs/apps/guides/migrate-to-standard-web-app.mdx
@@ -99,6 +99,10 @@ Your app uses the Farcaster SDK. The migration replaces Farcaster-specific auth,
 <Step title="Replace auth and identity">
   Farcaster sign-in and FID-based identity are not available in the Base App. Replace them with [SIWE](https://viem.sh/docs/siwe/utilities/createSiweMessage) for authentication and the connected wallet address for user identity.
 
+  <Warning>
+  The example below generates the SIWE nonce in the browser with `generateSiweNonce()`. A client-issued nonce provides **no replay protection**: any attacker who captures a valid SIWE message + signature pair can replay it against your server, because the server has no record of which nonces it issued. Only use this pattern if your app does not require server-side sessions or replay protection. For verified, server-issued nonces, follow the [Authenticate users](/base-account/guides/authenticate-users) guide and confirm nonces server-side before accepting the SIWE message.
+  </Warning>
+
   Build, sign, and verify the SIWE message:
 
   ```tsx SignIn.tsx lines expandable wrap highlight={1,9,14-18,33-34}


### PR DESCRIPTION
## Summary

Fixes #1452

Adds a prominent `<Warning>` block above the SIWE code example in the "Replace auth and identity" step of the Base App migration guide. The example generates the SIWE nonce with `generateSiweNonce()` in the browser; a client-issued nonce provides no replay protection — any attacker who captures a valid message + signature pair can replay it against the server because the server has no record of which nonces it issued.

The new warning explicitly:
- Names the security limitation (no replay protection)
- Explains the attack model (capture + replay)
- Clarifies when the pattern is acceptable (apps without server-side sessions)
- Points developers at the Authenticate users guide's server-issued nonce pattern

The existing `<Note>` disclaimer that sits closer to the code example is kept for context but is easier to miss — the new `<Warning>` immediately above the example is harder to overlook.

---

## Changes

**`docs/apps/guides/migrate-to-standard-web-app.mdx`** (Step "Replace auth and identity", before the SIWE code example)
- Added a 4-line `<Warning>` block calling out the replay protection gap.

---

## How to Test

1. Checkout the branch.
2. Open `docs/apps/guides/migrate-to-standard-web-app.mdx` and navigate to the "Replace auth and identity" step.
3. Confirm the rendered guide shows the `<Warning>` directly above the SIWE code snippet.
4. The warning text should match the issue description: explain client-side nonce + replay attack model + link to `/base-account/guides/authenticate-users`.

---

## Checklist

- [x] Follows Contributing Guide and Conventional Commits
- [x] No duplicate PRs — searched existing
- [x] Changes scoped to this fix only
- [x] Tested on docs/base chain preview
- [x] No config keys changed
- [x] No architecture changes
- [x] Cross-platform impact: docs only

---

## Risk & Impact

**None.** Documentation-only addition of a warning block. No code, config, or behavior changes.

**Type:** 🐛 Bug fix / 📝 Documentation update
**Fixes:** #1452