### PR TITLE
added sticker for 200ms blocks

### DIFF
--- a/docs/base-chain/specs/upgrades/denim/200ms-native-blocks.mdx
+++ b/docs/base-chain/specs/upgrades/denim/200ms-native-blocks.mdx
@@ -1,6 +1,7 @@
 ---
 title: "200ms native blocks"
 description: "Specification for Denim's canonical 200ms blocks, including BaseTime, derivation, validation, and RPC behavior."
+tag: "Soon"
 ---
 
 <Warning>


### PR DESCRIPTION
**What changed? Why?**
Add soon badge to 200ms docs
