### PR TITLE
docs(node-operators): add OpenChainBench as live RPC benchmarking reference

### DIFF
--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -195,4 +195,6 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 <HeaderNoToc title="Supported Networks"/>
 
 - Base Mainnet
+## Benchmarking Tools
 
+[OpenChainBench](https://openchainbench.com) provides live RPC latency benchmarks for Base node providers. It probes 5 providers every minute from 3 global regions and reports p50, p90, and p99 latency — useful for comparing providers objectively before choosing one for production.

--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -197,4 +197,4 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 - Base Mainnet
 ## Benchmarking Tools
 
-[OpenChainBench](https://openchainbench.com) provides live RPC latency benchmarks for Base node providers. It probes 5 providers every minute from 3 global regions and reports p50, p90, and p99 latency — useful for comparing providers objectively before choosing one for production.
+[OpenChainBench](https://openchainbench.com/benchmarks/base-rpc) provides live RPC latency benchmarks for Base node providers. It probes 5 providers every minute from 3 global regions and reports p50, p90, and p99 latency — useful for comparing providers objectively before choosing one for production.


### PR DESCRIPTION
OpenChainBench (https://openchainbench.com) is an open-source live benchmark that probes 5 Base RPC providers every minute from 3 global regions (US, EU, Asia) and reports p50/p90/p99 latency. Adding it as a reference at the end of the node-providers page gives developers an objective comparison tool when choosing among the providers already listed.