### PR TITLE
Remove demo link from verify-onchain guide

### DIFF
--- a/docs/apps/guides/verify-onchain.mdx
+++ b/docs/apps/guides/verify-onchain.mdx
@@ -8,8 +8,7 @@ description: "Enforce Sybil resistance and policy gating inside any Base contrac
 **Base Verify Onchain lets your smart contract enforce "one real person, once" and gate on real-world traits, like an active Coinbase One membership. The check runs in your contract, so you don't run a verification backend.** Base Verify signs a short-lived verification your contract checks in the same transaction as a claim, deposit, or vote.
 
 <Tip>
-  Live on Base Sepolia! Try the
-  [demo](https://base-verify-onchain-demo.vercel.app/). Please [reach
+  Live on Base Sepolia! Please [reach
   out](https://forms.gle/WTcuWyKkvUV6gGik6) if you have use cases in mind!
 </Tip>
 


### PR DESCRIPTION
## Summary
- Removes the "Try the demo" link (`base-verify-onchain-demo.vercel.app`) and its mention from the Base Verify Onchain guide
- Keeps the "Live on Base Sepolia" tip and the interest-form CTA intact
- Confirmed no other references to this demo link exist elsewhere in the docs repo

## Test plan
- [x] Ran `/lint` on the changed file — no errors or warnings
- [x] Verified diff is minimal and scoped to the demo link removal