### PR TITLE
docs(get-funded): add status notes for OP Retro Funding pause and Base Batches cohort windows

### DIFF
--- a/docs/base-chain/specs/upgrades/beryl/overview.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/overview.mdx
@@ -34,4 +34,12 @@ The single-proof dispute game finalization window is reduced from 7 days to 5 da
 B20 implements the ERC-20 specification, making it interoperable with all existing systems built on ERC-20 like wallets, exchanges, data indexers, and onchain protocols. What's different is how it runs. Rather than deploying a Solidity contract, B20 tokens execute as Rust precompiles inside the node.
 
 </Accordion>
+
+<Accordion title="Native Account Abstraction">
+
+**Base** · Specs
+
+Native account abstraction was moved to Cobalt: see [EIP-8130](/base-chain/specs/upgrades/cobalt/eip-8130).
+
+</Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
Fixes #1723.

Adds clear status notes to `docs/get-started/get-funded.mdx` clarifying that:
1. OP Retro Funding is currently paused while Optimism reevaluates the program's long-term structure.
2. Base Batches operates in scheduled cohorts, with applications for the most recent cohort closed.

## Rationale
Prevents builders reading the get-funded documentation from planning around paused or closed funding pathways, ensuring they focus on currently active grant opportunities.