### PR TITLE
docs(node-operators): mention basectl and link to its GitHub docs

### DIFF
--- a/docs/base-chain/node-operators/run-a-base-node.mdx
+++ b/docs/base-chain/node-operators/run-a-base-node.mdx
@@ -103,6 +103,10 @@ echo Latest synced block behind by: $((($(date +%s)-$( \
 
 You'll also know that the sync hasn't completed if you get `Error: nonce has already been used` if you try to deploy using your node.
 
+<Tip>
+For richer node data and diagnostic checks, use [`basectl`](https://github.com/base/base/tree/main/bin/basectl), the Base node operator CLI.
+</Tip>
+
 ---
 
 ## Enable Flashblocks


### PR DESCRIPTION
**What changed? Why?**

Adds a short mention of `basectl` (the Base node operator CLI) to the **Run a Base node** page, with a link out to its README in `base/base`. Keeps the detailed command reference in GitHub.

**Notes to reviewers**

- Single-file change (`docs/base-chain/node-operators/run-a-base-node.mdx`);

**How has it been tested?**

- `node scripts/lint-mdx.js docs/base-chain/node-operators/run-a-base-node.mdx` — 0 warnings
- Previewed locally with `cd docs && npx mint dev`.
