### PR TITLE
fix: correct broken EIP-8130 links in beryl overview

### DIFF
--- a/docs/base-chain/specs/upgrades/beryl/overview.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/overview.mdx
@@ -8,7 +8,7 @@ description: "Overview of the Beryl hardfork, introducing the B20 native token s
 - Introduce [B20](/base-chain/specs/upgrades/beryl/b20): Base's native token standard for stablecoin, real-world asset (RWA), and long-tail token issuers
 - Reduce the single-proof withdrawal finalization period from 7 days to 5 days for increased capital efficiency
 - Reth V2: up to 50% disk reduction and a rewritten state root pipeline delivering +33% throughput
-- Upcoming in a later Beryl phase: [native account abstraction (EIP-8130)](/base-chain/specs/upgrades/beryl/eip-8130), currently previewing on the vibenet devnet
+- Upcoming in a later Beryl phase: [native account abstraction (EIP-8130)](/base-chain/specs/upgrades/cobalt/eip-8130), currently previewing on the vibenet devnet
 
 ## Activation Timestamps
 
@@ -45,7 +45,7 @@ B20 is Base's native token standard - ERC-20 compatible tokens implemented as Ru
 
 A later Beryl phase brings account abstraction into the protocol. Accounts configure authorized actors and signature validation onchain. Apps get portable smart accounts, scoped session keys, atomic batching, and native gas sponsorship without bundler or relay infrastructure. EIP-8130 is experimental and currently runs only on the vibenet devnet.
 
-- [Native Account Abstraction (EIP-8130)](/base-chain/specs/upgrades/beryl/eip-8130)
+- [Native Account Abstraction (EIP-8130)](/base-chain/specs/upgrades/cobalt/eip-8130)
 
 ## Withdrawals
 


### PR DESCRIPTION
Closes #1781

## Problem
`docs/base-chain/specs/upgrades/beryl/overview.mdx` had two links pointing to `/base-chain/specs/upgrades/beryl/eip-8130`, which doesn't exist. The EIP-8130 page actually lives under `cobalt`.

## Fix
Updated both links to point to `/base-chain/specs/upgrades/cobalt/eip-8130`, the correct existing path.

## Verification
Ran `node scripts/lint-mdx.js docs/base-chain/specs/upgrades/beryl/overview.mdx` before and after — the "Possibly broken internal link" warning is resolved, 0 errors/warnings after the fix.