### PR TITLE
docs: add BoltRPC to Base node providers

### DIFF
--- a/docs/base-chain/node-operators/node-providers.mdx
+++ b/docs/base-chain/node-operators/node-providers.mdx
@@ -76,6 +76,14 @@ import {HeaderNoToc} from "/snippets/headerNoToc.mdx";
 - Base Mainnet
 - Base Sepolia (Testnet)
 
+## BoltRPC
+
+[BoltRPC](https://boltrpc.io/) provides dedicated HTTPS and WebSocket RPC endpoints for Base, with a single API key across 20+ networks, published request-unit pricing, and no per-request throttling within plan quota. Operated by an ISO/IEC 27001:2022 certified infrastructure team. See their [Base RPC page](https://boltrpc.io/networks/base) and [pricing](https://boltrpc.io/pricing).
+
+<HeaderNoToc title="Supported Networks"/>
+
+- Base Mainnet
+
 ## Chainstack
 
 [Chainstack](https://chainstack.com/build-better-with-base/) allows developers to run high-performing Base nodes and APIs in minutes. They offer elastic Base RPC nodes that provide personal, geographically diverse, and protected API endpoints, as well as archive nodes to query the entire history of the Base Mainnet. Get started with their [free and paid pricing plans](https://chainstack.com/pricing/).


### PR DESCRIPTION
**What changed? Why?**

Adds BoltRPC to the Base node providers page with a link to its Base RPC offering and a short summary of HTTPS/WebSocket access, multi-chain API key model, and pricing.

**Notes to reviewers**

- Entry follows the existing provider listing format.
- Links:
  - https://boltrpc.io/
  - https://boltrpc.io/networks/base
  - https://boltrpc.io/pricing
- Supported networks listed: Base Mainnet (chain ID 8453).
- Docs-only change; does not modify Base network configuration.

**How has it been tested?**

- Verified Base Mainnet product page and endpoint docs at https://boltrpc.io/networks/base
- Documentation-only change