### PR TITLE
fix(docs): update EIP-8130 links in beryl/overview.mdx to point to co…

### DIFF
--- a/docs/base-chain/specs/upgrades/beryl/overview.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/overview.mdx
@@ -34,4 +34,12 @@ The single-proof dispute game finalization window is reduced from 7 days to 5 da
 B20 implements the ERC-20 specification, making it interoperable with all existing systems built on ERC-20 like wallets, exchanges, data indexers, and onchain protocols. What's different is how it runs. Rather than deploying a Solidity contract, B20 tokens execute as Rust precompiles inside the node.
 
 </Accordion>
+
+<Accordion title="Native Account Abstraction">
+
+**Base** · Specs
+
+Native account abstraction was moved to Cobalt: see [EIP-8130](/base-chain/specs/upgrades/cobalt/eip-8130).
+
+</Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
Fixes #1781.

Updates broken `/base-chain/specs/upgrades/beryl/eip-8130` links in `docs/base-chain/specs/upgrades/beryl/overview.mdx` to point to the active EIP-8130 specification page located at `/base-chain/specs/upgrades/cobalt/eip-8130`.

## Rationale
Prevents developers reading the Beryl hardfork specification overview from hitting 404 pages when clicking on EIP-8130 Native Account Abstraction documentation.