### PR TITLE
fix(docs): repair 64 broken links in the Beryl/B20 spec

### DIFF
--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/activate.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/activate.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for activate(bytes32)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/architecture-and-precompiles)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#precompile-addresses)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/admin.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/admin.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for admin()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/architecture-and-precompiles)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#precompile-addresses)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/checkActivated.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/checkActivated.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for checkActivated(bytes32)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/architecture-and-precompiles)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#precompile-addresses)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/deactivate.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/deactivate.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for deactivate(bytes32)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/architecture-and-precompiles)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#precompile-addresses)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/isActivated.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IActivationRegistry/isActivated.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for isActivated(bytes32)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/architecture-and-precompiles)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#precompile-addresses)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/burn.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/burn.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for burn(uint256)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/burnBlocked.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/burnBlocked.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for burnBlocked(address,uint256)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/burnWithMemo.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/burnWithMemo.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for burnWithMemo(uint256,bytes32)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/getRoleAdmin.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/getRoleAdmin.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for getRoleAdmin(bytes32)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/roles-and-access-control)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#roles-model)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/grantRole.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/grantRole.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for grantRole(bytes32,address)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/roles-and-access-control)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#roles-model)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/hasRole.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/hasRole.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for hasRole(bytes32,address)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/roles-and-access-control)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#roles-model)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/mint.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/mint.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for mint(address,uint256)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/mintWithMemo.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/mintWithMemo.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for mintWithMemo(address,uint256,bytes32).
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/pause.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/pause.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for pause(PausableFeature[])."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/pausedFeatures.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/pausedFeatures.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for pausedFeatures()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/policyId.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/policyId.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for policyId(bytes32)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/renounceLastAdmin.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/renounceLastAdmin.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for renounceLastAdmin()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/roles-and-access-control)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#roles-model)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/renounceRole.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/renounceRole.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for renounceRole(bytes32,address)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/roles-and-access-control)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#roles-model)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/revokeRole.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/revokeRole.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for revokeRole(bytes32,address)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/roles-and-access-control)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#roles-model)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/seizeWithMemo.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/seizeWithMemo.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for seizeWithMemo(address,address,uint256,
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/setRoleAdmin.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/setRoleAdmin.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for setRoleAdmin(bytes32,bytes32)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/roles-and-access-control)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#roles-model)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/transfer.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/transfer.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for transfer(address,uint256)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/transferFrom.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/transferFrom.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for transferFrom(address,address,uint256).
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/transferFromWithMemo.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/transferFromWithMemo.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for transferFromWithMemo(address,address,u
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/transferWithMemo.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/transferWithMemo.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for transferWithMemo(address,uint256,bytes
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/unpause.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/unpause.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for unpause(PausableFeature[])."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/token-lifecycle)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/updatePolicy.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20/updatePolicy.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for updatePolicy(bytes32,uint64)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/OPERATOR_ROLE.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/OPERATOR_ROLE.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for OPERATOR_ROLE()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/WAD_PRECISION.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/WAD_PRECISION.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for WAD_PRECISION()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/announce.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/announce.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for announce(bytes[],string,string,string)
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/batchMint.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/batchMint.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for batchMint(address[],uint256[])."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/cancelUIMultiplierUpdate.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/cancelUIMultiplierUpdate.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for cancelUIMultiplierUpdate()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/extraMetadata.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/extraMetadata.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for extraMetadata(string)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/isAnnouncementIdUsed.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/isAnnouncementIdUsed.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for isAnnouncementIdUsed(string)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/multiplier.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/multiplier.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for multiplier()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/scaledBalanceOf.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/scaledBalanceOf.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for scaledBalanceOf(address)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/toRawBalance.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/toRawBalance.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for toRawBalance(uint256)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/toScaledBalance.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/toScaledBalance.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for toScaledBalance(uint256)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/updateExtraMetadata.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/updateExtraMetadata.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for updateExtraMetadata(string,string)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/updateMultiplier.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/updateMultiplier.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for updateMultiplier(uint256)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/updateUIMultiplier.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Asset/updateUIMultiplier.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for updateUIMultiplier(uint256,uint256)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Factory/createB20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Factory/createB20.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for createB20(uint8,bytes32,bytes,bytes[])
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/implementation/deployment-and-initcalls-encoding)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#factory)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Factory/getB20Address.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Factory/getB20Address.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for getB20Address(uint8,address,bytes32)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/implementation/deployment-and-initcalls-encoding)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#factory)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Factory/isB20.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Factory/isB20.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for isB20(address)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/implementation/deployment-and-initcalls-encoding)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#factory)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Factory/isB20Initialized.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Factory/isB20Initialized.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for isB20Initialized(address)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/implementation/deployment-and-initcalls-encoding)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#factory)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Stablecoin/currency.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IB20Stablecoin/currency.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for currency()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/variants-asset-vs-stablecoin)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#variants)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/MAX_COMPOSITE_CHILD_POLICIES.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/MAX_COMPOSITE_CHILD_POLICIES.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for MAX_COMPOSITE_CHILD_POLICIES()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/MIN_COMPOSITE_CHILD_POLICIES.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/MIN_COMPOSITE_CHILD_POLICIES.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for MIN_COMPOSITE_CHILD_POLICIES()."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/compositePolicyChildIds.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/compositePolicyChildIds.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for compositePolicyChildIds(uint64)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/createCompositePolicy.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/createCompositePolicy.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for createCompositePolicy(address,uint8,ui
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/createPolicy.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/createPolicy.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for createPolicy(address,uint8)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/createPolicyWithAccounts.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/createPolicyWithAccounts.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for createPolicyWithAccounts(address,uint8
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/finalizeUpdateAdmin.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/finalizeUpdateAdmin.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for finalizeUpdateAdmin(uint64)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/isAuthorized.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/isAuthorized.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for isAuthorized(uint64,address)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/pendingPolicyAdmin.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/pendingPolicyAdmin.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for pendingPolicyAdmin(uint64)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/policyAdmin.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/policyAdmin.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for policyAdmin(uint64)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/policyExists.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/policyExists.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for policyExists(uint64)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/renounceAdmin.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/renounceAdmin.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for renounceAdmin(uint64)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/stageUpdateAdmin.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/stageUpdateAdmin.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for stageUpdateAdmin(uint64,address)."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/updateAllowlist.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/updateAllowlist.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for updateAllowlist(uint64,bool,address[])
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/updateBlocklist.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/updateBlocklist.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for updateBlocklist(uint64,bool,address[])
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/updateComposite.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/b20/specification/reference/interfaces/IPolicyRegistry/updateComposite.mdx
@@ -4,7 +4,7 @@ description: "Generated B20 reference for updateComposite(uint64,uint64[])."
 ---
 
 
-[Related concept](/base-chain/specs/upgrades/beryl/b20/specification/concepts/policies-and-scopes)
+[Related concept](/base-chain/specs/upgrades/beryl/b20/specification#policy-registry)
 
 ## Signature
 

--- a/docs/base-chain/specs/upgrades/beryl/overview.mdx
+++ b/docs/base-chain/specs/upgrades/beryl/overview.mdx
@@ -8,7 +8,7 @@ description: "Overview of the Beryl hardfork, introducing the B20 native token s
 - Introduce [B20](/base-chain/specs/upgrades/beryl/b20): Base's native token standard for stablecoin, real-world asset (RWA), and long-tail token issuers
 - Reduce the single-proof withdrawal finalization period from 7 days to 5 days for increased capital efficiency
 - Reth V2: up to 50% disk reduction and a rewritten state root pipeline delivering +33% throughput
-- Upcoming in a later Beryl phase: [native account abstraction (EIP-8130)](/base-chain/specs/upgrades/beryl/eip-8130), currently previewing on the vibenet devnet
+- Upcoming in a later Beryl phase: [native account abstraction (EIP-8130)](/base-chain/specs/upgrades/cobalt/eip-8130), currently previewing on the vibenet devnet
 
 ## Activation Timestamps
 
@@ -45,7 +45,7 @@ B20 is Base's native token standard - ERC-20 compatible tokens implemented as Ru
 
 A later Beryl phase brings account abstraction into the protocol. Accounts configure authorized actors and signature validation onchain. Apps get portable smart accounts, scoped session keys, atomic batching, and native gas sponsorship without bundler or relay infrastructure. EIP-8130 is experimental and currently runs only on the vibenet devnet.
 
-- [Native Account Abstraction (EIP-8130)](/base-chain/specs/upgrades/beryl/eip-8130)
+- [Native Account Abstraction (EIP-8130)](/base-chain/specs/upgrades/cobalt/eip-8130)
 
 ## Withdrawals
 


### PR DESCRIPTION
## Problem

Every generated B20 interface reference page renders a `[Related concept](…)` link on line 7 that points into `.../b20/specification/concepts/` or `.../b20/specification/implementation/`. **Neither directory exists in this repo**, so all 62 of those links 404 in production.

These pages are reachable by users — `specification/index.mdx` links into the generated reference tree — so the path is: spec → reference → method page → click "Related concept" → 404.

Verified live:

| Broken target | Links | docs.base.org |
|---|---|---|
| `…/specification/concepts/token-lifecycle` | 13 | 404 |
| `…/specification/concepts/policies-and-scopes` | 18 | 404 |
| `…/specification/concepts/variants-asset-vs-stablecoin` | 15 | 404 |
| `…/specification/concepts/roles-and-access-control` | 7 | 404 |
| `…/specification/concepts/architecture-and-precompiles` | 5 | 404 |
| `…/specification/implementation/deployment-and-initcalls-encoding` | 4 | 404 |
| `/base-chain/specs/upgrades/beryl/eip-8130` | 2 | 404 |

## Fix

The concept material *does* exist — as sections of `specification/index.mdx` — so each link is repointed at the matching anchor:

| Was | Now |
|---|---|
| `concepts/roles-and-access-control` | `specification#roles-model` |
| `concepts/policies-and-scopes` | `specification#policy-registry` |
| `concepts/variants-asset-vs-stablecoin` | `specification#variants` |
| `concepts/architecture-and-precompiles` | `specification#precompile-addresses` |
| `implementation/deployment-and-initcalls-encoding` | `specification#factory` |
| `concepts/token-lifecycle` | `specification` (spans Mint / Burn / Seize / Supply Cap / Pause, so no single anchor fits) |

Separately, `beryl/overview.mdx` links twice to `/base-chain/specs/upgrades/beryl/eip-8130`, which 404s — that page lives at `/base-chain/specs/upgrades/**cobalt**/eip-8130` ("Native Account Abstraction").

Every destination and anchor id was checked against the rendered pages on docs.base.org. One line changed per link; no prose edits.

## Notes for maintainers

- The reference pages look **machine-generated** (`description: "Generated B20 reference for …"`). If so, the durable fix belongs in whatever generates them, or this will regress on the next run. Happy to adjust if you can point me at the generator.
- `beryl/overview.mdx` still *describes* EIP-8130 as "upcoming in a later Beryl phase" while the page now lives under Cobalt. I only corrected the link — the prose seemed like a maintainer call.
- If the `concepts/` and `implementation/` pages are planned rather than dropped, the alternative fix is to publish them and revert this. Either way the links shouldn't 404 in the meantime.
