### PR TITLE
fix(scripts): exclude static/ from top-level doc sections

### DIFF
--- a/scripts/lib/docs-utils.js
+++ b/scripts/lib/docs-utils.js
@@ -31,7 +31,7 @@ const CONSTANTS = {
 
   skipDirs: [
     'node_modules', '.git', 'dist', 'build', 'coverage',
-    '.next', 'images', 'videos', 'logo', 'openapi', '.claude', 'snippets'
+    '.next', 'images', 'videos', 'logo', 'openapi', '.claude', 'snippets', 'static'
   ],
 
   extensions: ['.md', '.mdx'],


### PR DESCRIPTION
## Summary

`docs/AGENTS.md` currently links to `./static/llms.txt`, which does not exist. This fixes the root cause in the generator.

## Root cause

`discoverTopLevelSections()` in `scripts/lib/docs-utils.js` treats every directory under `docs/` as a documentation section unless it is listed in `CONSTANTS.skipDirs`.

`docs/static/` is not a documentation section — it only contains `docs/static/assets/`. Since it was not excluded, the generator emitted a section entry for it, producing a link to a `llms.txt` that is never generated.

## Fix

Add `'static'` to `CONSTANTS.skipDirs`, consistent with how `images`, `videos`, `logo` and `openapi` are already excluded.

```diff
   skipDirs: [
     'node_modules', '.git', 'dist', 'build', 'coverage',
-    '.next', 'images', 'videos', 'logo', 'openapi', '.claude', 'snippets'
+    '.next', 'images', 'videos', 'logo', 'openapi', '.claude', 'snippets', 'static'
   ],
```

After this change, regenerating `docs/AGENTS.md` will no longer emit the `- [Static](./static/llms.txt)` entry.

## Verification

- `docs/static/llms.txt` → 404 (does not exist)
- `docs/static/` → contains only `assets/`
- `docs/AGENTS.md` line 17 → `- [Static](./static/llms.txt)`

Fixes #1806
