### PR TITLE
fix(docs): drop .mdx suffix from signInWithEthereum link

### DIFF
--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_connect.mdx
@@ -190,7 +190,7 @@ When using the `signInWithEthereum` capability, always generate a fresh, unique 
 
 ## Usage with Capabilities
 
-You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum.mdx) capability to authenticate the user.
+You can use the `wallet_connect` with the [`signInWithEthereum`](/base-account/reference/core/capabilities/signInWithEthereum) capability to authenticate the user.
 
 import PolicyBanner from "/snippets/PolicyBanner.mdx";
 


### PR DESCRIPTION
The link in the "Usage with Capabilities" section of `wallet_connect.mdx` points at `/base-account/reference/core/capabilities/signInWithEthereum.mdx`, which 404s on the live site — matches issue #685.

Checked the rest of the repo: every other internal link (415 of them, including two others on this exact same target page, `capabilities/overview.mdx`) omits the `.mdx` suffix. This was the only one that had it.

Fix: drop the `.mdx` suffix so it matches the working convention used everywhere else.

Closes #685