### PR TITLE
docs: remove b20-playground from nav (page stays live)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -102,8 +102,7 @@
             "group": "Beryl Upgrade",
             "tag": "New",
             "pages": [
-              "base-chain/specs/upgrades/beryl/overview",
-              "base-chain/specs/upgrades/beryl/b20-playground"
+              "base-chain/specs/upgrades/beryl/overview"
             ]
           },
           {


### PR DESCRIPTION
**What changed? Why?**

Removed the `base-chain/specs/upgrades/beryl/b20-playground` entry from the "Beryl Upgrade" navigation group in `docs/docs.json`. The page file is untouched, so the URL `https://docs.base.org/base-chain/specs/upgrades/beryl/b20-playground` stays live and directly accessible — it's just no longer surfaced in the sidebar.

The Beryl overview page (`base-chain/specs/upgrades/beryl/overview`) remains in the nav.

**Notes to reviewers**

No redirect needed since the page still exists — only its nav visibility changed.

**How has it been tested?**

Verified the nav diff: only the `b20-playground` line was removed; the `overview` entry is retained.

Generated with Claude Code