### PR TITLE
fix: lint multiline MDX tags

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -14,7 +14,6 @@ description: Look up Base documentation with a compact directory-grouped index b
 - [Base Chain](./base-chain/llms.txt) — Start here for Base Chain docs, including concepts, network reference, node operation, APIs, and protocol specifications.
 - [Get Started](./get-started/llms.txt)
 - [Ledgers](./ledgers/llms.txt) — An introduction to Base Ledgers, the enterprise way to run confidential payments that settle on Base.
-- [Static](./static/llms.txt)
 
 ## Tools available for AI assistants
 

--- a/scripts/lib/docs-utils.js
+++ b/scripts/lib/docs-utils.js
@@ -31,7 +31,7 @@ const CONSTANTS = {
 
   skipDirs: [
     'node_modules', '.git', 'dist', 'build', 'coverage',
-    '.next', 'images', 'videos', 'logo', 'openapi', '.claude', 'snippets'
+    '.next', 'images', 'videos', 'logo', 'openapi', '.claude', 'snippets', 'static'
   ],
 
   extensions: ['.md', '.mdx'],

--- a/scripts/lint-mdx.js
+++ b/scripts/lint-mdx.js
@@ -249,8 +249,20 @@ function checkMintlifyComponents(content, filePath) {
   // Valid callout components
   const validCallouts = ["Note", "Tip", "Warning", "Info", "Check"];
 
+  function collectTagText(start) {
+    let text = lines[start];
+    let end = start;
+    while (!text.includes(">") && end + 1 < lines.length) {
+      end += 1;
+      text += `\n${lines[end]}`;
+    }
+    return text;
+  }
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    const startsSupportedTag = /<(Step|Tab|Accordion|Card|CardGroup|ParamField|ResponseField|Frame|Steps|Tabs|AccordionGroup|img)(\s|>|$)/.test(line);
+    const tagText = startsSupportedTag ? collectTagText(i) : line;
 
     // Check for HTML comments
     if (line.includes("<!--")) {
@@ -274,11 +286,11 @@ function checkMintlifyComponents(content, filePath) {
     }
 
     // Check opening tags
-    const openTagMatch = line.match(/<(Step|Tab|Accordion|Card|CardGroup|ParamField|ResponseField|Frame|Steps|Tabs|AccordionGroup)(\s[^>]*)?\/?>/);
+    const openTagMatch = tagText.match(/<(Step|Tab|Accordion|Card|CardGroup|ParamField|ResponseField|Frame|Steps|Tabs|AccordionGroup)(\s[^>]*)?\/?>/);
     if (openTagMatch) {
       const tag = openTagMatch[1];
       const attrs = openTagMatch[2] || "";
-      const isSelfClosing = line.includes("/>");
+      const isSelfClosing = tagText.includes("/>");
 
       // Check required attributes
       if (requiredAttrs[tag]) {
@@ -328,7 +340,7 @@ function checkMintlifyComponents(content, filePath) {
     }
 
     // Check for img without alt
-    if (line.includes("<img") && !line.includes("alt=")) {
+    if (tagText.includes("<img") && !tagText.includes("alt=")) {
       issues.push({
         line: i + 1,
         severity: "warning",


### PR DESCRIPTION
Addresses issues #1806, #1795, and #1792.

What changed:
- Exclude the asset-only static directory from generated documentation indexes.
- - Update the MDX linter to inspect component attributes and image alt attributes when tags span multiple lines.
- - Regenerate docs/AGENTS.md after the index change.
Why:
The previous checks missed invalid metadata when a component tag or image attribute crossed a line boundary. The generated index also included a directory without documentation pages.

Testing:
- Node syntax checks passed.
- - Targeted multiline MDX fixture detected the missing Card title and missing image alt while accepting valid multiline tags.
- - git diff --check passed.
The full existing repository lint baseline reports 1,447 errors and 74 warnings, so validation focused on the changed logic and a targeted regression fixture.