### PR TITLE
docs: add node101 to Base node providers

### DIFF
--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -105,7 +105,7 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 
 ## node101
 
-[node101](https://node101.io/en/rpc/base) provides managed Base RPC access with JSON-RPC, distributed infrastructure, dashboard monitoring, trace APIs, and Flashblocks API support.
+[node101](https://node101.io/en/rpc/base) provides managed Base Mainnet RPC access through shared and dedicated infrastructure, with JSON-RPC, distributed architecture, Trace APIs, Flashblocks API access, and usage monitoring through the 101 Dashboard. Archive node services and 24/7 technical support are also available.
 
 <HeaderNoToc title="Supported Networks"/>
 
@@ -203,4 +203,3 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 <HeaderNoToc title="Supported Networks"/>
 
 - Base Mainnet
-

--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -103,6 +103,14 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 - Base Mainnet
 - Base Sepolia (Testnet)
 
+## node101
+
+[node101](https://node101.io/en/rpc/base) provides managed Base RPC access with JSON-RPC, distributed infrastructure, dashboard monitoring, trace APIs, and Flashblocks API support.
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+
 ## NodeReal
 
 [NodeReal](https://nodereal.io/) is a blockchain infrastructure and services provider that provides instant and easy-access to Base node APIs.


### PR DESCRIPTION
**What changed? Why?**

Adds node101 to the Base node providers page with a link to its Base RPC offering and a concise summary of its infrastructure and API capabilities.

**Notes to reviewers**

The entry lists Base Mainnet and uses product details published on the [node101 Base RPC page](https://node101.io/en/rpc/base).

**How has it been tested?**

- Ran `node scripts/lint-mdx.js docs/base-chain/node-operators/node-providers.mdx`
- Result: 0 errors and 0 warnings
