### PR TITLE
docs(builder-codes): use HTTPS for base.dev links

### DIFF
--- a/docs/specifications/builder-codes/for-app-developers.mdx
+++ b/docs/specifications/builder-codes/for-app-developers.mdx
@@ -6,7 +6,7 @@ description: "Integrate Builder Codes into your app using Wagmi or Viem to attri
 
 ## Automatic Attribution on Base
 
-Once your app is registered on [base.dev](http://base.dev/), the Base App will auto-append your Builder Code to transactions its users make in your app (e.g. via your app, or the Base App's browser). This powers your onchain analytics in [base.dev](http://base.dev/) and qualifies you for potential future rewards.
+Once your app is registered on [base.dev](https://base.dev/), the Base App will auto-append your Builder Code to transactions its users make in your app (e.g. via your app, or the Base App's browser). This powers your onchain analytics in [base.dev](https://base.dev/) and qualifies you for potential future rewards.
 
 ## Integrating Outside the Base App
 


### PR DESCRIPTION
**What changed? Why?**

Both `base.dev` links in the automatic attribution section of the Builder Codes guide were on `http://`. The rest of the page already links to base.dev over https.

Closes #1910.

**Notes to reviewers**

Single line, link scheme only.

**How has it been tested?**

Verified base.dev resolves over HTTPS.