### PR TITLE
docs: fix broken DA Footprint anchor link on Jovian upgrade page

### DIFF
--- a/docs/base-chain/specs/upgrades/jovian/overview.mdx
+++ b/docs/base-chain/specs/upgrades/jovian/overview.mdx
@@ -13,7 +13,7 @@ description: "Overview of the Jovian hardfork, introducing a configurable minimu
 ## Execution Layer
 
 - [Minimum Base Fee](/base-chain/specs/upgrades/jovian/exec-engine#minimum-base-fee)
-- [DA Footprint Limit](/base-chain/specs/upgrades/jovian/exec-engine#da-footprint-limit)
+- [DA Footprint Limit](/base-chain/specs/upgrades/jovian/exec-engine#da-footprint-block-limit)
 - [Operator Fee](/base-chain/specs/upgrades/jovian/exec-engine#operator-fee)
 
 ## Consensus Layer


### PR DESCRIPTION
**What changed? Why?**

On the Jovian upgrade overview, the `DA Footprint Limit` link points to `jovian/exec-engine#da-footprint-limit`, but the target heading on that page is `## DA Footprint Block Limit`, whose generated anchor is `#da-footprint-block-limit`. The current link is missing `block`, so it does not resolve to the section.

This updates the fragment to `#da-footprint-block-limit` to match the actual heading.

**Notes to reviewers**

Single-line fragment fix in `docs/base-chain/specs/upgrades/jovian/overview.mdx`. The target heading `## DA Footprint Block Limit` is in `docs/base-chain/specs/upgrades/jovian/exec-engine.mdx`. The sibling links in the same list (`#minimum-base-fee`, `#operator-fee`) already resolve correctly.

**How has it been tested?**

Confirmed the target page has no `#da-footprint-limit` heading and that `## DA Footprint Block Limit` (anchor `#da-footprint-block-limit`) is the intended section.