### PR TITLE
docs(CBW-210): redirect Base Account and Base MCP docs to CDP

### DIFF
--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -7,6 +7,10 @@ keywords: ["Base MCP", "AI agent wallet", "mcp.base.org", "AI assistant wallet",
 
 import { WalletSetupDemo } from "/snippets/WalletSetupDemo.jsx"
 
+<Note>
+  Base MCP documentation now lives on [Coinbase Developer Docs](https://docs.cdp.coinbase.com/base-account/base-mcp/overview). This page redirects there.
+</Note>
+
 Base MCP gives your AI assistant direct access to your [Base Account](/sdks/base-account/overview) (the smart wallet powering the Base App). Connect once and your assistant can check balances, send funds, swap tokens, sign messages, execute contract calls, and pay x402-enabled APIs across multiple networks. Every write action requires your approval.
 
 <Visibility for="agents">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -851,6 +851,14 @@
   },
   "redirects": [
     {
+      "source": "/sdks/base-account/:slug*",
+      "destination": "https://docs.cdp.coinbase.com/base-account/:slug*"
+    },
+    {
+      "source": "/agents/:slug*",
+      "destination": "https://docs.cdp.coinbase.com/base-account/base-mcp/:slug*"
+    },
+    {
       "source": "/base-chain/network-information/bridging-and-withdrawals",
       "destination": "/specifications/base-protocol/bridging/withdrawals"
     },
@@ -868,7 +876,7 @@
     },
     {
       "source": "/base-account",
-      "destination": "/sdks/base-account/overview"
+      "destination": "https://docs.cdp.coinbase.com/base-account/overview"
     },
     {
       "source": "/base-chain/flashblocks",
@@ -892,15 +900,15 @@
     },
     {
       "source": "/agents",
-      "destination": "/agents/overview"
+      "destination": "https://docs.cdp.coinbase.com/base-account/base-mcp/overview"
     },
     {
       "source": "/agents/index",
-      "destination": "/agents/overview"
+      "destination": "https://docs.cdp.coinbase.com/base-account/base-mcp/overview"
     },
     {
       "source": "/sdks/coinbase-wallet",
-      "destination": "/sdks/base-account/overview"
+      "destination": "https://docs.cdp.coinbase.com/base-account/overview"
     },
     {
       "source": "/base-chain/network-information/native-account-abstraction",

--- a/docs/sdks/base-account/overview.mdx
+++ b/docs/sdks/base-account/overview.mdx
@@ -5,6 +5,10 @@ description: "Add universal sign-in and one-tap USDC payments to any app with th
 keywords: ["Base Account SDK", "Sign in with Base", "Base Pay", "USDC payments SDK", "smart wallet SDK"]
 ---
 
+<Note>
+  Base Account SDK documentation now lives on [Coinbase Developer Docs](https://docs.cdp.coinbase.com/base-account/overview). This page redirects there.
+</Note>
+
 The Base Account SDK connects your app to the onchain accounts that power the [Base App](https://base.app) — over one hundred thousand users with a passkey-backed [Smart Wallet](/sdks/base-account/reference/onchain-contracts/smart-wallet). Add sign-in and USDC payments in a few lines; users hold their own keys and you never touch private data or funds.
 
 <CardGroup cols={2}>


### PR DESCRIPTION
**What changed? Why?**

Redirects the Base Account SDK and Base MCP sections on docs.base.org to the migrated pages on Coinbase Developer Docs so those docs have one source of truth after [CBW-210](https://linear.app/coinbase/issue/CBW-210/migrate-base-account-docs-from-docsbaseorg-to-coinbase-developer-docs).

- `/sdks/base-account/*` → `https://docs.cdp.coinbase.com/base-account/*`
- `/agents/*` → `https://docs.cdp.coinbase.com/base-account/base-mcp/*`
- Notices on the two overview pages as a fallback if a crawler still hits the old URL

**Notes to reviewers**

Merge the CDP docs PR first so these redirects do not 404:
https://coinbase.ghe.com/c3/cdp-docs/pulls (head `felix-zhang:felixzhang/cbw-210-migrate-base-account-docs`)

**How has it been tested?**

`docs.json` still parses as JSON. Redirects follow the existing Mintlify `:slug*` pattern used elsewhere in this repo.

Made with [Cursor](https://cursor.com)