### PR TITLE
docs(quickstart): fix broken payment example in web quickstart

### DIFF
--- a/docs/base-account/quickstart/web.mdx
+++ b/docs/base-account/quickstart/web.mdx
@@ -158,23 +158,23 @@ This guide uses the CDN approach for simplicity.
         }
       };
 
-      // One-tap USDC payment using window.base API (works with or without sign-in)
+      // One-tap USDC payment using the pay() function
       document.getElementById("pay").onclick = async () => {
         try {
           showStatus("Processing payment...", "success");
 
-          const result = await window.base.pay({
+          const { id } = await pay({
             amount: "5.00", // USD – SDK quotes equivalent USDC
             to: "0x2211d1D0020DAEA8039E46Cf1367962070d77DA9",
             testnet: true, // set to false or omit for Mainnet
           });
 
-          const status = await window.base.getPaymentStatus({
-            id: result.id,
+          const { status } = await getPaymentStatus({
+            id,
             testnet: true,
           });
 
-          showStatus(`🎉 Payment completed! Status: ${status.status}`);
+          showStatus(`🎉 Payment completed! Status: ${status}`);
         } catch (error) {
           showStatus(`❌ Payment failed: ${error.message}`, "error");
         }


### PR DESCRIPTION
- Replace non-working window.base.pay/getPaymentStatus with SDK pay()/getPaymentStatus
- Remove undefined result.id usage; destructure id from pay() result
- Align CDN quickstart with actual @base-org/account API surface
- Closes #1758

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
