### PR TITLE
docs: add SwiftNodes to Base node providers

### DIFF
--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -163,6 +163,14 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 - Base Mainnet
 - Base Sepolia (Testnet)
 
+## SwiftNodes
+
+[SwiftNodes](https://swiftnodes.io/base-rpc) is a multi-chain RPC provider offering low-latency HTTP and WebSocket access to Base, with free and paid plans under a single API key.
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+
 ## SubQuery
 
 [SubQuery](https://subquery.network/rpc) is a globally distributed, decentralized network of RPC nodes, offering generous free public endpoints and higher access through Flex Plans


### PR DESCRIPTION
### Summary

Adds **SwiftNodes** to the Base node providers list.

SwiftNodes is a multi-chain RPC provider offering low-latency HTTP and WebSocket access to Base Mainnet (chain ID 8453) under a single API key, with free and paid plans. The entry is inserted alphabetically (between Stackup and SubQuery) and follows the existing `##` section + `<HeaderNoToc>` + Supported Networks format. Only Base Mainnet is listed (we do not currently serve Base Sepolia).
