### PR TITLE
fix(nav): remove sidebar entries that repeat their parent group

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -49,6 +49,20 @@ description: "Value description"
 
 Edit `docs.json` to add/remove pages. Add redirects when removing pages.
 
+**Sidebar labels must not repeat their parent group.** A group whose child page
+carries the same label renders as a collapsible that expands to reveal one
+identical entry ("Flashblocks > Flashblocks"), which reads like a bug. The
+sidebar label is `sidebarTitle` if present, otherwise `title`.
+
+- **Single-page group**: drop the group wrapper and list the page as a bare
+  string in the parent's `pages` array.
+- **Multi-page group**: keep the group and give the duplicate child a distinct
+  `sidebarTitle` — usually `"Overview"` (or a qualified name when a sibling
+  already uses "Overview").
+
+`node scripts/validate-docs-structure.js` fails on violations; it runs in CI via
+`scripts/verify-doc-samples.sh` on any `docs/**` change.
+
 ## References
 
 | File | Purpose |
@@ -63,5 +77,6 @@ Edit `docs.json` to add/remove pages. Add redirects when removing pages.
 1. Run `/lint` and fix errors
 2. Run `/agents` if docs structure changed
    - Or include `agents.md` / `llms.txt` in your commit message — the `githooks/post-commit` hook will regenerate the matching index files and create a follow-up commit. Enable hooks once per clone with `git config --local core.hooksPath githooks` (repo-scoped, never global).
-3. Add redirects for removed pages
-4. Verify links work
+3. Run `node scripts/validate-docs-structure.js` if `docs.json` or page frontmatter changed (nav, orphans, redirects, redundant sidebar labels)
+4. Add redirects for removed pages
+5. Verify links work

--- a/docs/base-chain/specs/protocol/proofs/index.mdx
+++ b/docs/base-chain/specs/protocol/proofs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Proofs"
+sidebarTitle: "Overview"
 description: "Overview of the offchain services and onchain contracts that make L2 checkpoint proposals verifiable from Ethereum in the Azul proof system."
 ---
 

--- a/docs/base-chain/specs/upgrades/delta/overview.mdx
+++ b/docs/base-chain/specs/upgrades/delta/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delta"
+sidebarTitle: "Overview"
 description: "Overview of the Delta hardfork, introducing span batches to reduce L1 data costs by compressing multiple L2 blocks into single batcher transactions."
 ---
 

--- a/docs/base-chain/specs/upgrades/ecotone/overview.mdx
+++ b/docs/base-chain/specs/upgrades/ecotone/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Ecotone"
+sidebarTitle: "Overview"
 description: "Overview of the Ecotone hardfork, integrating Ethereum Dencun changes including EIP-4844 blob transactions and EIP-4788 beacon block roots."
 ---
 

--- a/docs/base-chain/specs/upgrades/fjord/overview.mdx
+++ b/docs/base-chain/specs/upgrades/fjord/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Fjord"
+sidebarTitle: "Overview"
 description: "Overview of the Fjord hardfork, introducing FastLZ-based L1 fee estimation, the RIP-7212 secp256r1 precompile, and brotli channel compression."
 ---
 

--- a/docs/base-chain/specs/upgrades/granite/overview.mdx
+++ b/docs/base-chain/specs/upgrades/granite/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Granite"
+sidebarTitle: "Overview"
 description: "Overview of the Granite hardfork, adding bn256Pairing precompile input size restrictions and CHANNEL_TIMEOUT parameter changes."
 ---
 

--- a/docs/base-chain/specs/upgrades/holocene/overview.mdx
+++ b/docs/base-chain/specs/upgrades/holocene/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Holocene"
+sidebarTitle: "Overview"
 description: "Overview of the Holocene hardfork, introducing dynamic EIP-1559 parameters configurable via SystemConfig and stricter block derivation rules."
 ---
 

--- a/docs/base-chain/specs/upgrades/isthmus/overview.mdx
+++ b/docs/base-chain/specs/upgrades/isthmus/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Isthmus"
+sidebarTitle: "Overview"
 description: "Overview of the Isthmus hardfork, incorporating Ethereum Pectra EIPs and introducing the operator fee mechanism for sequencer revenue."
 ---
 

--- a/docs/base-chain/specs/upgrades/jovian/overview.mdx
+++ b/docs/base-chain/specs/upgrades/jovian/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Jovian"
+sidebarTitle: "Overview"
 description: "Overview of the Jovian hardfork, introducing a configurable minimum base fee and a DA footprint gas scalar for improved fee market stability."
 ---
 

--- a/docs/build-on-base/overview.mdx
+++ b/docs/build-on-base/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+sidebarTitle: "Build on Base"
 keywords: ["build on Base", "Base use cases", "stablecoins DeFi payments Base", "real-world assets Base", "Base solutions"]
 description: "Build financial products on Base by outcome: integrate DeFi, tokenize assets, issue stablecoins, or accept payments."
 ---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -225,12 +225,7 @@
                   "base-chain/network-information/troubleshooting-transactions"
                 ]
               },
-              {
-                "group": "Flashblocks",
-                "pages": [
-                  "base-chain/flashblocks/faq"
-                ]
-              },
+              "base-chain/flashblocks/faq",
               {
                 "group": "Protocol Overview",
                 "pages": [
@@ -238,12 +233,7 @@
                   "base-chain/specs/protocol/overview"
                 ]
               },
-              {
-                "group": "Batcher",
-                "pages": [
-                  "base-chain/specs/protocol/batcher"
-                ]
-              },
+              "base-chain/specs/protocol/batcher",
               {
                 "group": "Consensus",
                 "pages": [
@@ -793,12 +783,7 @@
                   "base-chain/specs/upgrades/delta/span-batches"
                 ]
               },
-              {
-                "group": "Canyon",
-                "pages": [
-                  "base-chain/specs/upgrades/canyon/overview"
-                ]
-              }
+              "base-chain/specs/upgrades/canyon/overview"
             ]
           }
         ]

--- a/docs/sdks/base-account/reference/core/provider-rpc-methods/sdk-overview.mdx
+++ b/docs/sdks/base-account/reference/core/provider-rpc-methods/sdk-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Provider RPC Methods"
+sidebarTitle: "Provider Overview"
 description: "The Base Account SDK provider (CoinbaseWalletProvider) — an EIP-1193 Ethereum provider and its request method."
 ---
 

--- a/docs/sdks/base-verify/overview.mdx
+++ b/docs/sdks/base-verify/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Base Verify API"
+sidebarTitle: "Overview"
 description: "Use Base Verify APIs and contracts to prove verified account ownership, prevent duplicate participation, and enforce eligibility policies."
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,6 +47,25 @@ node scripts/lint-mdx.js all
 node scripts/lint-mdx.js all || exit 1
 ```
 
+## Documentation structure validator
+
+```bash
+node scripts/validate-docs-structure.js
+```
+
+Runs in CI through `scripts/verify-doc-samples.sh` on any `docs/**` change.
+
+| Check | Description |
+|-------|-------------|
+| Nav pages | Every `docs.json` page reference resolves to a file |
+| Duplicate nav entries | A page appears at most once in the nav |
+| Redundant sidebar labels | No page (or nested group) repeats its parent group's name — flatten single-page groups, or set a distinct `sidebarTitle` |
+| Orphans | Every publishable `.mdx` is reachable from the nav |
+| Redirects | No duplicate sources, fragments in sources, chains, or missing targets |
+| Internal links | Scoped link check across the use-case sections |
+
+Exit code `1` on any violation.
+
 ## Docs index generators
 
 Two generators emit AI-facing site indexes from the `docs/` tree. Both share helpers in `lib/docs-utils.js` (frontmatter parser, `.mintignore` loader, file walker, section discovery).

--- a/scripts/validate-docs-structure.js
+++ b/scripts/validate-docs-structure.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { parseFrontmatter } = require('./lib/docs-utils');
 
 const root = path.resolve(__dirname, '..');
 const docs = path.join(root, 'docs');
@@ -46,6 +47,65 @@ for (const page of navPages) {
   if (seenNav.has(page)) errors.push(`duplicate nav entry ${page}`);
   seenNav.add(page);
 }
+
+// --- Redundant sidebar labels ---
+// A page must not carry the same sidebar label as the group that contains it,
+// and a group must not be nested inside a group of the same name. Mintlify
+// renders those as a collapsible whose only visible child repeats the parent
+// ("Flashblocks > Flashblocks"), which reads like a bug. Fix by flattening a
+// single-page group into a bare page entry, or by giving the page a distinct
+// `sidebarTitle` (usually "Overview").
+function pageFile(page) {
+  const candidates = [`${page}.mdx`, `${page}.md`, path.join(page, 'index.mdx')];
+  for (const candidate of candidates) {
+    const full = path.join(docs, candidate);
+    if (fs.existsSync(full)) return full;
+  }
+  return null;
+}
+
+function sidebarLabel(page) {
+  const file = pageFile(page);
+  if (!file) return null;
+  const { frontmatter } = parseFrontmatter(fs.readFileSync(file, 'utf8'));
+  return frontmatter.sidebarTitle || frontmatter.title || null;
+}
+
+const labelKey = (value) => String(value).toLowerCase().replace(/[^a-z0-9]/g, '');
+
+function walkGroupLabels(node, parentGroup) {
+  if (Array.isArray(node)) {
+    node.forEach((item) => walkGroupLabels(item, parentGroup));
+    return;
+  }
+  if (typeof node === 'string') {
+    if (!parentGroup) return;
+    const label = sidebarLabel(node);
+    if (label && labelKey(label) === labelKey(parentGroup)) {
+      errors.push(
+        `redundant sidebar label: page ${node} ("${label}") repeats its parent group "${parentGroup}" - flatten the group into a bare page entry or set a distinct sidebarTitle`,
+      );
+    }
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  // Tabs and anchors start a fresh sidebar; only groups nest labels.
+  const scope = node.tab !== undefined || node.anchor !== undefined ? null : parentGroup;
+  if (node.group !== undefined) {
+    if (scope && labelKey(node.group) === labelKey(scope)) {
+      errors.push(`redundant sidebar label: group "${node.group}" is nested inside a group with the same name`);
+    }
+    walkGroupLabels(node.pages || [], node.group);
+    walkGroupLabels(node.groups || [], node.group);
+    return;
+  }
+  walkGroupLabels(node.tabs || [], null);
+  walkGroupLabels(node.anchors || [], null);
+  walkGroupLabels(node.groups || [], scope);
+  walkGroupLabels(node.pages || [], scope);
+}
+
+walkGroupLabels(config.navigation, null);
 
 // --- Orphan detection: every publishable .mdx must be reachable from nav ---
 // Exemptions:


### PR DESCRIPTION
**What changed? Why?**

Fourteen sidebar groups expanded to reveal a single child with the identical label — `Flashblocks > Flashblocks`, `Batcher > Batcher` — which reads like a rendering bug rather than navigation.

Two fixes, depending on the group:

- **Single-page groups flattened** into bare page entries in `docs.json`: `Flashblocks`, `Batcher`, and Upgrades → Optimism → `Canyon`. This also matches the existing "no single-page dropdown groups" rule in `docs/ia-guidelines.md`.
- **Multi-page groups keep the group**, and the duplicate child gets a distinct `sidebarTitle` (page `title`/H1 unchanged): `Proofs`, the seven Optimism hardfork overviews (Jovian, Isthmus, Holocene, Granite, Fjord, Ecotone, Delta), `Base Verify API`, and `Provider RPC Methods` — which gets "Provider Overview" because a sibling page already uses "Overview" for the `request` method. `Build on Base > Overview > Overview` becomes "Build on Base", matching how the SDKs & APIs and Upgrades tabs label their landing pages.

To keep it from recurring, `scripts/validate-docs-structure.js` gained a **redundant sidebar labels** check: it walks the nav, resolves each page's label (`sidebarTitle`, else `title`), and errors when it matches the enclosing group — also catching a group nested inside a same-named group. It already runs in CI through `scripts/verify-doc-samples.sh` on any `docs/**` change. The rule is documented in `claude.md` (Navigation + Before Committing) and `scripts/README.md`.

**Notes to reviewers**

- No page moves, no URL changes, so no redirects needed — only sidebar labels and three group wrappers.
- `docs/ia-guidelines.md` is intentionally left untouched.
- Out of scope, possible follow-up: three single-page groups remain that don't duplicate their child's name but do violate the "no single-page dropdown groups" guideline — Upgrades → `Denim`, and SDKs & APIs → `Overview` and `CLIs`.

**How has it been tested?**

- `node scripts/validate-docs-structure.js` → "Navigation, orphans, redirects, and scoped internal links are valid."
- Regression-tested the new check by temporarily re-nesting the `Batcher` group; it failed with `redundant sidebar label: page base-chain/specs/protocol/batcher ("Batcher") repeats its parent group "Batcher" - flatten the group into a bare page entry or set a distinct sidebarTitle`.
- `node scripts/lint-mdx.js` → 0 errors (2 pre-existing "no headings" warnings).