### PR TITLE
docs(base-account): use HTTPS for Coinbase/Base links in basenames FAQ

### DIFF
--- a/docs/sdks/base-account/basenames/basenames-faq.mdx
+++ b/docs/sdks/base-account/basenames/basenames-faq.mdx
@@ -25,12 +25,12 @@ Basenames are priced based on name length, and are designed to be globally acces
 
 You can get one free Basename (5+ letters) for one year if you meet any of the below criteria:
 
-- [Coinbase Verification](http://coinbase.com/onchain-verify)
+- [Coinbase Verification](https://coinbase.com/onchain-verify)
 - [Summer Pass Level 3 NFT](https://wallet.coinbase.com/ocs)
 - [Buildathon participant NFT](https://onchain-summer.devfolio.co/)
 - [base.eth NFT holder](https://opensea.io/collection/base-org-base-eth)
 - cb.id username (acquired prior to Fri Aug 9, 2024)
-- [BNS name owner](http://basename.app) - free 4+ letter name (basename.app)
+- [BNS name owner](https://basename.app) - free 4+ letter name (basename.app)
 
 An equivalent-value discount of 0.001 ETH will be applied if registering a shorter name, or registering for more than 1 year, with the exception of the BNS name owner discount (valued at 0.01 ETH per unique address). You will need to pay the standard registration fees if you wish to keep your Basename after your initial discount has been fully applied. Discounts are only applied once, and are limited to one per address. Even if you meet multiple criteria, you will only be eligible for a single discount on one Basename. If you satisfy multiple criteria, we will automatically apply the highest-value discount to your registration.
 
@@ -82,7 +82,7 @@ Transferring all 3 to the same address will fully transfer ownership of the Base
 
 Step by step:
 
-- Navigate to [base.org/names](http://base.org/names)
+- Navigate to [base.org/names](https://base.org/names)
 - Sign in with wallet that owns the basename
 - Click "My Basenames" in the top right corner
 - Click the three dots of the basename you want to transfer and click transfer name


### PR DESCRIPTION
**What changed? Why?**

The Basenames FAQ links to `coinbase.com`, `basename.app` and `base.org` using `http://`. All three are Coinbase/Base's own properties and serve over HTTPS.

Closes #1908.

**Notes to reviewers**

Only the link scheme changed, no wording touched.

**How has it been tested?**

Verified all three destinations resolve over HTTPS before making the change.