### PR TITLE
fix(lint-mdx): handle multi-line <img> tags in alt-attribute check

### DIFF
--- a/scripts/lint-mdx.js
+++ b/scripts/lint-mdx.js
@@ -327,13 +327,23 @@ function checkMintlifyComponents(content, filePath) {
       }
     }
 
-    // Check for img without alt
+    // Check for img without alt (img tag may span multiple lines)
     if (line.includes("<img") && !line.includes("alt=")) {
-      issues.push({
-        line: i + 1,
-        severity: "warning",
-        message: "<img> should have `alt` attribute",
-      });
+      let tagText = line;
+      let hasAlt = tagText.includes("alt=");
+      let k = i;
+      while (!hasAlt && !tagText.includes(">") && k < lines.length - 1) {
+        k++;
+        tagText += lines[k];
+        hasAlt = tagText.includes("alt=");
+      }
+      if (!hasAlt) {
+        issues.push({
+          line: i + 1,
+          severity: "warning",
+          message: "<img> should have `alt` attribute",
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #1792

## Problem
The alt-attribute check in scripts/lint-mdx.js only looked at the single line containing <img, so when an <img> tag's attributes were spread across multiple lines, a present alt= attribute on a later line was never seen, producing a false-positive warning.

## Fix
The check now accumulates lines starting at the <img> tag until the tag closes (or end of file) before checking for alt=, matching the multi-line lookback pattern already used by the adjacent Frame-wrapping check in the same function.

## Verification
- node scripts/lint-mdx.js all: warnings drop from 75 to 70 (exactly the 5 false positives fixed), errors unchanged at 1246
- Tested against a synthetic multi-line <img> with no alt: still correctly flagged
- Tested against a synthetic multi-line <img> with alt= on a later line: no longer flagged