### PR TITLE
fix(scripts): handle optional leading slash in mintignore directory patterns

### DIFF
--- a/scripts/lib/docs-utils.js
+++ b/scripts/lib/docs-utils.js
@@ -80,7 +80,8 @@ function loadMintIgnore(mintignorePath) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;
     if (trimmed.endsWith('/*')) {
-      ignored.dirs.add(trimmed.slice(1, -2));
+      const dir = trimmed.startsWith('/') ? trimmed.slice(1, -2) : trimmed.slice(0, -2);
+      ignored.dirs.add(dir);
     } else if (trimmed.startsWith('/')) {
       ignored.files.add(trimmed.slice(1));
     } else {

--- a/scripts/lib/docs-utils.test.js
+++ b/scripts/lib/docs-utils.test.js
@@ -1,0 +1,22 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { loadMintIgnore } = require('./docs-utils');
+
+test('loadMintIgnore parses directory patterns with and without leading slash', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mintignore-'));
+  const mintignore = path.join(dir, '.mintignore');
+
+  try {
+    fs.writeFileSync(mintignore, ['/foo/*', 'bar/*', 'draft-notes/*'].join('\n'));
+
+    const ignored = loadMintIgnore(mintignore);
+
+    assert.deepEqual([...ignored.dirs].sort(), ['bar', 'draft-notes', 'foo']);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What changed

Updated `loadMintIgnore()` so directory patterns ending in `/*` work both with and without a leading slash, and added a focused `node:test` regression test.

## Why

The parser previously used `trimmed.slice(1, -2)` for every directory pattern, assuming entries were written like `/foo/*`. A slashless pattern like `foo/*` was stored as `oo`, so the intended directory was never ignored.

Fixes #1819

## Validation

- `node --test scripts/lib/docs-utils.test.js`
- `node --check scripts/llms.js`
- `node --check scripts/agents.js`
- `node --check scripts/lib/docs-utils.js`
- `node --check scripts/lib/docs-utils.test.js`
- `git diff --check -- scripts/lib/docs-utils.js scripts/lib/docs-utils.test.js`