### PR TITLE
fix generated AGENTS static section link

### DIFF
--- a/scripts/lib/docs-utils.js
+++ b/scripts/lib/docs-utils.js
@@ -31,7 +31,7 @@ const CONSTANTS = {
 
   skipDirs: [
     'node_modules', '.git', 'dist', 'build', 'coverage',
-    '.next', 'images', 'videos', 'logo', 'openapi', '.claude', 'snippets'
+    '.next', 'images', 'videos', 'logo', 'openapi', '.claude', 'snippets', 'static'
   ],
 
   extensions: ['.md', '.mdx'],


### PR DESCRIPTION
Closes #1806.

## What changed

- Added `static` to the generated docs skip list.
- Regenerated `docs/AGENTS.md` so it no longer links to `./static/llms.txt`.

## Why

`docs/static/` contains static assets, but the AGENTS generator was treating it as a documentation section and producing a link to a missing `docs/static/llms.txt` file.

## Testing

- Ran `node scripts/agents.js`
- Confirmed `docs/AGENTS.md` no longer contains `[Static](./static/llms.txt)`