### PR TITLE
docs: fix duplicate H1 headings in Holocene derivation spec

### DIFF
--- a/docs/base-chain/specs/upgrades/holocene/derivation.mdx
+++ b/docs/base-chain/specs/upgrades/holocene/derivation.mdx
@@ -218,9 +218,9 @@ partially submitted channel that were included pre-Holocene must be sent again. 
 unlikely scenario since production batchers are usually configured to submit a channel in a single
 transaction.
 
-# Rationale
+## Rationale
 
-## Strict Frame and Batch Ordering
+### Strict Frame and Batch Ordering
 
 Strict Frame and Batch Ordering simplifies implementations of the derivation pipeline, and leads to
 better worst-case cached data usage.
@@ -234,7 +234,7 @@ batch (from the span batch, or the staging channel directly)
 
 This has advantages for Fault Proof program implementations.
 
-## Partial Span Batch Validity
+### Partial Span Batch Validity
 
 Partial Span Batch Validity guarantees that a valid singular batch derived from a span batch can
 immediately be processed as valid and advance the safe chain, instead of being in an undecided state
@@ -243,14 +243,14 @@ gives strong worst-case guarantees for Fault Proofs because the validity of a bl
 on the validity of any future blocks any more. Note that before Holocene, to verify the first block
 of a span batch required validating the full span batch.
 
-## Fast Channel Invalidation
+### Fast Channel Invalidation
 
 The new Fast Channel Invalidation rule is a consistency implication of the Strict Ordering Rules.
 Because batches inside channels must be ordered and contiguous, assuming that all batches inside a
 channel are self-consistent (i.e., parent L2 hashes point to the block resulting from the previous
 batch), an invalid batch also forward-invalidates all remaining batches of the same channel.
 
-## Steady Block Derivation
+### Steady Block Derivation
 
 Steady Block Derivation changes the derivation rules for invalid payload attributes, replacing an
 invalid payload by a deposit-only/empty payload. Crucially, this means that the effect of an invalid
@@ -259,7 +259,7 @@ and Interop, because it guarantees that batch validity is not influenced by futu
 block derived from a valid batch will be determined by the engine stage before it pulls new payload
 attributes from the previous stage. This avoids larger derivation pipeline resets.
 
-## Less Defensive Protocol
+### Less Defensive Protocol
 
 The stricter derivation rules lead to a less defensive protocol. The old protocol rules allowed for
 second chances for invalid payloads and submitting frames and batches within channels out of order.
@@ -271,9 +271,9 @@ Furthermore, the more relaxed rules created a lot more corner cases and complex 
 made it harder to reason about and test the protocol, increasing the risk of chain splits between
 different implementations.
 
-# Security and Implementation Considerations
+## Security and Implementation Considerations
 
-## Reorgs
+### Reorgs
 
 Before Steady Block Derivation, invalid payloads got second chances to be replaced by valid future
 payloads. Because they will now be immediately replaced by as deposit-only payloads, there is a
@@ -290,7 +290,7 @@ It is this latter case that inspired the Steady Block Derivation rule. It guaran
 secondary effects of an invalid Interop dependency are contained to a single block only, which
 avoids a cascade of cross-L2 Interop reorgs that revisit L2 chains more than once.
 
-## Batcher Hardening
+### Batcher Hardening
 
 In a sense, Holocene shifts some complexity from derivation to the batching phase. Simpler and
 stricter derivation rules need to be met by a more complex batcher implementation.
@@ -318,7 +318,7 @@ sync-status should repeatedly be queried and matched against the expected safe c
 discrepancy, the batcher should then stop batching and wait for the sequencer to fully derive up
 until the latest L1 batcher transactions, and only then continue batching.
 
-## Sync Start
+### Sync Start
 
 Thanks to the new strict frame and batch ordering rules, the sync start algorithm can be simplified
 in the average case. The rules guarantee that


### PR DESCRIPTION
## Problem

`node scripts/lint-mdx.js all` reports this page twice:

```
docs/base-chain/specs/upgrades/holocene/derivation.mdx:221 - Multiple H1 headings found (should have at most one)
docs/base-chain/specs/upgrades/holocene/derivation.mdx:274 - Multiple H1 headings found (should have at most one)
```

`# Rationale` and `# Security and Implementation Considerations` sit at H1 next to the page's own `# Holocene Derivation`, so the document has three top-level headings. The sections under them then render at the same level as the eight H2s belonging to the opening section, so the page outline reads as one flat list rather than three sections.

Of the 187 pages under `docs/base-chain/specs`, this is the only one with more than one H1. The three sibling derivation pages (`consensus`, `fjord`, `isthmus`) each have exactly one.

## Change

Demote the two mid-document H1s to H2 and their subsections to H3. That leaves a single page H1 and puts Rationale and Security alongside Summary, Frame Queue and the rest.

H3 is already this file's subsection level (Pruning, Timeout, Reading & Frame Loading under Channel Bank), so the change introduces nothing new.

Before:

```
# Holocene Derivation
## Summary ... ## Activation
# Rationale
## Strict Frame and Batch Ordering ...
# Security and Implementation Considerations
## Reorgs ...
```

After:

```
# Holocene Derivation
## Summary ... ## Activation
## Rationale
### Strict Frame and Batch Ordering ...
## Security and Implementation Considerations
### Reorgs ...
```

Prose is untouched. The diff is 10 heading lines.

## Verification

- `node scripts/lint-mdx.js docs/base-chain/specs/upgrades/holocene/derivation.mdx` — 0 errors, 0 warnings
- `node scripts/lint-mdx.js all` — repo-wide errors drop from 33 to 31
- `validate-docs-structure`, `check-terminology` and `verify-doc-samples` all still pass

The 31 remaining errors are `Missing frontmatter` on `docs/snippets/**`, which are imported partials (`import { Danger } from "/snippets/danger.mdx"`) and correctly have none. That looks like a linter false positive rather than a docs problem, and there are already open PRs on `lint-mdx.js`, so I left it alone.
