### PR TITLE
Redesign upgrades landing page with Mintlify updates

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -822,7 +822,7 @@ const client = createPublicClient({ chain: base, transport: http() })
 
 ### Overview
 
-- [Upgrades](https://docs.base.org/upgrades/overview): Base evolves through named hardforks. Each hardfork introduces protocol changes, new features, or parameter updates that take effect at a specific activation block. This tab tracks what changed, when, and how to migrate.
+- [Upgrades](https://docs.base.org/upgrades/overview): Track Base network upgrades, activation dates, and the protocol changes included in each release.
 
 - [Configuration Changelog](https://docs.base.org/base-chain/network-information/configuration-changelog): A log of configuration changes to the Base networks.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -756,7 +756,7 @@
 
 ### Overview
 
-- [Upgrades](https://docs.base.org/upgrades/overview): Base evolves through named hardforks. Each hardfork introduces protocol changes, new features, or parameter updates that take effect at a specific activation block. This tab tracks what changed, when, and how to migrate.
+- [Upgrades](https://docs.base.org/upgrades/overview): Track Base network upgrades, activation dates, and the protocol changes included in each release.
 
 - [Configuration Changelog](https://docs.base.org/base-chain/network-information/configuration-changelog): A log of configuration changes to the Base networks.
 

--- a/docs/upgrades/overview.mdx
+++ b/docs/upgrades/overview.mdx
@@ -1,32 +1,150 @@
 ---
 title: "Upgrades"
-description: "Base evolves through named hardforks. Each hardfork introduces protocol changes, new features, or parameter updates that take effect at a specific activation block. This tab tracks what changed, when, and how to migrate."
+description: "Track Base network upgrades, activation dates, and the protocol changes included in each release."
 ---
 
-## Base Upgrades
+Base evolves through named network upgrades. Each release introduces protocol changes, new features, or parameter updates that activate across Base Sepolia and Base Mainnet.
 
-| Upgrade | Status | Activation |
-|----------|--------|------------|
-| [Denim](/upgrades/denim/200ms-blocks) | Planning | TBD |
-| [Cobalt](/upgrades/cobalt/overview) | Upcoming | Sep 2026 |
-| [Beryl](/upgrades/beryl/overview) | Live | Jun 25, 2026 |
-| [Azul](/upgrades/azul/overview) | Live | May 28, 2026 |
+Base upgrade dates follow the [Base Chain upgrades tracker](https://chain.base.org/upgrades). A month without a confirmed activation timestamp is a planning target and may change.
 
-## Upstream (OP Stack) Hardforks
+## Base Network Upgrades
 
-Base inherits upstream OP Stack hardforks. Each entry documents the changes Base adopted.
+<Update label="November 2026" tags={["Planning", "Base upgrade"]}>
+## [Denim](/upgrades/denim/200ms-blocks)
 
-| Hardfork | Status |
-|----------|--------|
-| [Jovian](/upgrades/jovian/overview) | Upcoming |
-| [Isthmus](/upgrades/isthmus/overview) | Live |
-| [Holocene](/upgrades/holocene/overview) | Live |
-| [Granite](/upgrades/granite/overview) | Live |
-| [Fjord](/upgrades/fjord/overview) | Live |
-| [Ecotone](/upgrades/ecotone/overview) | Live |
-| [Delta](/upgrades/delta/overview) | Live |
-| [Canyon](/upgrades/canyon/overview) | Live |
+Denim introduces native blocks at a 200ms cadence, millisecond-resolution RPC timestamps, and onchain millisecond time through BaseTime.
+
+- **Base Sepolia:** Targeting November 2026
+- **Base Mainnet:** Targeting November 2026
+
+[View the Denim specification](/upgrades/denim/200ms-blocks)
+</Update>
+
+<Update label="September 2026" tags={["Planning", "Base upgrade"]}>
+## [Cobalt](/upgrades/cobalt/overview)
+
+Cobalt adds native account abstraction with EIP-8130, improves the B20 token standard, and introduces dynamic node upgrades.
+
+- **Base Sepolia:** Targeting September 2026
+- **Base Mainnet:** Targeting September 2026
+
+[View Cobalt features](/upgrades/cobalt/overview)
+</Update>
+
+<Update label="June 25, 2026" tags={["Live", "Base upgrade"]}>
+## [Beryl](/upgrades/beryl/overview)
+
+Beryl makes Base a first-class issuance platform with B20 tokens, reduces withdrawal delays, and adopts Reth V2 as the reference execution client.
+
+- **Base Sepolia:** Activated June 18, 2026
+- **Base Mainnet:** Activated June 25, 2026
+
+[View Beryl features](/upgrades/beryl/overview)
+</Update>
+
+<Update label="May 28, 2026" tags={["Live", "Base upgrade"]}>
+## [Azul](/upgrades/azul/overview)
+
+Azul is Base's first independent network upgrade. It strengthens security and decentralization, advances the path to 1 gigagas per second, and improves the developer experience.
+
+- **Base Sepolia:** Activated April 20, 2026
+- **Base Mainnet:** Activated May 28, 2026
+
+[View Azul features](/upgrades/azul/overview)
+</Update>
+
+## Upstream OP Stack Hardforks
+
+Base adopted the following upstream OP Stack hardforks. Entries are ordered by Base Mainnet activation date.
+
+<Update label="December 2, 2025" tags={["Live", "OP Stack"]}>
+## [Jovian](/upgrades/jovian/overview)
+
+Jovian introduces a configurable minimum base fee and a data availability footprint gas scalar for improved fee-market stability.
+
+- **Base Sepolia:** Activated November 19, 2025
+- **Base Mainnet:** Activated December 2, 2025
+
+[View Jovian changes](/upgrades/jovian/overview)
+</Update>
+
+<Update label="May 9, 2025" tags={["Live", "OP Stack"]}>
+## [Isthmus](/upgrades/isthmus/overview)
+
+Isthmus incorporates Ethereum Pectra EIPs and introduces the operator fee mechanism for sequencer revenue.
+
+- **Base Sepolia:** Activated April 17, 2025
+- **Base Mainnet:** Activated May 9, 2025
+
+[View Isthmus changes](/upgrades/isthmus/overview)
+</Update>
+
+<Update label="January 9, 2025" tags={["Live", "OP Stack"]}>
+## [Holocene](/upgrades/holocene/overview)
+
+Holocene introduces dynamic EIP-1559 parameters configurable through `SystemConfig` and stricter block derivation rules.
+
+- **Base Sepolia:** Activated November 26, 2024
+- **Base Mainnet:** Activated January 9, 2025
+
+[View Holocene changes](/upgrades/holocene/overview)
+</Update>
+
+<Update label="September 11, 2024" tags={["Live", "OP Stack"]}>
+## [Granite](/upgrades/granite/overview)
+
+Granite adds `bn256Pairing` precompile input-size restrictions and updates the channel timeout parameter.
+
+- **Base Sepolia:** Activated August 12, 2024
+- **Base Mainnet:** Activated September 11, 2024
+
+[View Granite changes](/upgrades/granite/overview)
+</Update>
+
+<Update label="July 10, 2024" tags={["Live", "OP Stack"]}>
+## [Fjord](/upgrades/fjord/overview)
+
+Fjord introduces FastLZ-based L1 fee estimation, the RIP-7212 `secp256r1` precompile, and Brotli channel compression.
+
+- **Base Sepolia:** Activated May 29, 2024
+- **Base Mainnet:** Activated July 10, 2024
+
+[View Fjord changes](/upgrades/fjord/overview)
+</Update>
+
+<Update label="March 14, 2024" tags={["Live", "OP Stack"]}>
+## [Ecotone](/upgrades/ecotone/overview)
+
+Ecotone integrates Ethereum Dencun changes, including EIP-4844 blob transactions and EIP-4788 beacon block roots.
+
+- **Base Sepolia:** Activated February 21, 2024
+- **Base Mainnet:** Activated March 14, 2024
+
+[View Ecotone changes](/upgrades/ecotone/overview)
+</Update>
+
+<Update label="February 22, 2024" tags={["Live", "OP Stack"]}>
+## [Delta](/upgrades/delta/overview)
+
+Delta introduces span batches to reduce L1 data costs by compressing multiple L2 blocks into a single batcher transaction.
+
+- **Base Sepolia:** Activated December 22, 2023
+- **Base Mainnet:** Activated February 22, 2024
+
+[View Delta changes](/upgrades/delta/overview)
+</Update>
+
+<Update label="January 11, 2024" tags={["Live", "OP Stack"]}>
+## [Canyon](/upgrades/canyon/overview)
+
+Canyon brings Ethereum Shanghai EIPs, including EIP-3651, EIP-3855, and EIP-3860, to the Base execution layer.
+
+- **Base Sepolia:** Activated November 14, 2023
+- **Base Mainnet:** Activated January 11, 2024
+
+[View Canyon changes](/upgrades/canyon/overview)
+</Update>
 
 ## Other Changes
 
-The [configuration changelog](/base-chain/network-information/configuration-changelog) tracks network parameter changes that don't belong to a specific hardfork.
+The [configuration changelog](/base-chain/network-information/configuration-changelog) tracks network parameter changes that do not belong to a specific upgrade.


### PR DESCRIPTION
## Summary

- replace the upgrades status tables with Mintlify's native `Update` timeline component
- sync Base upgrade rollout dates with `chain.base.org`, including the November 2026 Denim target
- mark Jovian live with its Base Sepolia and Base Mainnet activation dates
- refresh the generated LLM indexes for the new page description

## Validation

- `node scripts/lint-mdx.js docs/upgrades/overview.mdx`
- `node scripts/validate-docs-structure.js`
- `npm test`
- local Mintlify preview at `/upgrades/overview`