### PR TITLE
fix(docs): warn that client-side SIWE nonce provides no replay protection

### DIFF
--- a/docs/apps/guides/migrate-to-standard-web-app.mdx
+++ b/docs/apps/guides/migrate-to-standard-web-app.mdx
@@ -101,6 +101,12 @@ Your app uses the Farcaster SDK. The migration replaces Farcaster-specific auth,
 
   Build, sign, and verify the SIWE message:
 
+  <Warning>
+  The example below generates the SIWE nonce client-side with `generateSiweNonce()`. A client-issued nonce provides **no replay protection**: an attacker who captures a valid message and signature pair can replay it against your server because the server has no record of which nonces it issued.
+
+  If your app uses server-side sessions, use the [Authenticate users](/base-account/guides/authenticate-users) pattern with a server-issued nonce and backend verification instead.
+  </Warning>
+
   ```tsx SignIn.tsx lines expandable wrap highlight={1,9,14-18,33-34}
   'use client';
 


### PR DESCRIPTION
Closes #1722.

Adds a Warning block above the SIWE example in the Base App migration guide explaining that client-side generated nonces provide no replay protection and pointing to the server-issued nonce pattern.