### PR TITLE
docs: say "reveals" instead of "leaks" in Base Verify Onchain guide

### DIFF
--- a/docs/apps/guides/verify-onchain.mdx
+++ b/docs/apps/guides/verify-onchain.mdx
@@ -109,7 +109,7 @@ Whatever your own contract stores or emits alongside a claim is public too. The 
 
 Your policy is public and your claims are public, so anyone can pair the two. The Coinbase One example consumer declares `provider = "coinbase"` and the condition `coinbase_one_active eq true`, so every wallet in its `Claimed` log is publicly known to have held an active Coinbase One membership at claim time. An observer cannot tell which Coinbase account, but does learn that the wallet had one.
 
-A narrower policy leaks more. Gating on `followers gte 10000` marks each claiming wallet as a large X account, while gating on `verified eq true` says much less. Your contract name and any action naming leak the same way.
+The narrower your policy, the more a claim reveals. Gating on `followers gte 10000` marks each claiming wallet as a large X account, while gating on `verified eq true` says much less. The same applies to your contract name and any action naming.
 
 Because `identityHash` is scoped per contract, the same person claiming in two different contracts produces two unrelated hashes that observers cannot link. Within a single contract, every claim from that person shares one hash, which is exactly what makes the dedupe work.
 


### PR DESCRIPTION
**What changed? Why?**

Follow-up wording fix to #1834, from review feedback.

The "What an observer can infer" section described a narrow policy as leaking information. "Leak" implies an unintended failure or a breach, but the disclosure here is by design: the developer picks a public policy and deploys it to a public chain, and the system behaves exactly as specified. On a page whose job is to set accurate expectations about public state, "reveals" is the more neutral and more accurate verb.

One line changed:

> ~~A narrower policy **leaks** more. [...] Your contract name and any action naming **leak** the same way.~~
> The narrower your policy, the more a claim **reveals**. [...] The same applies to your contract name and any action naming.

**Notes to reviewers**

No change in meaning, only in tone. The surrounding heading already frames this as "What an observer can infer", so "allows observers to infer more" was the other candidate but read as redundant next to it.

**How has it been tested?**

- Ran `node scripts/lint-mdx.js` on the file. The 6 reported "code block missing language specifier" errors are pre-existing on closing fences and unchanged by this edit.
- Confirmed this is the only use of "leak" on the page.