### PR TITLE
docs: fix broken P256VERIFY anchor link in Fjord upgrade page

### DIFF
--- a/docs/base-chain/specs/upgrades/fjord/overview.mdx
+++ b/docs/base-chain/specs/upgrades/fjord/overview.mdx
@@ -12,7 +12,7 @@ description: "Overview of the Fjord hardfork, introducing FastLZ-based L1 fee es
 
 ## Execution Layer
 
-- [RIP-7212: Precompile for secp256r1 Curve Support](/base-chain/specs/protocol/execution/evm/precompiles#P256VERIFY)
+- [RIP-7212: Precompile for secp256r1 Curve Support](/base-chain/specs/protocol/execution/evm/precompiles#p256verify)
 - [FastLZ compression for L1 data fee calculation](/base-chain/specs/upgrades/fjord/exec-engine#fees)
 - [Deprecate the `getL1GasUsed` method on the `GasPriceOracle` contract](/base-chain/specs/upgrades/fjord/predeploys#l1-gas-usage-estimation)
 - [Deprecate the `L1GasUsed` field on the transaction receipt](/base-chain/specs/upgrades/fjord/exec-engine#l1-gas-usage-estimation)


### PR DESCRIPTION
**What changed? Why?**

The Fjord upgrade page links to the `P256VERIFY` precompile section using an uppercase fragment:

```
/base-chain/specs/protocol/execution/evm/precompiles#P256VERIFY
```

Generated anchors are lowercased, so the heading `## P256VERIFY` renders as `#p256verify`. Anchor matching is case-sensitive, so the current link does not scroll to the target section. This updates the fragment to `#p256verify` to match the generated anchor.

The other links in the same list on this page already use lowercase fragments (`#fees`, `#l1-gas-usage-estimation`), so this makes the `P256VERIFY` entry consistent with them.

**Notes to reviewers**

Single-character fragment change on one line (`docs/base-chain/specs/upgrades/fjord/overview.mdx`). The target heading `## P256VERIFY` lives in `docs/base-chain/specs/protocol/execution/evm/precompiles.mdx`.

**How has it been tested?**

Verified the target heading exists and that its generated anchor is `#p256verify`, consistent with other cross-references in the docs that link to capitalized headings using lowercase fragments.