### PR TITLE
docs: fix broken vibenet anchor links to connecting-to-base

### DIFF
--- a/docs/base-chain/network-information/native-account-abstraction.mdx
+++ b/docs/base-chain/network-information/native-account-abstraction.mdx
@@ -9,7 +9,7 @@ Native account abstraction makes smart accounts a property of the chain instead 
 Base's implementation is [EIP-8130](https://eip.tools/eip/8130), landing with the [Cobalt upgrade](/base-chain/specs/upgrades/cobalt/overview).
 
 <Warning>
-EIP-8130 is experimental and currently runs only on the [vibenet devnet](https://chain.base.org/vibenet). See [connecting to Base](/base-chain/quickstart/connecting-to-base#vibenet) for connection details.
+EIP-8130 is experimental and currently runs only on the [vibenet devnet](https://chain.base.org/vibenet). See [connecting to Base](/base-chain/quickstart/connecting-to-base#network-details) for connection details.
 </Warning>
 
 ## Why native
@@ -82,7 +82,7 @@ A transaction can name a **payer** that covers gas on the sender's behalf, so sp
   <Card title="Reference contracts" icon="github" href="https://github.com/base/eip-8130">
     `AccountConfiguration`, account implementations, and authenticators, with Foundry tests.
   </Card>
-  <Card title="Connect to vibenet" icon="plug" href="/base-chain/quickstart/connecting-to-base#vibenet">
+  <Card title="Connect to vibenet" icon="plug" href="/base-chain/quickstart/connecting-to-base#network-details">
     RPC endpoints and chain ID for the devnet where EIP-8130 runs today.
   </Card>
 </CardGroup>

--- a/docs/base-chain/specs/reference/native-account-abstraction.mdx
+++ b/docs/base-chain/specs/reference/native-account-abstraction.mdx
@@ -9,7 +9,7 @@ This is the technical reference for EIP-8130 on Base. For what native account ab
 [EIP-8130](https://eip.tools/eip/8130) builds account abstraction into the protocol. An account registers who can act for it, and how its signatures are checked, in an onchain system contract. The chain validates each transaction against that configuration, so smart accounts work without bundlers, relays, or a separate mempool.
 
 <Warning>
-EIP-8130 is experimental and currently runs only on the [vibenet devnet](https://chain.base.org/vibenet). You can learn more about connecting to vibenet [here](/base-chain/quickstart/connecting-to-base#vibenet).
+EIP-8130 is experimental and currently runs only on the [vibenet devnet](https://chain.base.org/vibenet). You can learn more about connecting to vibenet [here](/base-chain/quickstart/connecting-to-base#network-details).
 </Warning>
 
 ## Network details

--- a/docs/base-chain/specs/upgrades/cobalt/overview.mdx
+++ b/docs/base-chain/specs/upgrades/cobalt/overview.mdx
@@ -23,7 +23,7 @@ Cobalt has not been scheduled on mainnet or Sepolia. EIP-8130 is experimental an
 
 ## Required Software
 
-Node software requirements will be published here once Cobalt is scheduled. To follow along today, connect to [vibenet](/base-chain/quickstart/connecting-to-base#vibenet).
+Node software requirements will be published here once Cobalt is scheduled. To follow along today, connect to [vibenet](/base-chain/quickstart/connecting-to-base#network-details).
 
 ## Native Account Abstraction (EIP-8130)
 


### PR DESCRIPTION
**What changed? Why?**

Four links point readers to `connecting-to-base#vibenet` for Vibenet connection details, but that page has no `#vibenet` anchor. The Vibenet connection details live in the `Vibenet` tab under the `## Network details` heading, and Mint tabs are not addressable by their own fragment, so the current links land on the page without reaching the intended section.

This repoints the four links to `connecting-to-base#network-details`, the real heading anchor for the section that contains the Vibenet tab.

Affected links:
- `base-chain/network-information/native-account-abstraction.mdx` (inline link + `Connect to vibenet` card)
- `base-chain/specs/reference/native-account-abstraction.mdx`
- `base-chain/specs/upgrades/cobalt/overview.mdx`

**Notes to reviewers**

`#network-details` is the closest working anchor, since the target is a `<Tab>` and tabs cannot be deep-linked by fragment. These were the only links to `connecting-to-base` in the docs, and all four used the non-existent `#vibenet` fragment.

**How has it been tested?**

Confirmed `connecting-to-base.mdx` has no `#vibenet` anchor and that `## Network details` (anchor `#network-details`) is the section containing the `Vibenet` tab. Verified no `connecting-to-base#vibenet` references remain.