### PR TITLE
docs(basenames): remove deprecated Onchain Registry mention

### DIFF
--- a/docs/base-account/basenames/basenames-faq.mdx
+++ b/docs/base-account/basenames/basenames-faq.mdx
@@ -50,7 +50,7 @@ There is no limit to registration length, but there is a minimum of 1 year.
 
 ### 7. How can I use my Basename?
 
-You can use your Basename across apps in the Base ecosystem, starting with base.org, Onchain Registry, and Onchain Summer Pass. You can also use it for sending and receiving on Base and other EVM chains.
+You can use your Basename across apps in the Base ecosystem, starting with base.org and Onchain Summer Pass. You can also use it for sending and receiving on Base and other EVM chains.
 
 ### 8. Is my profile information published onchain?
 


### PR DESCRIPTION
Fixes #1745. The Basenames FAQ currently mentions `Onchain Registry` as an active ecosystem app, but that section/link is no longer available. This removes the stale reference so the docs no longer point users to a dead pathway.

Changes:
- `docs/base-account/basenames/basenames-faq.mdx`: remove `Onchain Registry` from the supported apps list in the Basenames usage FAQ.