### PR TITLE
Fix text color bugs in demo scenario pills and link buttons

### DIFF
--- a/docs/snippets/AssetDemo.jsx
+++ b/docs/snippets/AssetDemo.jsx
@@ -284,7 +284,7 @@ export const AssetDemo = ({ flow }) => {
         .wf-btn2 { font-family: ${sans}; font-size: 13px; font-weight: 600; border-radius: 6px; padding: 10px 14px; cursor: pointer; background: ${C.white}; border: 1px solid ${C.border}; color: ${C.body}; width: 100%; transition: background .15s ease; }
         .wf-btn2:hover { background: ${C.panel}; }
         .wf-pill { font-family: ${sans}; font-size: 12px; font-weight: 500; border-radius: 6px; padding: 5px 10px; cursor: pointer; white-space: nowrap; color: ${C.sec}; background: ${C.white}; border: 1px solid ${C.border}; transition: all .12s ease; }
-        .wf-pill:hover { color: ${C.ink}; border-color: ${C.sub}; }
+        .wf-pill:not(.wf-pill-on):hover { color: ${C.ink}; border-color: ${C.sub}; }
         .wf-pill-on { color: ${C.onBlue}; background: ${C.blue}; border-color: ${C.blue}; }
         .wf-stage { font-family: ${sans}; font-size: 12.5px; white-space: nowrap; padding: 11px 2px; border-bottom: 2px solid transparent; display: inline-flex; align-items: center; gap: 7px; }
         @media (max-width: 640px) {
@@ -386,7 +386,7 @@ export const AssetDemo = ({ flow }) => {
               </div>
               <div className="wf-t-body" style={{ color: C.body, margin: "12px 0 16px" }}>{f.title} — every step ran onchain in the simulation above.</div>
               <button className="wf-btn2" onClick={reset}>Run again</button>
-              <a className="wf-btn" href="/base-chain/network-information/b20-token-standard" style={{ textDecoration: "none", marginTop: 8, display: "flex", boxSizing: "border-box" }}>See technical details →</a>
+              <a className="wf-btn" href="/base-chain/network-information/b20-token-standard" style={{ textDecoration: "none", color: C.onBlue, marginTop: 8, display: "flex", boxSizing: "border-box" }}>See technical details →</a>
             </div>
           ) : (
             <div className="wf-anim" key={stepIndex}>

--- a/docs/snippets/B20PlaygroundDemo.jsx
+++ b/docs/snippets/B20PlaygroundDemo.jsx
@@ -562,7 +562,7 @@ export const B20FlowDemo = ({ flow }) => {
         .wf-btn2 { font-family: ${sans}; font-size: 13px; font-weight: 600; border-radius: 6px; padding: 10px 14px; cursor: pointer; background: ${C.white}; border: 1px solid ${C.border}; color: ${C.body}; width: 100%; transition: background .15s ease; }
         .wf-btn2:hover { background: ${C.panel}; }
         .wf-pill { font-family: ${sans}; font-size: 12px; font-weight: 500; border-radius: 6px; padding: 5px 10px; cursor: pointer; white-space: nowrap; color: ${C.sec}; background: ${C.white}; border: 1px solid ${C.border}; transition: all .12s ease; }
-        .wf-pill:hover { color: ${C.ink}; border-color: ${C.sub}; }
+        .wf-pill:not(.wf-pill-on):hover { color: ${C.ink}; border-color: ${C.sub}; }
         .wf-pill-on { color: ${C.onBlue}; background: ${C.blue}; border-color: ${C.blue}; }
         .wf-stage { font-family: ${sans}; font-size: 12.5px; white-space: nowrap; padding: 11px 2px; border-bottom: 2px solid transparent; display: inline-flex; align-items: center; gap: 7px; }
         @media (max-width: 640px) {

--- a/docs/snippets/DeFiDemo.jsx
+++ b/docs/snippets/DeFiDemo.jsx
@@ -237,7 +237,7 @@ export const DeFiDemo = ({ flow }) => {
         .wf-btn2 { font-family: ${sans}; font-size: 13px; font-weight: 600; border-radius: 6px; padding: 10px 14px; cursor: pointer; background: ${C.white}; border: 1px solid ${C.border}; color: ${C.body}; width: 100%; transition: background .15s ease; }
         .wf-btn2:hover { background: ${C.panel}; }
         .wf-pill { font-family: ${sans}; font-size: 12px; font-weight: 500; border-radius: 6px; padding: 5px 10px; cursor: pointer; white-space: nowrap; color: ${C.sec}; background: ${C.white}; border: 1px solid ${C.border}; transition: all .12s ease; }
-        .wf-pill:hover { color: ${C.ink}; border-color: ${C.sub}; }
+        .wf-pill:not(.wf-pill-on):hover { color: ${C.ink}; border-color: ${C.sub}; }
         .wf-pill-on { color: ${C.onBlue}; background: ${C.blue}; border-color: ${C.blue}; }
         .wf-stage { font-family: ${sans}; font-size: 12.5px; white-space: nowrap; padding: 11px 2px; border-bottom: 2px solid transparent; display: inline-flex; align-items: center; gap: 7px; }
         @media (max-width: 640px) {
@@ -336,7 +336,7 @@ export const DeFiDemo = ({ flow }) => {
               </div>
               <div className="wf-t-body" style={{ color: C.body, margin: "12px 0 16px" }}>{f.title} — every step ran onchain in the simulation above.</div>
               <button className="wf-btn2" onClick={reset}>Run again</button>
-              <a className="wf-btn" href={f.href} style={{ textDecoration: "none", marginTop: 8, display: "flex", boxSizing: "border-box" }}>See technical details →</a>
+              <a className="wf-btn" href={f.href} style={{ textDecoration: "none", color: C.onBlue, marginTop: 8, display: "flex", boxSizing: "border-box" }}>See technical details →</a>
             </div>
           ) : (
             <div className="wf-anim" key={stepIndex}>

--- a/docs/snippets/PaymentsDemo.jsx
+++ b/docs/snippets/PaymentsDemo.jsx
@@ -447,7 +447,7 @@ export const PaymentsDemo = ({ flow }) => {
         .wf-btn2 { font-family: ${sans}; font-size: 13px; font-weight: 600; border-radius: 6px; padding: 10px 14px; cursor: pointer; background: ${C.white}; border: 1px solid ${C.border}; color: ${C.body}; width: 100%; transition: background .15s ease; }
         .wf-btn2:hover { background: ${C.panel}; }
         .wf-pill { font-family: ${sans}; font-size: 12px; font-weight: 500; border-radius: 6px; padding: 5px 10px; cursor: pointer; white-space: nowrap; color: ${C.sec}; background: ${C.white}; border: 1px solid ${C.border}; transition: all .12s ease; }
-        .wf-pill:hover { color: ${C.ink}; border-color: ${C.sub}; }
+        .wf-pill:not(.wf-pill-on):hover { color: ${C.ink}; border-color: ${C.sub}; }
         .wf-pill-on { color: ${C.onBlue}; background: ${C.blue}; border-color: ${C.blue}; }
         .wf-stage { font-family: ${sans}; font-size: 12.5px; white-space: nowrap; padding: 11px 2px; border-bottom: 2px solid transparent; display: inline-flex; align-items: center; gap: 7px; }
         @media (max-width: 640px) {
@@ -565,7 +565,7 @@ export const PaymentsDemo = ({ flow }) => {
               </div>
               <div className="wf-t-body" style={{ color: C.body, margin: "12px 0 16px" }}>{f.title} — every step completed in the mock simulation above.</div>
               <button className="wf-btn2" onClick={reset}>Run again</button>
-              <a className="wf-btn" href={f.href || "/build-on-base/accept-payments/request-a-payment"} style={{ textDecoration: "none", marginTop: 8, display: "flex", boxSizing: "border-box" }}>See technical details →</a>
+              <a className="wf-btn" href={f.href || "/build-on-base/accept-payments/request-a-payment"} style={{ textDecoration: "none", color: C.onBlue, marginTop: 8, display: "flex", boxSizing: "border-box" }}>See technical details →</a>
             </div>
           ) : (
             <div className="wf-anim" key={stepIndex}>

--- a/docs/snippets/StablecoinDemo.jsx
+++ b/docs/snippets/StablecoinDemo.jsx
@@ -309,7 +309,7 @@ export const StablecoinDemo = ({ flow }) => {
         .wf-btn2 { font-family: var(--wf-sans); font-size: 14px; font-weight: 500; letter-spacing: -0.01em; border-radius: 6px; padding: 10px 14px; cursor: pointer; background: ${C.white}; border: 1px solid ${C.border}; color: ${C.body}; width: 100%; transition: background .15s ease; }
         .wf-btn2:hover { background: ${C.panel}; }
         .wf-pill { font-family: var(--wf-sans); font-size: 12px; font-weight: 500; border-radius: 6px; padding: 5px 10px; cursor: pointer; white-space: nowrap; color: ${C.sec}; background: ${C.white}; border: 1px solid ${C.border}; transition: all .12s ease; }
-        .wf-pill:hover { color: ${C.ink}; border-color: ${C.sub}; }
+        .wf-pill:not(.wf-pill-on):hover { color: ${C.ink}; border-color: ${C.sub}; }
         .wf-pill-on { color: ${C.onBlue}; background: ${C.blue}; border-color: ${C.blue}; }
         .wf-stage { font-family: var(--wf-sans); font-size: 12.5px; white-space: nowrap; padding: 11px 2px; border-bottom: 2px solid transparent; display: inline-flex; align-items: center; gap: 7px; }
         @media (max-width: 640px) {
@@ -410,7 +410,7 @@ export const StablecoinDemo = ({ flow }) => {
               </div>
               <div className="wf-t-body" style={{ color: C.body, margin: "12px 0 16px" }}>{f.title} — every step ran onchain in the simulation above.</div>
               <button className="wf-btn2" onClick={reset}>Run again</button>
-              <a className="wf-btn" href="/base-chain/network-information/b20-token-standard" style={{ textDecoration: "none", marginTop: 8, display: "flex", boxSizing: "border-box" }}>See technical details →</a>
+              <a className="wf-btn" href="/base-chain/network-information/b20-token-standard" style={{ textDecoration: "none", color: C.onBlue, marginTop: 8, display: "flex", boxSizing: "border-box" }}>See technical details →</a>
             </div>
           ) : (
             <div className="wf-anim" key={stepIndex}>


### PR DESCRIPTION
**What changed? Why?**

Two text-color bugs in the interactive demo snippets (`docs/snippets/*Demo.jsx`) made text illegible or invisible:

1. **Selected scenario pill turned black on hover.** The shared `.wf-pill:hover` rule sets text to near-black ink, and its `:hover` pseudo-class gives it higher specificity than the active `.wf-pill-on` class — so hovering the selected blue pill (e.g. "Lend") rendered black text on a blue background. Fixed by scoping the hover rule to `.wf-pill:not(.wf-pill-on):hover`, so only unselected pills get the hover treatment.

2. **"See technical details →" button appeared empty.** The link-styled button on the "Flow complete" screen relies on `a.wf-btn { color: var(--wf-on-blue) }`, but the docs site's global link styles out-specify it and repaint the text blue — blue-on-blue, invisible. Fixed by setting `color: C.onBlue` inline on the anchor, which wins regardless of stylesheet specificity.

Both bugs were copy-pasted across the demo components, so all affected files are patched: `DeFiDemo.jsx`, `AssetDemo.jsx`, `PaymentsDemo.jsx`, `StablecoinDemo.jsx`, `B20PlaygroundDemo.jsx`.

**Notes to reviewers**

Pure CSS/style fixes — no behavior, content, or navigation changes.

**How has it been tested?**

Verified locally with `mint dev` on `/get-started/integrate-defi`: the selected pill keeps white-on-blue text on hover, unselected pills retain their hover effect, and the "See technical details →" button text is visible on the flow-complete screen.