### PR TITLE
docs: fix broken Flashblocks FAQ anchor links

### DIFF
--- a/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_call.mdx
+++ b/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_call.mdx
@@ -11,7 +11,7 @@ Executes a message call immediately without broadcasting a transaction to the ne
 </Tip>
 
 <Note>
-**`eth_call "pending"` block context on Flashblocks nodes:** Block-context properties (`block.number`, `block.timestamp`, `block.basefee`) may reflect a block several behind tip due to how nodes cache historical Flashblocks. See the [FAQ](/base-chain/flashblocks/faq#why-does-eth_call-pending-report-a-block-number-several-blocks-behind-tip) for details.
+**`eth_call "pending"` block context on Flashblocks nodes:** Block-context properties (`block.number`, `block.timestamp`, `block.basefee`) may reflect a block several behind tip due to how nodes cache historical Flashblocks. See the [FAQ](/base-chain/flashblocks/faq#rpc) for details.
 </Note>
 
 ## Parameters

--- a/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
+++ b/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
@@ -50,7 +50,7 @@ Unique identifier for the block being built. Remains consistent across all Flash
 </ParamField>
 
 <ParamField path="index" type="number">
-Flashblock index within the current block. Starts at 0 (system transactions only). User transactions begin at index 1. Typically reaches 9–10 per block, but [may exceed 10](/base-chain/flashblocks/faq#can-the-flashblock-index-exceed-10-is-that-a-bug) during sequencer timing drift.
+Flashblock index within the current block. Starts at 0 (system transactions only). User transactions begin at index 1. Typically reaches 9–10 per block, but [may exceed 10](/base-chain/flashblocks/faq#websocket) during sequencer timing drift.
 </ParamField>
 
 <ParamField path="base" type="Base Object">


### PR DESCRIPTION
**What changed? Why?**

Two pages link into the Flashblocks FAQ using fragments derived from `<Accordion>` titles:

- `eth_call` → `flashblocks/faq#why-does-eth_call-pending-report-a-block-number-several-blocks-behind-tip`
- Flashblocks API overview → `flashblocks/faq#can-the-flashblock-index-exceed-10-is-that-a-bug`

Accordion titles are not headings, so no anchor is generated for them and neither fragment resolves. Both links currently land at the top of the FAQ instead of the relevant answer.

This repoints them to the headings of the sections that contain those accordions:

- the `eth_call "pending"` answer lives under `## RPC` → `#rpc`
- the Flashblock index answer lives under `## WebSocket` → `#websocket`

**Notes to reviewers**

These are the only two cross-references in the docs that target accordion titles rather than headings; every other anchor link points at a real heading. Section-level anchors are the closest working targets without adding explicit anchors to the FAQ. Only the two linking pages are touched — `faq.mdx` itself is unchanged.

**How has it been tested?**

Checked that `flashblocks/faq.mdx` contains no headings matching either fragment, and confirmed the two answers sit under the `## RPC` and `## WebSocket` headings whose anchors are `#rpc` and `#websocket`.