### PR TITLE
fix(docs): stop redirecting Base Account child pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4030,10 +4030,6 @@
       "destination": "/base-chain/network-information/smart-contracts"
     },
     {
-      "source": "/sdks/base-account/:slug*",
-      "destination": "/sdks/base-account/overview"
-    },
-    {
       "source": "/sdks/base-account",
       "destination": "/sdks/base-account/overview"
     },


### PR DESCRIPTION
**What changed? Why?**

Removed the `/sdks/base-account/:slug*` redirect that sent every Base Account SDK child page to the Overview page. The exact `/sdks/base-account` redirect remains so the section root still resolves to `/sdks/base-account/overview`.

**Notes to reviewers**

This restores direct access to the Guides, Get Started, Framework Integrations, and Reference routes in the Base Account SDK section.

**How has it been tested?**

- Parsed `docs/docs.json` as JSON
- Ran `node scripts/validate-docs-structure.js`
- Verified no redirect shadows any of the 127 live Base Account SDK routes
- Ran `git diff --check`