### PR TITLE
Add Base Verify Onchain demo link

### DIFF
--- a/docs/apps/guides/verify-onchain.mdx
+++ b/docs/apps/guides/verify-onchain.mdx
@@ -8,8 +8,8 @@ description: "Enforce Sybil resistance and policy gating inside any Base contrac
 **Base Verify Onchain lets your smart contract enforce "one real person, once" and gate on real-world traits, like an active Coinbase One membership. The check runs in your contract, so you don't run a verification backend.** Base Verify signs a short-lived verification your contract checks in the same transaction as a claim, deposit, or vote.
 
 <Tip>
-  Live on Base Sepolia! Please [reach
-  out](https://forms.gle/WTcuWyKkvUV6gGik6) if you have use cases in mind!
+  Live on Base Sepolia! Try the [demo](https://verify.base.dev/onchain-demo), or [reach
+  out](https://forms.gle/WTcuWyKkvUV6gGik6) if you have use cases in mind.
 </Tip>
 
 Integration is three steps:


### PR DESCRIPTION
## Summary
Add a link to the hosted Base Verify Onchain demo from the Apps guide so developers can try the flow directly.

## What changed
- Updated the Verify Users Onchain guide tip to link to https://verify.base.dev/onchain-demo

## Test plan
- [x] Confirmed the docs diff only updates the demo link copy

Linear: N/A

type=routine
risk=low
impact=sev5
backwards_compatible=true
automerge=false