### PR TITLE
fix(docs): add metadata to protocol overview diagrams

### DIFF
--- a/docs/base-chain/specs/overview.mdx
+++ b/docs/base-chain/specs/overview.mdx
@@ -11,7 +11,7 @@ protocol components and the core user flows.
 
 There are three primary actors that interact with Base: users, sequencers, and validators.
 
-```mermaid
+```mermaid Network Participants lines wrap expandable
 graph TD
     EthereumL1(Ethereum L1)
 
@@ -86,7 +86,7 @@ Validators can also act as Proposers and/or Challengers who:
 
 The following diagram shows how the major protocol components interact across L1 and L2.
 
-```mermaid
+```mermaid High-Level System Diagram lines wrap expandable
 graph LR
     subgraph "Ethereum L1"
         OptimismPortal(<a href="./protocol/bridging/withdrawals.html#the-optimism-portal-contract">OptimismPortal</a>)
@@ -139,7 +139,7 @@ P2P network to give validators low-latency access before batches land on L1.
 
 [Consensus →](./protocol/consensus/)
 
-```mermaid
+```mermaid Consensus Flow lines wrap expandable
 graph LR
     L1(Ethereum L1)
     subgraph "Rollup Node"
@@ -180,7 +180,7 @@ finalizes the withdrawal on L1 via `OptimismPortal`.
 
 [Bridging →](./protocol/bridging/deposits)
 
-```mermaid
+```mermaid Bridging Flow lines wrap expandable
 graph LR
     subgraph "Deposit Path"
         User1(User)
@@ -217,7 +217,7 @@ any validator to independently reconstruct the L2 chain from L1.
 
 [Batcher →](./protocol/batcher)
 
-```mermaid
+```mermaid Batcher Flow lines wrap expandable
 graph LR
     Sequencer(Sequencer)
     Batcher(<a href="./protocol/batcher.html">Batcher</a>)
@@ -245,7 +245,7 @@ challengers can dispute invalid claims. Valid withdrawals can only be finalized 
 
 [Proofs →](./protocol/proofs/)
 
-```mermaid
+```mermaid Proofs Flow lines wrap expandable
 graph LR
     Proposer(Proposer)
     DGF(<a href="./protocol/proofs/contracts.html#disputegamefactory">DisputeGameFactory</a>)
@@ -272,7 +272,7 @@ Users will often begin their L2 journey by depositing ETH from L1.
 Once they have ETH to pay fees, they'll start sending transactions on L2.
 The following diagram demonstrates this interaction and key Base protocol components.
 
-```mermaid
+```mermaid Depositing ETH to Base lines wrap expandable
 graph TD
     subgraph "Ethereum L1"
         OptimismPortal(<a href="./protocol/bridging/withdrawals.html#the-optimism-portal-contract">OptimismPortal</a>)
@@ -310,7 +310,7 @@ Users may also want to withdraw ETH or ERC20 tokens from Base back to Ethereum. 
 as standard transactions on L2 but are then completed using transactions on L1. Withdrawals must reference a valid
 proof game contract that proposes the state of the L2 at a given point in time.
 
-```mermaid
+```mermaid Withdrawing From Base lines wrap expandable
 graph LR
     subgraph "Ethereum L1"
         BatchInbox(<a href="./reference/glossary.html#batcher-transaction">Batch Inbox Address</a>)


### PR DESCRIPTION
**What changed? Why?**

Adds descriptive titles and the required `lines wrap expandable` metadata to the eight Mermaid diagrams on the canonical Base Protocol overview page.

The same metadata was added to the legacy `specs/protocol/overview.mdx` page in #1883. After #1867 moved that content to `specs/overview.mdx`, the canonical page still had bare Mermaid fences, so the changed-file style check reported 16 errors. This reuses the already-approved metadata from the legacy page.

**Notes to reviewers**

This only changes the eight opening fence lines. Diagram content, links, navigation, and page structure are unchanged.

**How has it been tested?**

- `node scripts/lint-mdx.js docs/base-chain/specs/overview.mdx` (0 errors)
- `node scripts/lint-mdx.js all --check-nav` (466 files, 0 errors)
- `npm test` (80 passed)
- `node scripts/validate-docs-structure.js`
- `git diff --check`
