### PR TITLE
fix(docs): close 3 doc gaps from #1730

### DIFF
--- a/docs/base-account/reference/core/capabilities/datacallback.mdx
+++ b/docs/base-account/reference/core/capabilities/datacallback.mdx
@@ -211,7 +211,7 @@ export async function POST(request: Request) {
   const requestData = await request.json();
 
   try {
-    const { requestedInfo } = requestData.capabilities.dataCallback;
+    const { requestedInfo } = requestData;
     const errors = {};
 
     // Validate email

--- a/docs/base-account/reference/core/provider-rpc-methods/wallet_sendCalls.mdx
+++ b/docs/base-account/reference/core/provider-rpc-methods/wallet_sendCalls.mdx
@@ -9,6 +9,10 @@ Defined in [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792)
 Requests that the wallet submits a batch of calls. This method allows applications to send multiple transactions atomically or sequentially.
 </Info>
 
+<Tip>
+`wallet_sendCalls` submits transactions through Base Account, which uses ERC-4337 smart account infrastructure. Expect higher gas usage than a traditional EOA transfer. For rough estimates, see the [Gas Usage](/base-account/more/troubleshooting/usage-details/gas-usage) guide.
+</Tip>
+
 ## Parameters
 
 <ParamField body="version" type="string" required>

--- a/docs/base-account/reference/prolink-utilities/decodeProlink.mdx
+++ b/docs/base-account/reference/prolink-utilities/decodeProlink.mdx
@@ -107,11 +107,19 @@ async function validateAndExecuteProlink(
         throw new Error(`Unauthorized contract: ${call.to}`);
       }
     }
-    
+
+    // Inject the connected account as the sender if missing.
+    // Prolinks are encoded without a known opener, so `from` is often absent.
+    const { accounts } = await provider.request({ method: 'wallet_connect', params: [] });
+    const sender = accounts?.[0];
+    if (sender && !params.from) {
+      params = { ...params, from: sender };
+    }
+
     // Execute the request
     const result = await provider.request({
       method: decoded.method,
-      params: decoded.params
+      params: [params]
     });
     
     console.log('Transaction result:', result);

--- a/docs/get-started/get-funded.mdx
+++ b/docs/get-started/get-funded.mdx
@@ -8,8 +8,8 @@ description: "The Base ecosystem offers multiple funding pathways designed speci
 Whether you're just starting to experiment or ready to become a full-time founder, Base provides structured funding opportunities that grow with your ambitions. Each pathway is designed for different stages of your builder journey, with clear progression paths between programs.
 
 <CardGroup cols={2}>
-<Card title="Weekly Rewards" icon="calendar" href="#weekly-rewards%3A-start-building-today">
-  2 ETH in weekly rewards for prototypes and experiments through Talent Protocol.
+<Card title="Weekly Rewards" icon="calendar">
+  This program has ended.
 </Card>
 
 <Card title="Builder Grants" icon="bolt" href="#builder-grants%3A-live-on-base">
@@ -55,9 +55,9 @@ Whether you're just starting to experiment or ready to become a full-time founde
 
 ## Weekly Rewards: Start Building Today
 
-The Builder Rewards Program distributes 2 ETH weekly to active builders—perfect for experimentation and learning.
-
-[Join Builder Rewards Program](https://www.builderscore.xyz/)
+<Warning>
+The Builder Rewards Program through Talent Protocol has ended. The builderscore.xyz page no longer shows an active Base campaign.
+</Warning>
 
 ### How It Works
 1. Build anything on Base (prototypes welcome)


### PR DESCRIPTION
Closes #1730.

- Fix `dataCallback` example to read `requestedInfo` from top-level body.
- Add `from` injection in `decodeProlink` example.
- Add gas note on `wallet_sendCalls`.