### PR TITLE
fix(base-account): parse the SIWE nonce correctly and bind verification to the app domain

### DIFF
--- a/docs/base-account/guides/authenticate-users.mdx
+++ b/docs/base-account/guides/authenticate-users.mdx
@@ -147,12 +147,22 @@ try {
 ```ts Backend (Viem)
 import { createPublicClient, http } from 'viem';
 import { base } from 'viem/chains';
+import { verifySiweMessage } from 'viem/siwe';
+
+// The domain your app is served from. Anything signed for another
+// domain must not be accepted here.
+const APP_DOMAIN = 'yourapp.com';
 
 const client = createPublicClient({ chain: base, transport: http() });
 
 export async function verifySig(req, res) {
   const { address, message, signature } = req.body;
-  const valid = await client.verifyMessage({ address, message, signature });
+  const valid = await verifySiweMessage(client, {
+    address,
+    message,
+    signature,
+    domain: APP_DOMAIN,
+  });
   if (!valid) return res.status(401).json({ error: 'Invalid signature' });
   // create session / JWT
   res.json({ ok: true });
@@ -178,6 +188,14 @@ export async function verifySig(req, res) {
   regardless of where it originated.
 </Note>
 
+<Warning>
+  Always check the `domain` field of the signed message against your own domain.
+  A signature is valid for whichever domain it was signed for, so a signature a
+  user produced on another site is cryptographically valid on yours too.
+  `verifySiweMessage` performs this check when you pass `domain`; a bare
+  `verifyMessage` call does not, and accepts the signature.
+</Warning>
+
 ### Example Express Server
 
 ```ts title="server/auth.ts" expandable
@@ -185,12 +203,17 @@ import crypto from "crypto";
 import express from "express";
 import { createPublicClient, http } from "viem";
 import { base } from "viem/chains";
+import { parseSiweMessage, verifySiweMessage } from "viem/siwe";
 
 const app = express();
 app.use(express.json());
 
 // Simple in-memory nonce store (swap for Redis or DB in production)
 const nonces = new Set<string>();
+
+// The domain your app is served from. Anything signed for another
+// domain must not be accepted here.
+const APP_DOMAIN = "yourapp.com";
 
 app.get("/auth/nonce", (_, res) => {
   const nonce = crypto.randomBytes(16).toString("hex");
@@ -203,14 +226,19 @@ const client = createPublicClient({ chain: base, transport: http() });
 app.post("/auth/verify", async (req, res) => {
   const { address, message, signature } = req.body;
 
-  // 1. Check nonce hasn\'t been reused
-  const nonce = message.match(/at (\w{32})$/)?.[1];
+  // 1. Check this server issued the nonce and hasn't seen it before
+  const { nonce } = parseSiweMessage(message);
   if (!nonce || !nonces.delete(nonce)) {
     return res.status(400).json({ error: "Invalid or reused nonce" });
   }
 
-  // 2. Verify signature
-  const valid = await client.verifyMessage({ address, message, signature });
+  // 2. Verify the signature and bind it to your domain
+  const valid = await verifySiweMessage(client, {
+    address,
+    message,
+    signature,
+    domain: APP_DOMAIN,
+  });
   if (!valid) return res.status(401).json({ error: "Invalid signature" });
 
   // 3. Create session / JWT here


### PR DESCRIPTION
> **Correction (2026-08-11):** an earlier version of this description said issue #1502 had no PR. That was wrong — five PRs already target this file. I missed them because I listed open PRs with a limit that truncated before reaching May. The section at the bottom now sets out how this PR relates to them, and I'm happy to close this in favour of one of them.

The `Authenticate users` guide ships an Express example that rejects every valid login, and a verification step that accepts signatures a user produced on someone else's site. Both are in code a developer is meant to copy into a production auth endpoint.

## 1. The nonce is never extracted, so `/auth/verify` always returns 400

`docs/base-account/guides/authenticate-users.mdx:207` reads the nonce with:

```js
const nonce = message.match(/at (\w{32})$/)?.[1];
```

In an EIP-4361 message the nonce is on its own `Nonce: <value>` line and `Issued At:` comes after it, so nothing sits at the end of the string for `$` to anchor to. The match is always `null`, the guard below it fires, and the endpoint answers `400 Invalid or reused nonce` for a completely valid login.

Using the message format this repo documents at `docs/base-account/reference/core/capabilities/signInWithEthereum.mdx:128`:

```js
const message =
  "localhost:3000 wants you to sign in with your Ethereum account:\n" +
  "0x1234567890123456789012345678901234567890\n\n" +
  "Sign in with Ethereum to the app.\n\n" +
  "URI: http://localhost:3000\nVersion: 1\nChain ID: 8453\n" +
  "Nonce: abc123def456\nIssued At: 2024-01-15T10:30:00Z";

message.match(/at (\w{32})$/)?.[1];   // undefined  <- the guide
message.match(/Nonce: (\w+)/)?.[1];   // 'abc123def456'
```

Two other pages in this repo already read the nonce correctly — `signInWithEthereum.mdx:216` and `framework-integrations/privy/authentication.mdx:227` — so this guide was the only one reading it incorrectly. This PR uses viem's `parseSiweMessage` rather than another regex.

## 2. Verification is not bound to your domain

Both snippets verified with:

```js
const valid = await client.verifyMessage({ address, message, signature });
```

`verifyMessage` only answers "does this signature match this message". It never looks at the `domain` field, so a SIWE signature a user was asked to produce on `evil.com` verifies against your endpoint as well. EIP-4361 requires the relying party to check `domain` against its own host (issue #1502).

Swapped to `verifySiweMessage`, which validates `domain`, `nonce` and expiry before checking the signature. It still routes through `verifyHash` internally, so ERC-6492 and ERC-1271 signatures from not-yet-deployed Base Accounts keep verifying exactly as before — the guide's own note at line 62 stays accurate.

## Verification

I ran the proposed server code unmodified against a local node, signing real messages with viem:

| Case | Before | After |
|---|---|---|
| Legitimate login | `400 Invalid or reused nonce` | `200 { ok: true }` |
| Replay of the same signature | `400` | `400 Invalid or reused nonce` |
| Signature minted for `evil.com` | `200 { ok: true }` | `401 Invalid signature` |
| Nonce the server never issued | `400` | `400 Invalid or reused nonce` |

Row 1 is the functional bug, row 3 is the security one. Rows 2 and 4 confirm the existing replay protection still behaves.

## Relationship to the existing PRs on this file

Five PRs already touch this guide, all opened in May and all still unreviewed. For whoever triages this, here is what each actually changes, checked against viem 2.55.13:

| PR | Fixes the nonce regex | Adds domain binding | Note |
|---|---|---|---|
| #1503 | no | yes | Destructures `const { isValid } = await verifySiweMessage(...)`. That function returns a `boolean`, so `isValid` is `undefined` and the endpoint would answer 401 for every login. |
| #1542 | **yes** | yes | Closest to this PR. Moves `nonces.delete(nonce)` to after verification, so a nonce survives a failed attempt and two concurrent requests can both pass the `has()` check. |
| #1553 | no | yes | Manual `parseSiweMessage(...).domain` comparison; keeps `verifyMessage`. |
| #1559 | no | yes | Passes `nonce` to `verifySiweMessage`, but that `nonce` still comes from the broken regex. |
| #1560 | no | no | Separate issue (`Math.random()` nonces), no overlap. |

**#1542 covers the same two defects this PR does and is the older submission.** The differences here are that the nonce stays an atomic check-and-consume (`nonces.delete` as the guard, as in the current guide), the domain constant does not default to `localhost:3000`, and the behaviour is backed by the run above. If you would rather take #1542, this can be closed — the important thing is that one of them lands, because the guide is currently broken for every reader who copies it.

## Notes

- `node scripts/lint-mdx.js docs/base-account/guides/authenticate-users.mdx` reports the same 9 errors and 1 warning before and after this change — no new findings introduced.
- This deliberately does not touch the client-side nonce generation discussed in #1560, #1761 and #1722.
