### PR TITLE
docs(get-funded): mark Weekly Rewards as ended

### DIFF
--- a/docs/get-started/get-funded.mdx
+++ b/docs/get-started/get-funded.mdx
@@ -8,8 +8,8 @@ description: "The Base ecosystem offers multiple funding pathways designed speci
 Whether you're just starting to experiment or ready to become a full-time founder, Base provides structured funding opportunities that grow with your ambitions. Each pathway is designed for different stages of your builder journey, with clear progression paths between programs.
 
 <CardGroup cols={2}>
-<Card title="Weekly Rewards" icon="calendar" href="#weekly-rewards%3A-start-building-today">
-  2 ETH in weekly rewards for prototypes and experiments through Talent Protocol.
+<Card title="Weekly Rewards" icon="calendar">
+  This program has ended.
 </Card>
 
 <Card title="Builder Grants" icon="bolt" href="#builder-grants%3A-live-on-base">
@@ -55,9 +55,9 @@ Whether you're just starting to experiment or ready to become a full-time founde
 
 ## Weekly Rewards: Start Building Today
 
-The Builder Rewards Program distributes 2 ETH weekly to active builders—perfect for experimentation and learning.
-
-[Join Builder Rewards Program](https://www.builderscore.xyz/)
+<Warning>
+The Builder Rewards Program through Talent Protocol has ended. The builderscore.xyz page no longer shows an active Base campaign.
+</Warning>
 
 ### How It Works
 1. Build anything on Base (prototypes welcome)


### PR DESCRIPTION
Closes #1723.

Update docs/get-started/get-funded.mdx to reflect that the Builder Rewards Program / Weekly Rewards pathway through Talent Protocol has ended.