### PR TITLE
fix(docs): use HTTPS for Privacy Policy link in Terms of Service

### DIFF
--- a/docs/terms-of-service.mdx
+++ b/docs/terms-of-service.mdx
@@ -111,7 +111,7 @@ Any questions, comments, suggestions, ideas, feedback, reviews, or other informa
 
 12. # **Privacy** 
 
-For more information regarding our collection, use, and disclosure of personal data and certain other data, please see our [Privacy Policy](http://docs.base.org/privacy-policy).  The processing of personal data by Coinbase as a processor will be subject to any data processing agreement that you enter into with Coinbase.
+For more information regarding our collection, use, and disclosure of personal data and certain other data, please see our [Privacy Policy](https://docs.base.org/privacy-policy).  The processing of personal data by Coinbase as a processor will be subject to any data processing agreement that you enter into with Coinbase.
 
 13. # **Third-Party Services**
 


### PR DESCRIPTION
**What changed? Why?**

The Terms of Service links to the Privacy Policy using `http://docs.base.org/privacy-policy` instead of `https://`. `docs.base.org` serves over HTTPS everywhere else on the site.

Closes #1909.

**Notes to reviewers**

Single-line, link scheme only.

**How has it been tested?**

Verified the destination resolves over HTTPS.