### PR TITLE
fix: use HTTPS for ad opt-out portal links in cookie policy

### DIFF
--- a/docs/cookie-policy.mdx
+++ b/docs/cookie-policy.mdx
@@ -74,9 +74,9 @@ please note, if you set your browser to disable cookies, you may not be able to 
 of our Services. Also, if you disable cookies, other parts of our Services may not function properly.
 
 There are also additional tools available to manage third party cookies. You can visit the DAA's
-opt-out portal available at [optout.aboutads.info](http://optout.aboutads.info/), the DAA of Canada's
+opt-out portal available at [optout.aboutads.info](https://optout.aboutads.info/), the DAA of Canada's
 opt-out portal available at [youradchoices.ca/en/tools](https://youradchoices.ca/en/tools), or visit
-the NAI's opt-out portal available at [optout.networkadvertising.org](http://optout.networkadvertising.org/?c=1).
+the NAI's opt-out portal available at [optout.networkadvertising.org](https://optout.networkadvertising.org/?c=1).
 Residents of the European Union may opt-out of online behavioural advertising served by the European
 Interactive Digital Advertising Alliance&apos;s participating member organizations by visiting
 [youronlinechoices.eu](https://www.youronlinechoices.eu/) or through your mobile device settings,


### PR DESCRIPTION
**What changed? Why?**

The cookie policy links to the DAA's and NAI's ad opt-out portals using `http://`. Both domains serve over HTTPS:

- `optout.aboutads.info` -> now linked as `https://optout.aboutads.info/`
- `optout.networkadvertising.org` -> now linked as `https://optout.networkadvertising.org/?c=1`

Closes #1468.

**Notes to reviewers**

Small, single-purpose change, no content or wording changed, just the link scheme.

**How has it been tested?**

Verified both destinations resolve correctly over HTTPS before making the change.