### PR TITLE
fix: correct broken redirect destinations for basenames wagmi guide and apps quickstart

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1271,151 +1271,151 @@
     },
     {
       "source": "/onchainkit/identity/identity",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/address",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/avatar",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/badge",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/identity-card",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/name",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/socials",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/get-address",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/get-attestations",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/get-avatar",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/get-avatars",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/get-name",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/get-names",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/use-address",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/use-avatar",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/use-avatars",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/use-name",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/use-names",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/identity/types",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/components/identity/identity",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/components/identity/address",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/components/identity/avatar",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/components/identity/badge",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/components/identity/identity-card",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/components/identity/name",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/components/identity/socials",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/utilities/identity/get-address",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/utilities/identity/get-attestations",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/utilities/identity/get-avatar",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/utilities/identity/get-avatars",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/utilities/identity/get-name",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/utilities/identity/get-names",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/hooks/identity/use-address",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/hooks/identity/use-avatar",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/hooks/identity/use-avatars",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/hooks/identity/use-name",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/latest/hooks/identity/use-names",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/onchainkit/checkout/checkout",
@@ -1867,11 +1867,11 @@
     },
     {
       "source": "/basenames/basenames-onchainkit-tutorial",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/identity/basenames/basenames-onchainkit-tutorial",
-      "destination": "/base-account/basenames/basenames-wagmi-tutorial"
+      "destination": "/base-account/framework-integrations/wagmi/basenames"
     },
     {
       "source": "/base-chain/quickstart/bridge-token",
@@ -1955,7 +1955,7 @@
     },
     {
       "source": "/mini-apps/overview",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/features/wallet",
@@ -2315,27 +2315,27 @@
     },
     {
       "source": "/cookbook/growth/cast-actions",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/deploy-to-vercel",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/email-campaigns",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/gating-and-redirects",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/hyperframes",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/growth/retaining-users",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/payments/build-ecommerce-app",
@@ -2347,19 +2347,19 @@
     },
     {
       "source": "/cookbook/social/convert-farcaster-frame",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/social/farcaster-nft-minting-guide",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/social/farcaster-no-code-nft-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/cast-actions",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/commerce/build-an-ecommerce-app",
@@ -2367,35 +2367,35 @@
     },
     {
       "source": "/cookbook/use-case-guides/create-email-campaigns",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/creator/convert-farcaster-frame-to-open-frame",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/deploy-to-vercel",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/gating-and-redirects",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/hyperframes",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/nft-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/no-code-minting",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/retaining-users",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/use-case-guides/transactions",
@@ -2807,7 +2807,7 @@
     },
     {
       "source": "/use-cases/decentralize-social-app",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/use-cases/defi-your-app",
@@ -2855,11 +2855,11 @@
     },
     {
       "source": "/base-app/introduction/what-are-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/introduction/why-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/overview",
@@ -2879,11 +2879,11 @@
     },
     {
       "source": "/base-app/miniapps/quickstart",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/build-with-minikit/quickstart",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/existing-apps/:slug*",
@@ -2895,15 +2895,15 @@
     },
     {
       "source": "/mini-apps/quickstart/new-apps/:slug*",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/build-with-minikit/mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/base-app/miniapps/search-and-discovery",
@@ -2963,15 +2963,15 @@
     },
     {
       "source": "/mini-apps/quickstart/new-apps/install",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/new-apps/deploy",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/quickstart/new-apps/create-manifest",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/design-ux/:slug*",
@@ -3067,7 +3067,7 @@
     },
     {
       "source": "/cookbook/onchain-social",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/defi-your-app",
@@ -3095,11 +3095,11 @@
     },
     {
       "source": "/cookbook/introduction-to-mini-apps",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/ai-powered-development-fundamentals",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/mastering-ai-prompt-engineering",
@@ -3107,7 +3107,7 @@
     },
     {
       "source": "/cookbook/essential-documentation-resources",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/ai-assisted-documentation-reading",
@@ -3119,7 +3119,7 @@
     },
     {
       "source": "/cookbook/minikit/build-your-mini-app-with-prompt",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/cookbook/converting-customizing-mini-apps",
@@ -3219,7 +3219,7 @@
     },
     {
       "source": "/mini-apps/quickstart/create-new-miniapp",
-      "destination": "/apps/quickstart/create-new-app"
+      "destination": "/apps/quickstart/build-app"
     },
     {
       "source": "/mini-apps/growth/build-viral-mini-apps",


### PR DESCRIPTION
Partially addresses #1783

## Problem
Two groups of redirects in `docs.json` pointed to pages that no longer exist:
- 39 redirects → `/base-account/basenames/basenames-wagmi-tutorial` (doesn't exist)
- 36 redirects → `/apps/quickstart/create-new-app` (doesn't exist)

## Fix
- Updated the 39 redirects to point to `/base-account/framework-integrations/wagmi/basenames`, the actual wagmi + basenames guide (verified by content match: title, description, and body all reference wagmi/viem basenames setup).
- Updated the 36 redirects to point to `/apps/quickstart/build-app`, the current quickstart page for creating a new app (verified against `docs.json` navigation, since `apps/quickstart/` only contains `build-app.mdx` and `deploy-on-base.mdx`).

## Scope
This fixes the 2 highest-impact broken destination groups (75 of ~270 broken redirect entries found in the audit). The remaining ~105 unique broken destinations are documented in #1783, since several of them (particularly `/onchainkit/*` and `/smart-wallet/*` legacy paths) may point to content intentionally moved out of this repo, and guessing at destinations for those risks introducing new incorrect redirects. Happy to open follow-up PRs once destinations are confirmed.

## Verification
- `docs.json` validated as parseable JSON after the change
- Confirmed via file-tree cross-check that both new destinations exist and match the semantic intent of the original (now-broken) destination
- `node scripts/lint-mdx.js all` run — no new errors introduced (this script doesn't check `docs.json` redirects, so the broken-redirect count itself isn't reflected there)