### PR TITLE
docs(proofs): drop dead NitroEnclaveVerifier source links

### DIFF
--- a/docs/base-chain/specs/protocol/proofs/registrar.mdx
+++ b/docs/base-chain/specs/protocol/proofs/registrar.mdx
@@ -13,7 +13,7 @@ intermediate certificates that AWS has withdrawn.
 A registrar is operated by Base. The proof system trusts only signers that this registrar has
 registered, so registrar correctness is a prerequisite for accepting TEE proofs onchain. Its output
 is still self-validating: the attestation ZK proof, the enclave PCR0 measurement, and the signer
-public key are all checked by `TEEProverRegistry` and [`NitroEnclaveVerifier`](https://github.com/base/contracts/blob/main/src/L1/proofs/tee/NitroEnclaveVerifier.sol)
+public key are all checked by `TEEProverRegistry` and `NitroEnclaveVerifier`
 before the signer becomes valid.
 
 ## Responsibilities
@@ -321,8 +321,8 @@ submission time and includes an image-hash match that the registrar cannot satis
 | [`TEEProverRegistry`](https://github.com/base/contracts/blob/main/src/L1/proofs/tee/TEEProverRegistry.sol)                 | `deregisterSigner(signer)`      | Per-orphan deregistration transaction.              |
 | [`TEEProverRegistry`](https://github.com/base/contracts/blob/main/src/L1/proofs/tee/TEEProverRegistry.sol)                 | `isRegisteredSigner(signer)`    | Pre-check, post-error reconciliation, orphan race guard. |
 | [`TEEProverRegistry`](https://github.com/base/contracts/blob/main/src/L1/proofs/tee/TEEProverRegistry.sol)                 | `getRegisteredSigners()`        | Once per cycle for orphan computation.              |
-| [`NitroEnclaveVerifier`](https://github.com/base/contracts/blob/main/src/L1/proofs/tee/NitroEnclaveVerifier.sol)           | `revokeCert(certHash)`          | When AWS CRL revokes an intermediate.               |
-| [`NitroEnclaveVerifier`](https://github.com/base/contracts/blob/main/src/L1/proofs/tee/NitroEnclaveVerifier.sol)           | `revokedCerts(certHash)`        | Layer-1 onchain durable revocation pre-check.       |
+| `NitroEnclaveVerifier`           | `revokeCert(certHash)`          | When AWS CRL revokes an intermediate.               |
+| `NitroEnclaveVerifier`           | `revokedCerts(certHash)`        | Layer-1 onchain durable revocation pre-check.       |
 
 PCR0 enforcement happens onchain at proof submission, not at registration. The registrar registers
 any enclave whose Nitro attestation verifies, regardless of its PCR0. This allows the next image's


### PR DESCRIPTION
Three links on the TEE registrar page point at `src/L1/proofs/tee/NitroEnclaveVerifier.sol` in `base/contracts`. That file was deleted along with `INitroEnclaveVerifier.sol` in [base/contracts#400](https://github.com/base/contracts/pull/400) (merged Aug 12), so all three 404 now — once in the intro paragraph and twice in the contract-calls table.

This renders the name as inline code instead, which is how the page already refers to contracts it doesn't link. The `TEEProverRegistry` and `TEEVerifier` links next to them still resolve and are untouched.

Checked before and after with `node scripts/lint-mdx.js` on the file — no new findings.

This only covers the dead links. The rest of #1817 — the page still describing the Boundless ZK-attestation flow that [base/base#4425](https://github.com/base/base/pull/4425) replaced with hinted Nitro registration — I've left alone, since I can't tell from outside where that migration lands. Happy to follow up there once you say what it should read.

Closes nothing on its own; see #1817 for the rest.
