### PR TITLE
docs: fix mentor affiliations on Base Mentorship Program page

### DIFF
--- a/docs/get-started/base-mentorship-program.mdx
+++ b/docs/get-started/base-mentorship-program.mdx
@@ -29,11 +29,11 @@ Base Mentors are experienced founders, operators, and subject matter experts acr
 | Elena Nadolinski | [Iron Fish (acq. Coinbase)](https://x.com/leanthebean) |
 | Franklin Bi | [Pantera Capital](https://panteracapital.com/team/) |
 | Ian Dutra | [a16z crypto](https://a16zcrypto.com/team/ian-dutra/) |
-| Jack Gorman | Variant |
-| Jacob Frantz | [Opyn (acq. Coinbase)](https://x.com/therealjfrantz) |
+| Jack Gorman | [Variant](https://variant.fund/team/) |
+| Jacob Frantz | [Sensible (acq. Coinbase)](https://x.com/therealjfrantz) |
 | Jai Prasad | [Definitive](https://x.com/jai_prasad17) |
 | Jakub Rusiecki | [1kx](https://1kx.network/team/jakub-rusiecki) |
-| Jay Drain Jr | a16z crypto |
+| Jay Drain Jr | [a16z crypto](https://a16zcrypto.com/our-team/) |
 | Jonathan Wu | [Asylum Ventures](https://www.asylum.vc/) |
 | Kaito Cunningham | [Utopia Labs (acq. Coinbase)](https://x.com/kaycidot) |
 | Katie Chiou | [Archetype](https://www.archetype.fund/team) |
@@ -42,7 +42,7 @@ Base Mentors are experienced founders, operators, and subject matter experts acr
 | Mark Beylin | [Haun Ventures](https://www.haun.co/team/mark-beylin) |
 | Mike Tomaino | [1confirmation](https://www.1confirmation.com/about) |
 | Nick Tomaino | [1confirmation](https://www.1confirmation.com/about) |
-| Nina Suthers | Variant |
+| Nina Suthers | [Variant](https://variant.fund/team/) |
 | Robin Ji | [Liquifi (acq. Coinbase)](https://x.com/robindavidji) |
 | Ryan Prescott | [a16z crypto](https://a16zcrypto.com/team/ryan-prescott/) |
 | Simone "Limone" Staffa | [Builders Garden](https://www.builders.garden/#mission) |


### PR DESCRIPTION
**What changed? Why?**

Updates to mentor affiliations on the Base Mentorship Program page (`docs/get-started/base-mentorship-program.mdx`):

- **Jacob Frantz** – affiliation changed from *Opyn (acq. Coinbase)* to *Sensible (acq. Coinbase)*
- **Jack Gorman** – added missing hyperlink to Variant (https://variant.fund/team/)
- **Nina Suthers** – added missing hyperlink to Variant (https://variant.fund/team/)
- **Jay Drain Jr** – added hyperlink to a16z crypto (https://a16zcrypto.com/our-team/)

**Notes to reviewers**

Jack Gorman and Nina Suthers previously had plain-text "Variant" affiliations that were not rendering as links. Jacob Frantz's X profile link is unchanged; only the affiliation label was corrected.

**How has it been tested?**

Content-only change to a Markdown table. Verified links and formatting locally.