### PR TITLE
fix(builder-codes): put the code length after the code in the example suffix

### DIFF
--- a/docs/specifications/builder-codes/overview.mdx
+++ b/docs/specifications/builder-codes/overview.mdx
@@ -98,7 +98,7 @@ Wallets supporting ERC-5792 can use the `DataSuffixCapability` for clean suffix 
     ],
     capabilities: {
       dataSuffix: {
-        value: "0x07626173656170700080218021802180218021802180218021",
+        value: "0x62617365617070070080218021802180218021802180218021",
         optional: true
       }
     }


### PR DESCRIPTION
The `dataSuffix` example in the Builder Codes overview encodes the code length **before** the code. `ox` — which this page recommends for generating the suffix — encodes it **after**, and the Base builder dashboard issues the same order `ox` produces.

```
page:  0x07 62617365617070 00 8021…    length first
ox:    0x62617365617070 07 00 8021…    length after the code
```

Verified with `ox@0.14.34`:

```ts
import * as Attribution from "ox/erc8021/Attribution";
Attribution.toDataSuffix({ codes: ["baseapp"] });
// 0x62617365617070070080218021802180218021802180218021
```

Same 25 bytes, same `00` id byte, same trailing `8021` magic — only the length byte moves.

### Why this one is worth fixing

The wrong order **fails quietly**. Feeding the current example's ordering to `ox`'s own parser throws nothing and returns a valid-looking result whose code is reversed, which resolves to no registered builder. Transactions index as unattributed, the integrator earns nothing, and no error surfaces anywhere in the stack.

We found it only because we pinned our own suffix byte-for-byte against the value the builder dashboard issued for our code, rather than deriving it from the docs. An integrator who follows the page and trusts a successful transaction would have no signal at all.

Also worth noting for anyone reading the page alongside the spec: ERC-8021 is not merged upstream (`ethereum/ERCs` #1209 and #1883 are both open), so there is no canonical document to arbitrate between the two orderings. `ox` and the dashboard agreeing is the strongest available evidence.