### PR TITLE
docs: add /screenshot command for PR preview screenshots

### DIFF
--- a/.claude/commands/screenshot.md
+++ b/.claude/commands/screenshot.md
@@ -55,10 +55,10 @@ Take screenshots of docs pages affected by the current PR's changes using `agent
 
 5. **Review screenshots**: Read each screenshot file to visually inspect the pages. Check for broken components, un-rendered MDX (raw `<Card>` tags, missing frontmatter titles), broken images, and sidebar issues. Describe what you see and confirm the changes render correctly.
 
-6. **Upload screenshots** to GitHub as draft release assets so they can be embedded in the PR:
+6. **Upload screenshots** to GitHub as prerelease assets so they can be embedded in the PR. Use a prerelease, not a draft — draft-release assets aren't anonymously fetchable on public repos, so GitHub's image proxy renders them as broken images in PR bodies:
 
    ```bash
-   gh release create screenshots-pr-<N> --draft --title "PR #<N> Screenshots" --notes "Screenshots for PR review" screenshots/*.png
+   gh release create screenshots-pr-<N> --prerelease --title "PR #<N> Screenshots" --notes "Screenshots for PR review" screenshots/*.png
    gh release view screenshots-pr-<N> --json assets --jq '.assets[] | "\(.name): \(.url)"'
    ```
 
@@ -66,7 +66,7 @@ Take screenshots of docs pages affected by the current PR's changes using `agent
 
 ## Notes
 
-- Screenshots are saved locally to `screenshots/` (gitignored) — do NOT commit them. They are shared via draft GitHub releases instead.
+- Screenshots are saved locally to `screenshots/` (gitignored) — do NOT commit them. They are shared via GitHub prereleases instead.
 - If the dev server is already running, reuse it — don't start a second one.
 - If a page fails to render (Mintlify build error), report the error output instead of a blank screenshot.
-- After a PR is merged, clean up its draft release: `gh release delete screenshots-pr-<N> --yes`
+- After a PR is merged, clean up its release and tag: `gh release delete screenshots-pr-<N> --cleanup-tag --yes`

--- a/.claude/commands/screenshot.md
+++ b/.claude/commands/screenshot.md
@@ -1,0 +1,72 @@
+# PR Preview Screenshots
+
+Take screenshots of docs pages affected by the current PR's changes using `agent-browser`, and return image markdown ready to embed in the PR body.
+
+## Instructions
+
+1. **Identify affected pages** from the git diff against the base branch:
+
+   ```bash
+   git diff $(git merge-base HEAD origin/master)...HEAD --name-only
+   ```
+
+   Map changed files to routes. Mintlify serves each MDX file at its path relative to `docs/`, minus the extension:
+
+   | Changed files | Routes to screenshot |
+   |---|---|
+   | `docs/<path>.mdx` | `/<path>` (e.g. `docs/get-started/quickstart.mdx` → `/get-started/quickstart`) |
+   | `docs/snippets/**` | Pages that import the snippet — find them with `grep -rl '<snippet-file>' docs --include='*.mdx'`, then screenshot one or two representative importers |
+   | `docs/images/**` | Pages that reference the image — `grep -rl '<image-path>' docs --include='*.mdx'` |
+   | `docs/docs.json` | A representative page from each added/renamed/moved group, to show the sidebar; skip for redirect-only changes |
+   | `docs/*.css`, `docs/logo/**`, `docs/favicon*` | The homepage plus one content-heavy page |
+   | `scripts/**`, `.github/**`, `*.md` outside `docs/` | No screenshots needed (not user-facing) |
+
+   If a PR touches many pages (e.g. a sweep across 20+ files), screenshot a representative sample of 3–5 pages rather than all of them, and say which were sampled.
+
+   If no user-facing files changed, say so and skip screenshots.
+
+2. **Start the dev server** if one isn't already running:
+
+   ```bash
+   (cd docs && npx mintlify dev) &
+   ```
+
+   It must run from `docs/` (where `docs.json` lives) and serves on `http://localhost:3000` (it picks the next free port if 3000 is taken — watch the startup output). First run can take a minute or two while it downloads the framework; poll the URL until it responds:
+
+   ```bash
+   until curl -s -o /dev/null --max-time 2 http://localhost:3000/; do sleep 3; done
+   ```
+
+3. **Take screenshots** with `agent-browser`. For each affected route:
+
+   ```bash
+   mkdir -p screenshots
+   agent-browser set viewport 1280 800
+   agent-browser open http://localhost:3000/<route> && agent-browser wait --load networkidle && agent-browser screenshot --full screenshots/<name>.png
+   ```
+
+   Use descriptive filenames derived from the route: `get-started-quickstart.png`, `base-chain-node-setup.png`.
+
+4. **Close the browser** when done:
+
+   ```bash
+   agent-browser close
+   ```
+
+5. **Review screenshots**: Read each screenshot file to visually inspect the pages. Check for broken components, un-rendered MDX (raw `<Card>` tags, missing frontmatter titles), broken images, and sidebar issues. Describe what you see and confirm the changes render correctly.
+
+6. **Upload screenshots** to GitHub as draft release assets so they can be embedded in the PR:
+
+   ```bash
+   gh release create screenshots-pr-<N> --draft --title "PR #<N> Screenshots" --notes "Screenshots for PR review" screenshots/*.png
+   gh release view screenshots-pr-<N> --json assets --jq '.assets[] | "\(.name): \(.url)"'
+   ```
+
+7. **Report results**: Return the image markdown for each screenshot (using the asset URLs from step 6) so it can be added to the **Screenshots** section of the PR body.
+
+## Notes
+
+- Screenshots are saved locally to `screenshots/` (gitignored) — do NOT commit them. They are shared via draft GitHub releases instead.
+- If the dev server is already running, reuse it — don't start a second one.
+- If a page fails to render (Mintlify build error), report the error output instead of a blank screenshot.
+- After a PR is merged, clean up its draft release: `gh release delete screenshots-pr-<N> --yes`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,3 +3,7 @@
 **Notes to reviewers**
 
 **How has it been tested?**
+
+**Screenshots**
+
+<!-- Run /screenshot to capture the affected docs pages and embed the images here. Write "N/A (no user-facing changes)" if the PR doesn't change any rendered pages. -->

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ next-env.d.ts
 /.idea/
 .astro/
 .mintlify/
+
+# PR preview screenshots (uploaded via draft GitHub releases, never committed)
+/screenshots/

--- a/claude.md
+++ b/claude.md
@@ -9,6 +9,7 @@ Technical documentation for Base (Ethereum L2). Built with Mintlify.
 | `mintlify dev` | Local dev server |
 | `/lint` | Lint MDX files and fix issues |
 | `/doc-feedback` | Review content quality |
+| `/screenshot` | Capture affected docs pages for the PR body |
 | `/agents` | Generate AGENTS.md index for AI agents (also runs via `githooks/post-commit` when commit message contains `agents.md`) |
 | `/llms` | Regenerate `docs/llms.txt` and `docs/llms-full.txt` (also runs via `githooks/post-commit` when commit message contains `llms.txt`) |
 
@@ -80,6 +81,19 @@ sidebar label is `sidebarTitle` if present, otherwise `title`.
 3. Run `node scripts/validate-docs-structure.js` if `docs.json` or page frontmatter changed (nav, orphans, redirects, redundant sidebar labels)
 4. Add redirects for removed pages
 5. Verify links work
+
+## Opening PRs
+
+Every PR that changes rendered pages must include screenshots:
+
+1. Run `/screenshot` to capture the affected pages and upload them as draft
+   release assets (`gh release create screenshots-pr-<N> --draft`).
+2. Fill in the **Screenshots** section of the PR template with the embedded
+   images. For backend-only changes (`scripts/`, `.github/`, repo-root
+   markdown), write "N/A (no user-facing changes)".
+3. Screenshots live in `screenshots/` locally (gitignored) — never commit them.
+4. After the PR merges, delete its draft release:
+   `gh release delete screenshots-pr-<N> --yes`.
 
 ## CI Approval Gates
 

--- a/claude.md
+++ b/claude.md
@@ -86,14 +86,16 @@ sidebar label is `sidebarTitle` if present, otherwise `title`.
 
 Every PR that changes rendered pages must include screenshots:
 
-1. Run `/screenshot` to capture the affected pages and upload them as draft
-   release assets (`gh release create screenshots-pr-<N> --draft`).
+1. Run `/screenshot` to capture the affected pages and upload them as
+   prerelease assets (`gh release create screenshots-pr-<N> --prerelease` —
+   draft releases don't work: their assets aren't publicly fetchable, so the
+   images render broken in PR bodies).
 2. Fill in the **Screenshots** section of the PR template with the embedded
    images. For backend-only changes (`scripts/`, `.github/`, repo-root
    markdown), write "N/A (no user-facing changes)".
 3. Screenshots live in `screenshots/` locally (gitignored) — never commit them.
-4. After the PR merges, delete its draft release:
-   `gh release delete screenshots-pr-<N> --yes`.
+4. After the PR merges, delete its release and tag:
+   `gh release delete screenshots-pr-<N> --cleanup-tag --yes`.
 
 ## CI Approval Gates
 


### PR DESCRIPTION
**What changed? Why?**

Ports the screenshot flow from bdocs so every PR gets visual previews of the pages it changes:

- New `/screenshot` Claude command (`.claude/commands/screenshot.md`): maps changed files to Mintlify routes (`docs/<path>.mdx` → `/<path>`, with reverse-lookup rules for `snippets/` and `images/` changes), captures affected pages with `agent-browser` against the local `mintlify dev` server, uploads them as release assets (`screenshots-pr-<N>`), and returns markdown for the PR body.
- PR template gains a **Screenshots** section (with an "N/A" escape hatch for non-visual changes).
- CLAUDE.md gains an "Opening PRs" section documenting the flow, plus a `/screenshot` row in the commands table.
- `.gitignore` excludes the local `screenshots/` staging directory — images are shared via releases, never committed.

**Notes to reviewers**

- No docs pages, `docs.json`, or gated `.github/` surfaces (workflows, CODEOWNERS, `ia-governance.json`, `.github/scripts/`) are touched, so no IA approval gates activate.
- Screenshots are uploaded as **prereleases** rather than drafts: draft-release assets on a public github.com repo aren't anonymously fetchable, so GitHub's image proxy can't render them in PR bodies (verified — draft asset URL returns 404 unauthenticated, published prerelease returns 200). Prereleases stay off "latest" and are deleted (with their tag) after merge.

**How has it been tested?**

Ran the flow end to end in this repo: started `mintlify dev` from `docs/`, captured `/get-started/base-chain` full-page at 1280×800 with `agent-browser`, verified the render, uploaded the asset via `gh release create screenshots-pr-1918`, and confirmed the asset URL is publicly fetchable. The screenshot below is the output of that run.

**Screenshots**

This PR itself has no user-facing page changes, but here is the flow's output as an illustration — `/get-started/base-chain` captured by `/screenshot`:

![get-started/base-chain rendered by mintlify dev, captured by the /screenshot flow](https://github.com/base/docs/releases/download/screenshots-pr-1918/get-started-base-chain.png)