### PR TITLE
Document RPC Fast as a supported RPC provider

### DIFF
--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -154,6 +154,14 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 
 - Base Mainnet
 
+## RPC Fast
+
+[RPC Fast](https://rpcfast.com) is a blockchain RPC platform developed by [Dysnix](https://dysnix.com), an infrastructure provider with an extensive experience of backend operations support for major Web3 players since 2018. RPC Fast offers Base mainnet RPC along with ETH, and a few other blockchains. Grab your [free Base RPC plan](https://control.rpcfast.com/) to start exploring.
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+
 ## Stackup
 
 [Stackup](https://www.stackup.sh/) is a leading ERC-4337 infrastructure platform. You can access hosted Base nodes with built-in [account abstraction tools](https://docs.stackup.sh/docs) like bundlers and paymasters.


### PR DESCRIPTION
**What changed? Why?**

Added RPC Fast to the Base node provider directory.

RPC Fast is an RPC SaaS provider that offers Base Mainnet RPC along with ETH, and a few other networks.

RPC Fast is a product by Dysnix, an infrastructure provider. Since 2018, Dysnix has been supporting backend operations for major players, like zkSync, Polygon, GCP, Nansen, Kolibrio, PancakeSwap, and others. More about us here: https://dysnix.com.

- Website: https://rpcfast.com
- Documentation: https://docs.rpcfast.com/rpc-fast-saas-evm/introduction

**Notes to reviewers**

This pull request only adds RPC Fast provider to documentation. No other changes is present in this PR.

**How has it been tested?**

- Verified Base Mainnet RPC availability against the dashboard https://control.rpcfast.com