### PR TITLE
docs: reorganize Specifications tab by topic, consolidate bridging sections

### DIFF
--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -3,3 +3,8 @@ writing.md
 API_MIGRATION_PLAN.md
 
 tone_of_voice.mdx
+
+# Pages removed from nav and redirected elsewhere
+base-chain/network-information/bridging-and-withdrawals.mdx
+base-chain/network-information/network-faucets.mdx
+base-chain/quickstart/connecting-to-base.mdx

--- a/docs/base-chain/overview.mdx
+++ b/docs/base-chain/overview.mdx
@@ -1,47 +1,31 @@
 ---
 title: "Overview"
-description: "Base protocol specifications, core primitives, and network systems."
+description: "Base protocol specifications — tokens, bridging, transactions, consensus, execution, and proofs."
 ---
 
-Technical specifications for how Base works at the chain level. Core Primitives covers what developers interact with directly — tokens, accounts, bridging, fees, and transactions. Network Systems covers protocol internals — the batcher, consensus, execution, and proof system.
-
-### Core Primitives
+Technical specifications for how Base works at the chain level, organized by topic from user-facing primitives to protocol internals.
 
 <CardGroup cols={2}>
   <Card title="B20" icon="coin" href="/base-chain/specs/reference/b20/index">
     Native token standard with compliance, memos, and supply controls.
   </Card>
-  <Card title="Native Account Abstraction" icon="key" href="/base-chain/specs/native-account-abstraction">
+  <Card title="Account Abstraction" icon="key" href="/base-chain/specs/native-account-abstraction">
     Smart accounts that send ordinary transactions with no bundlers or relays.
   </Card>
   <Card title="Bridging" icon="bridge" href="/base-chain/network-information/ecosystem-bridges">
-    Move ETH, stablecoins, and tokens to and from Base.
+    Move assets to and from Base — ecosystem bridges, Solana bridge, and protocol specs.
   </Card>
-  <Card title="Network Fees" icon="receipt" href="/base-chain/network-information/network-fees">
-    L2 execution fees, L1 security fees, and cost-saving strategies.
-  </Card>
-  <Card title="Transaction Ordering" icon="arrow-down-1-9" href="/base-chain/network-information/transaction-ordering">
-    How transactions are ordered by priority fee and arrival time.
-  </Card>
-  <Card title="Transaction Finality" icon="check-double" href="/base-chain/network-information/transaction-finality">
-    Confirmation stages from unsafe through finalized.
+  <Card title="Transactions" icon="arrow-down-1-9" href="/base-chain/network-information/transaction-ordering">
+    Ordering, finality, fees, throughput, and troubleshooting.
   </Card>
   <Card title="Flashblocks" icon="bolt" href="/base-chain/flashblocks/faq">
     Sub-second block building, WebSocket data, and RPC usage.
   </Card>
-</CardGroup>
-
-### Network Systems
-
-<CardGroup cols={2}>
-  <Card title="Protocol" icon="diagram-project" href="/base-chain/specs/protocol/overview">
+  <Card title="Protocol Overview" icon="diagram-project" href="/base-chain/specs/protocol/overview">
     Rollup architecture, core components, and user flows.
   </Card>
   <Card title="Batcher" icon="layer-group" href="/base-chain/specs/protocol/batcher">
     Posting L2 sequencer data to L1 for data availability.
-  </Card>
-  <Card title="Standard Bridges" icon="right-left" href="/base-chain/specs/protocol/bridging/bridges">
-    Cross-domain ETH and ERC-20 transfers between L1 and L2.
   </Card>
   <Card title="Consensus" icon="handshake" href="/base-chain/specs/protocol/consensus/index">
     L2 block derivation, P2P networking, and RPC specification.
@@ -51,8 +35,5 @@ Technical specifications for how Base works at the chain level. Core Primitives 
   </Card>
   <Card title="Proofs" icon="shield-check" href="/base-chain/specs/protocol/proofs/index">
     Multi-proof checkpoint verification with TEE and ZK provers.
-  </Card>
-  <Card title="Throughput and Limits" icon="gauge-high" href="/base-chain/network-information/throughput-and-limits">
-    Gas limits and throughput-related network parameters.
   </Card>
 </CardGroup>

--- a/docs/base-chain/specs/protocol/bridging/bridges.mdx
+++ b/docs/base-chain/specs/protocol/bridging/bridges.mdx
@@ -1,7 +1,11 @@
 ---
 title: "Standard Bridges"
-description: "Specification of the standard bridges enabling cross-domain ETH and ERC20 token transfers between L1 and L2 on Base."
+description: "Specification of the standard bridge contracts enabling cross-domain ETH and ERC-20 token transfers between L1 and L2 on Base."
 ---
+
+The standard bridges support cross-domain ETH and ERC-20 transfers between Ethereum (L1) and Base (L2). They are built on top of the [cross-domain messenger contracts](/base-chain/specs/protocol/bridging/messengers) and provide a standard interface for moving tokens between domains.
+
+For the underlying transaction mechanisms, see [Deposits](/base-chain/specs/protocol/bridging/deposits) and [Withdrawals](/base-chain/specs/protocol/bridging/withdrawals).
 
 ## Overview
 
@@ -34,13 +38,6 @@ interface StandardBridge {
     function OTHER_BRIDGE() view external returns (address);
 }
 ```
-
-## Token Depositing
-
-The `bridgeERC20` function is used to send a token from one domain to another
-domain. An `OptimismMintableERC20` token contract must exist on the remote
-domain to be able to deposit tokens to that domain. One of these tokens can be
-deployed using the `OptimismMintableERC20Factory` contract.
 
 ## Upgradability
 

--- a/docs/base-chain/specs/protocol/bridging/deposits.mdx
+++ b/docs/base-chain/specs/protocol/bridging/deposits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deposits"
-description: "Specification of the deposit mechanism for Base, detailing how L1 transactions are converted into L2 deposit transactions."
+description: "How deposits work on Base — from user experience to the protocol-level deposit transaction type and guaranteed gas market."
 ---
 
 [g-transaction-type]: ../../reference/glossary#transaction-type
@@ -11,6 +11,12 @@ description: "Specification of the deposit mechanism for Base, detailing how L1 
 [g-user-deposited]: ../../reference/glossary#user-deposited-transaction
 [g-eoa]: ../../reference/glossary#eoa
 [g-exec-engine]: ../../reference/glossary#execution-engine
+
+A deposit is a transaction initiated outside Base that becomes a transaction on Base. For Ethereum deposits, the L1 transaction emits data that Base nodes use to derive a corresponding L2 deposit transaction.
+
+Deposit transactions are included as part of the protocol. They do not use the same signature, nonce, or fee fields as ordinary L2 transactions because they are authorized by the L1 deposit event and pay for L2 gas on L1. For most users, the practical result is simple: after the source-chain transaction is confirmed and processed, the asset or message appears on Base.
+
+For available bridge routes, see [Bridge to Base](/base-chain/network-information/ecosystem-bridges).
 
 ## Overview
 

--- a/docs/base-chain/specs/protocol/bridging/withdrawals.mdx
+++ b/docs/base-chain/specs/protocol/bridging/withdrawals.mdx
@@ -1,12 +1,24 @@
 ---
 title: "Withdrawals"
-description: "Specification of the withdrawal mechanism for Base, describing how L2 state is proven on L1 and funds are released from the bridge."
+description: "How withdrawals work on Base — the standard 3-step flow, the 7-day challenge period, faster options, and the full protocol specification."
 ---
 
 [g-deposits]: ../../reference/glossary#deposits
 [g-withdrawal]: ../../reference/glossary#withdrawal
 [g-relayer]: ../../reference/glossary#withdrawals
 [g-execution-engine]: ../../reference/glossary#execution-engine
+
+A standard withdrawal is a cross-domain transaction initiated on Base and finalized on Ethereum. Standard withdrawals can transfer ETH, bridge supported ERC-20 tokens, or send a message from Base to an L1 contract. The flow has three stages:
+
+1. **Initiate on Base:** the withdrawal transaction is sent on Base. This records the withdrawal message in the `L2ToL1MessagePasser` contract.
+2. **Prove on Ethereum:** after the relevant Base state has been posted to Ethereum, anyone can submit a proof to the `OptimismPortal` contract showing that the withdrawal message exists on Base.
+3. **Finalize on Ethereum:** after the 7-day challenge period has passed, anyone can finalize the withdrawal on Ethereum. Finalization releases the assets or relays the message to the target contract.
+
+<Note>
+Standard withdrawals to Ethereum must wait 7 days before they can be finalized. Base uses fault proofs to secure withdrawals — the challenge period gives network participants time to dispute an invalid output root before withdrawals that depend on it can be finalized. See [Transaction Finality](/base-chain/network-information/transaction-finality#finality-for-withdrawal-transactions) for how withdrawal finality differs from ordinary Base transaction finality.
+</Note>
+
+Some bridge providers offer faster withdrawals by using liquidity, relayers, or market makers to give users funds before the standard withdrawal has fully finalized. See [Bridge to Base](/base-chain/network-information/ecosystem-bridges) for available routes.
 
 ## Overview
 

--- a/docs/content-guidelines.md
+++ b/docs/content-guidelines.md
@@ -95,11 +95,11 @@ description: "Concise description explaining page purpose and value"
 
 ## Specification Pages
 
-Content structure and writing guidelines for Base Protocol specification pages — Core Primitives and Network Systems.
+Content structure and writing guidelines for Specifications pages.
 
 ### Page Types
 
-Every feature or subsystem in Core Primitives and Network Systems uses a combination of these page types:
+Every feature or subsystem in the Specifications tab uses a combination of these page types:
 
 | Page type | Purpose | Example |
 |-----------|---------|---------|
@@ -162,12 +162,7 @@ Not every feature needs all four types. A single-page feature (e.g., network fee
 
 A feature gets a nested group in the sidebar (like B20, Bridging, Proofs) when it has 3+ pages. Features with 1–2 pages sit as flat entries in the parent group.
 
-| Core Primitives | Network Systems |
-|-----------------|-----------------|
-| Things developers interact with directly | Protocol internals that power the chain |
-| User-facing behavior: tokens, transactions, fees, bridges | Infrastructure: batcher, derivation, execution, proofs |
-| "What can I do on Base?" | "How does Base work under the hood?" |
-| Audience: app developers, integrators | Audience: protocol engineers, node operators, researchers |
+Content is organized by topic (B20, Bridging, Transactions, Consensus, Execution, Proofs, etc.), not by abstraction level. Each topic group flows from user-facing overview to deep protocol spec. A feature gets a nested group in the sidebar when it has 3+ pages; features with 1–2 pages sit as flat entries or single-page groups.
 
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -869,6 +869,14 @@
       "destination": "/base-chain/specs/protocol/bridging/withdrawals"
     },
     {
+      "source": "/base-chain/network-information/network-faucets",
+      "destination": "/get-started/get-funds"
+    },
+    {
+      "source": "/base-chain/quickstart/connecting-to-base",
+      "destination": "/get-started/connect-to-base"
+    },
+    {
       "source": "/base-account",
       "destination": "/sdks/base-account/overview"
     },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,7 +43,8 @@
               "get-started/base",
               "get-started/connect-to-base",
               "get-started/get-funds",
-              "get-started/make-a-transaction"
+              "get-started/make-a-transaction",
+              "base-chain/network-information/ecosystem-bridges"
             ]
           },
           {
@@ -175,13 +176,6 @@
             "group": "Specifications",
             "pages": [
               "base-chain/overview",
-              "base-chain/quickstart/connecting-to-base",
-              "base-chain/network-information/network-faucets"
-            ]
-          },
-          {
-            "group": "Core Primitives",
-            "pages": [
               {
                 "group": "B20",
                 "pages": [
@@ -214,36 +208,40 @@
               {
                 "group": "Bridging",
                 "pages": [
-                  "base-chain/network-information/ecosystem-bridges",
-                  "base-chain/network-information/base-solana-bridge",
-                  "base-chain/network-information/bridging-and-withdrawals"
+                  "base-chain/specs/protocol/bridging/bridges",
+                  "base-chain/specs/protocol/bridging/deposits",
+                  "base-chain/specs/protocol/bridging/withdrawals",
+                  "base-chain/specs/protocol/bridging/messengers",
+                  "base-chain/network-information/base-solana-bridge"
                 ]
               },
-              "base-chain/network-information/network-fees",
               {
                 "group": "Transactions",
                 "pages": [
                   "base-chain/network-information/transaction-ordering",
                   "base-chain/network-information/transaction-finality",
+                  "base-chain/network-information/network-fees",
+                  "base-chain/network-information/throughput-and-limits",
                   "base-chain/network-information/troubleshooting-transactions"
                 ]
               },
-              "base-chain/flashblocks/faq"
-            ]
-          },
-          {
-            "group": "Network Systems",
-            "pages": [
-              "base-chain/specs/overview",
-              "base-chain/specs/protocol/overview",
-              "base-chain/specs/protocol/batcher",
               {
-                "group": "Bridging",
+                "group": "Flashblocks",
                 "pages": [
-                  "base-chain/specs/protocol/bridging/bridges",
-                  "base-chain/specs/protocol/bridging/deposits",
-                  "base-chain/specs/protocol/bridging/messengers",
-                  "base-chain/specs/protocol/bridging/withdrawals"
+                  "base-chain/flashblocks/faq"
+                ]
+              },
+              {
+                "group": "Protocol Overview",
+                "pages": [
+                  "base-chain/specs/overview",
+                  "base-chain/specs/protocol/overview"
+                ]
+              },
+              {
+                "group": "Batcher",
+                "pages": [
+                  "base-chain/specs/protocol/batcher"
                 ]
               },
               {
@@ -275,8 +273,7 @@
                   "base-chain/specs/protocol/proofs/zk-prover",
                   "base-chain/specs/protocol/proofs/contracts"
                 ]
-              },
-              "base-chain/network-information/throughput-and-limits"
+              }
             ]
           },
           {
@@ -867,6 +864,10 @@
     ]
   },
   "redirects": [
+    {
+      "source": "/base-chain/network-information/bridging-and-withdrawals",
+      "destination": "/base-chain/specs/protocol/bridging/withdrawals"
+    },
     {
       "source": "/base-account",
       "destination": "/sdks/base-account/overview"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1966,7 +1966,7 @@
     },
     {
       "source": "/base-chain/tools/network-faucets",
-      "destination": "/base-chain/network-information/network-faucets"
+      "destination": "/get-started/get-funds"
     },
     {
       "source": "/base-chain/tools/node-providers",
@@ -2326,7 +2326,7 @@
     },
     {
       "source": "/chain/connecting-to-base",
-      "destination": "/base-chain/quickstart/connecting-to-base"
+      "destination": "/get-started/connect-to-base"
     },
     {
       "source": "/chain/cross-chain",
@@ -2370,11 +2370,11 @@
     },
     {
       "source": "/chain/network-faucets",
-      "destination": "/base-chain/network-information/network-faucets"
+      "destination": "/get-started/get-funds"
     },
     {
       "source": "/chain/network-information",
-      "destination": "/base-chain/quickstart/connecting-to-base"
+      "destination": "/get-started/connect-to-base"
     },
     {
       "source": "/chain/node-performance",
@@ -2434,7 +2434,7 @@
     },
     {
       "source": "/chain/using-base",
-      "destination": "/base-chain/quickstart/connecting-to-base"
+      "destination": "/get-started/connect-to-base"
     },
     {
       "source": "/chain/wallet",
@@ -2542,11 +2542,11 @@
     },
     {
       "source": "/docs/network-information",
-      "destination": "/base-chain/quickstart/connecting-to-base"
+      "destination": "/get-started/connect-to-base"
     },
     {
       "source": "/docs/tools/network-faucets",
-      "destination": "/base-chain/network-information/network-faucets"
+      "destination": "/get-started/get-funds"
     },
     {
       "source": "/feedback",
@@ -2894,7 +2894,7 @@
     },
     {
       "source": "/network-information",
-      "destination": "/base-chain/quickstart/connecting-to-base"
+      "destination": "/get-started/connect-to-base"
     },
     {
       "source": "/quickstart",
@@ -2910,7 +2910,7 @@
     },
     {
       "source": "/tools/network-faucets",
-      "destination": "/base-chain/network-information/network-faucets"
+      "destination": "/get-started/get-funds"
     },
     {
       "source": "/tutorials/deploy-with-foundry",

--- a/docs/ia-guidelines.md
+++ b/docs/ia-guidelines.md
@@ -46,7 +46,7 @@ What belongs in each navigation tab and section — and what doesn't. Use this w
 ### Overview
 
 - **Belongs**: Build on Base landing page and Vibenet testing guide.
-- **Does not belong**: Chain-level concepts (fees, finality, throughput) — those go in Base Protocol → Core Primitives.
+- **Does not belong**: Chain-level concepts (fees, finality, throughput) — those go in Specifications → Transactions.
 
 ### Integrate DeFi
 
@@ -56,17 +56,17 @@ What belongs in each navigation tab and section — and what doesn't. Use this w
 ### Tokenize Assets
 
 - **Belongs**: Step-by-step guides for asset tokenization: create an asset token, issue units, restrict holders, cancel blocked units, announce distributions, apply multipliers, and pause transfers.
-- **Does not belong**: B20 Asset variant specification details (those live in Base Protocol → Core Primitives → B20).
+- **Does not belong**: B20 Asset variant specification details (those live in Specifications → B20).
 
 ### Issue Stablecoins
 
 - **Belongs**: End-to-end guides for stablecoin issuers: deploy, mint, burn, restrict holders, block accounts, recover funds, pause, reconcile with memos. Each page is a task the issuer completes.
-- **Does not belong**: The B20 specification itself (that's Base Protocol → Core Primitives → B20). These guides *use* B20 but don't *define* it.
+- **Does not belong**: The B20 specification itself (that's Specifications → B20). These guides *use* B20 but don't *define* it.
 
 ### Accept Payments
 
 - **Belongs**: Guides for requesting, authorizing, capturing, verifying, and reconciling payments, plus refunds, payouts, splits, scheduled charges, and agentic payments.
-- **Does not belong**: B20 memo specification (Base Protocol → Core Primitives → B20). x402 protocol spec.
+- **Does not belong**: B20 memo specification (Specifications → B20). x402 protocol spec.
 
 ---
 
@@ -74,44 +74,72 @@ What belongs in each navigation tab and section — and what doesn't. Use this w
 
 **Audience**: Developers and technical users who need to understand how Base works at the chain level — primitives, protocol internals, network configuration, and node operations.
 
-### Base Protocol (Landing)
+Content is organized by topic, not by abstraction level. Each topic group flows from user-facing overview to deep protocol spec, so developers find everything about a subject in one place.
 
-- **Belongs**: Chain overview, connecting to Base quickstart, faucets. Entry points into the protocol tab.
-- **Does not belong**: Integration guides or solutions-first style writing. This section is meant for technical-first style writing. SDK setup (that's SDKs & APIs).
+**Changelog pattern**: Each topic group should include a changelog summary page that lists what changed per hardfork and links out to the detail entries in the Upgrades tab. The summary page lives here; the detail pages live in Upgrades under the hardfork that introduced them.
 
-### Core Primitives
+**Content structure**: See the [Specification Pages](../content-guidelines.md#specification-pages) section of the content guidelines for page types, page structure, and writing rules.
 
-- **Belongs**: Specifications and reference material for Base-native primitives that developers interact with directly: B20 token standard (full spec, interfaces, constants, errors, invariants), native account abstraction, bridging options, network fees, transaction ordering/finality, Flashblocks.
-- **Does not belong**: How-to guides for using these primitives (those go in Build on Base). API endpoint reference (SDKs & APIs). Per-hardfork changelog detail pages (those go in Upgrades → the hardfork group).
-- **Changelog pattern**: Each feature or subsystem in Core Primitives should include a changelog summary page that lists what changed per hardfork and links out to the detail entries in the Upgrades tab. The summary page lives here; the detail pages live in Upgrades under the hardfork that introduced them.
-- **Content structure**: See the [Specification Pages](../content-guidelines.md#specification-pages) section of the content guidelines for page types, page structure, and writing rules.
+### Specifications (Landing)
 
-#### B20 (Nested Group)
+- **Belongs**: Chain overview, connecting to Base quickstart, faucets. Entry points into the Specifications tab.
+- **Does not belong**: Integration guides or solutions-first style writing. This tab is meant for technical-first style writing. SDK setup (that's SDKs & APIs).
+
+### B20
 
 - **Belongs**: The normative B20 specification: index page, constants and addresses, errors and events, invariants and tests, interface reference pages (IActivationRegistry, IB20, IB20Asset, IB20Factory, IB20Stablecoin, IPolicyRegistry), and a changelog summary page that links to the per-hardfork detail entries in the Upgrades tab.
 - **Does not belong**: Tutorials on deploying B20 tokens (Build on Base → Issue Stablecoins). Per-hardfork changelog detail pages (Upgrades → Cobalt, Beryl, etc.). The "B20 token standard" overview for general audiences (that's a network-information page, not the spec).
 
-#### Bridging (Nested Group)
+### Account Abstraction
 
-- **Belongs**: Ecosystem bridges overview, Base-Solana bridge, bridging and withdrawals user guide, and a changelog summary page linking to hardfork entries that changed bridging.
-- **Does not belong**: Protocol-level bridging specs (those go in Network Systems → Bridging).
+- **Belongs**: Native account abstraction specification for Base. Listed as a top-level page, not a dropdown group (single-page groups should be promoted to top-level pages).
+- **Does not belong**: SDK integration guides for smart wallets (SDKs & APIs → Base Account SDK).
 
-#### Transactions (Nested Group)
+### Bridging
 
-- **Belongs**: Transaction ordering, transaction finality — how users experience transactions. Include a changelog summary page linking to hardfork entries that changed transaction behavior.
-- **Does not belong**: Derivation pipeline or consensus specs (Network Systems → Consensus).
+- **Belongs**: Standard bridges contract spec, deposits spec, withdrawals spec, cross-domain messengers spec, Base-Solana bridge. Include a changelog summary page linking to hardfork entries that changed bridging.
+- **Does not belong**: User-facing bridge route picker (that's Get Started → Quickstart). How-to guides for building bridge integrations (Build on Base). Per-hardfork changelog detail pages (Upgrades).
+- **Ordering**: Standard bridges → deposits → withdrawals → cross-domain messengers → Base-Solana bridge. Protocol specs first (general to specific), then the first-party ecosystem bridge.
 
-### Network Systems
+### Transactions
 
-- **Belongs**: Protocol-level specifications: batcher, bridging internals (deposits, withdrawals, messengers), consensus (derivation, P2P, RPC), execution (precompiles, predeploys, preinstalls), proofs (challenger, proposer, registrar, TEE prover, ZK prover, contracts), throughput and limits.
-- **Does not belong**: User-facing network info (fees, faucets — those are Core Primitives or the landing group). Hardfork-specific changes (Upgrades). B20 spec (Core Primitives).
-- **Changelog pattern**: Same as Core Primitives — each subsystem (batcher, consensus, execution, proofs, etc.) should include a changelog summary page that lists per-hardfork changes and links out to the detail entries in the Upgrades tab.
-- **Content structure**: See the [Specification Pages](../content-guidelines.md#specification-pages) section of the content guidelines — same page types and writing rules as Core Primitives.
+- **Belongs**: Transaction ordering, transaction finality, network fees, throughput and limits, troubleshooting transactions. Everything about how transactions work on Base, from user experience to network parameters.
+- **Does not belong**: Derivation pipeline or consensus specs (Consensus). Per-hardfork changelog detail pages (Upgrades).
+
+### Flashblocks
+
+- **Belongs**: Flashblocks reference — key concepts, architecture, and FAQ about block building, WebSocket data, RPC usage, and node setup.
+- **Does not belong**: Flashblocks API methods (SDKs & APIs → Base Chain API). Transaction ordering details (Transactions).
+
+### Protocol Overview
+
+- **Belongs**: Design philosophy and lineage (specs/overview), and the detailed protocol architecture with component diagrams and user flow walkthroughs (specs/protocol/overview).
+- **Does not belong**: Per-component specs (those go in their respective topic groups: Consensus, Execution, Proofs, etc.).
+
+### Batcher
+
+- **Belongs**: Batcher specification — how transaction batches are compressed and posted to Ethereum for data availability.
+- **Does not belong**: Derivation details (Consensus). Hardfork-specific batcher changes (Upgrades).
+
+### Consensus
+
+- **Belongs**: Consensus specifications: derivation pipeline, P2P networking, RPC methods for consensus.
+- **Does not belong**: Batcher (separate group). Execution engine details (Execution). Hardfork-specific changes (Upgrades).
+
+### Execution
+
+- **Belongs**: Execution specifications: EVM precompiles, predeploys, preinstalls.
+- **Does not belong**: Consensus or derivation details (Consensus). Hardfork-specific changes (Upgrades).
+
+### Proofs
+
+- **Belongs**: Proof system specifications: challenger, proposer, registrar, TEE prover, ZK prover, proof contracts.
+- **Does not belong**: Consensus or derivation details (Consensus). Hardfork-specific changes (Upgrades).
 
 ### Reference
 
-- **Belongs**: Node providers list, base contracts, glossary, configurability reference, troubleshooting transactions. Lookup-oriented content.
-- **Does not belong**: The B20 spec (that moved to Core Primitives). API endpoints (SDKs & APIs). Step-by-step guides of any kind.
+- **Belongs**: Builder codes, base contracts, smart contracts, configurability reference, glossary. Lookup-oriented content.
+- **Does not belong**: The B20 spec (that's in B20). API endpoints (SDKs & APIs). Step-by-step guides of any kind.
 
 ### Node Operators
 
@@ -137,7 +165,7 @@ What belongs in each navigation tab and section — and what doesn't. Use this w
 ### Base Chain API
 
 - **Belongs**: RPC overview, Ethereum JSON-RPC API methods, Flashblocks API methods, Debug API methods. Each page documents one RPC endpoint.
-- **Does not belong**: SDK wrapper methods (Base Account SDK). Flashblocks conceptual explainer (Base Protocol → Core Primitives). Node setup (Base Protocol → Node Operators).
+- **Does not belong**: SDK wrapper methods (Base Account SDK). Flashblocks conceptual explainer (Specifications → Flashblocks). Node setup (Base Protocol → Node Operators).
 
 ### Base Account SDK
 
@@ -170,7 +198,7 @@ What belongs in each navigation tab and section — and what doesn't. Use this w
 ### Optimism (Hardfork Groups)
 
 - **Belongs**: Upstream OP Stack hardfork specs that Base inherits (Jovian, Isthmus, Holocene, Granite, Fjord, Ecotone, Delta, Canyon). Each gets an overview plus per-component pages (exec-engine, derivation, predeploys, etc.).
-- **Does not belong**: Base-specific hardfork content (use the Base-named groups above). Current protocol specs (Base Protocol → Network Systems).
+- **Does not belong**: Base-specific hardfork content (use the Base-named groups above). Current protocol specs (Specifications → topic groups).
 
 ---
 
@@ -180,16 +208,23 @@ Key IA decisions from past reorganizations, for context:
 
 | Decision | Rationale |
 |----------|-----------|
-| B20 spec moved from Reference to Core Primitives | B20 is a first-class primitive developers interact with, not a lookup reference |
+| Topic-based groups replace Core Primitives / Network Systems | Developers navigate by topic (bridging, transactions), not by abstraction level (user-facing vs protocol internals). The old split created duplicate sidebar groups (two "Bridging" sections) and arbitrary placement decisions. Topic-based groups flow from overview → deep spec within each subject. |
+| B20 spec moved from Reference to its own group | B20 is a first-class primitive developers interact with, not a lookup reference |
 | How-to guides separated from specs | Build on Base is task-oriented (issue, accept, tokenize); Specifications is concept/spec-oriented |
 | API reference lives in SDKs & APIs, not Specifications | Developers looking for RPC methods think "API docs", not "protocol" |
-| Hardfork specs live in Upgrades, not Network Systems | Network Systems is the *current* canonical state; Upgrades tracks *deltas* |
+| Hardfork specs live in Upgrades, not topic groups | Topic groups are the *current* canonical state; Upgrades tracks *deltas* |
 | No per-feature upgrade groups | Feature changes (e.g., B20) go under the hardfork that introduced them (Cobalt, Beryl), not a standalone section |
-| Changelog summary pages in Specifications | Each Core Primitives and Network Systems feature gets a changelog summary page that links out to detail entries in the Upgrades tab — Specifications owns the spec and the summary, Upgrades owns the migration details |
+| Changelog summary pages in Specifications | Each topic group gets a changelog summary page that links out to detail entries in the Upgrades tab — Specifications owns the spec and the summary, Upgrades owns the migration details |
 | Node operators stay in Specifications | Node ops are protocol-adjacent, not SDK/API work |
 | Get Started → Solutions are entry ramps only | They link to Build on Base guides, they don't duplicate them |
 | Mini Apps renamed to Apps | Broader scope, `/mini-apps/` paths redirect to `/apps/` |
 | Tokenize Stocks renamed to Tokenize Assets | Broader scope for asset tokenization beyond equities |
+
+---
+
+## Navigation Structure
+
+- **No single-page dropdown groups**: If a group contains only one page, remove the group wrapper and list the page as a top-level nav item instead. A dropdown that expands to reveal a single link adds a click without adding value.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Replaces Core Primitives / Network Systems with topic-based groups** in the Specifications tab. Developers navigate by subject (Bridging, Transactions, etc.) instead of by abstraction level, eliminating duplicate sidebar groups.
- **Consolidates two Bridging sections** into one group with a clear ordering: Standard Bridges → Deposits → Withdrawals → Cross-Domain Messengers → Base-Solana Bridge.
- **Dissolves `bridging-and-withdrawals.mdx`** — its accessible intro content was redistributed into the spec pages (`deposits.mdx`, `withdrawals.mdx`, `bridges.mdx`) so each page stands on its own.
- **Moves ecosystem bridges route picker** from Specifications to Get Started → Quickstart (user-facing, not a spec).
- **Updates overview page** cards to match the new topic-based groups.
- **Updates IA guidelines and content guidelines** to reflect the new structure and decision rationale.

## Test plan

- [ ] Run `mintlify dev` and verify all Specifications pages render correctly
- [ ] Confirm sidebar groups appear in the intended order with no duplicates
- [ ] Verify the redirect from `bridging-and-withdrawals` → `withdrawals` works
- [ ] Check that ecosystem bridges appears under Get Started → Quickstart
- [ ] Run `/lint` and confirm no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)