### PR TITLE
docs: add Codex to data indexers page

### DIFF
--- a/docs/get-started/data-indexers.mdx
+++ b/docs/get-started/data-indexers.mdx
@@ -31,6 +31,23 @@ References:
 
 
 
+## Codex
+
+The [Codex Data API](https://www.codex.io) is a real-time blockchain data API for building trading apps, token screeners, and portfolio trackers. Codex indexes token prices, OHLCV charts, DEX pairs and trades, liquidity, holders, and wallet balances across [80+ networks](https://docs.codex.io/networks), including Base. Codex also indexes Base's native [B20 tokens](/base-chain/specs/upgrades/beryl/b20), identifying them as B20 and tracking their multiplier, supply cap, and paused status.
+
+Data is served through a single GraphQL API, with WebSocket subscriptions for streaming live prices, charts, and trades, and webhooks for event notifications. An official [TypeScript SDK](https://docs.codex.io/sdk) is available, and any [GraphQL](https://docs.codex.io/learn-graphql) client can query the API directly.
+
+To get started, [sign up](https://dashboard.codex.io/signup) to create an API key, then visit the [documentation](https://docs.codex.io) or follow the [getting started guide](https://docs.codex.io/get-started).
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+- Base Sepolia (Testnet)
+
+See [all supported networks](https://docs.codex.io/networks).
+
+
+
 ## Covalent
 
 [Covalent](https://www.covalenthq.com/?utm_source=base&utm_medium=partner-docs) is a hosted blockchain data solution providing access to historical and current on-chain data for [100+ supported blockchains](https://goldrush.dev/docs/chains), including [Base](https://goldrush.dev/docs/chains/base).


### PR DESCRIPTION
**What changed? Why?**

Adds Codex ([codex.io](https://www.codex.io)) to the data indexers page. Codex is a real-time blockchain data API (token prices, OHLCV charts, DEX trades, liquidity, holders, wallet balances) with Base Mainnet and Base Sepolia support, served over GraphQL with WebSocket subscriptions and webhooks. Codex also indexes B20 tokens, including their multiplier, supply cap, and paused status.

**Notes to reviewers**

The entry follows the existing page format (intro, get-started links, Supported Networks list) and is inserted in alphabetical order. All links point to codex.io, docs.codex.io, or dashboard.codex.io, plus one internal link to the B20 spec page.

**How has it been tested?**

Previewed locally with `mintlify dev` and verified all links resolve.
