### PR TITLE
fix: reduce page padding on mobile

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -163,6 +163,11 @@ body > div, main {
   padding-right: 1rem;
 }
 
+@media (max-width: 768px) {
+  #content-area { padding-left: 1rem; padding-right: 1rem; }
+  body > div, main { padding-left: 0; padding-right: 0; }
+}
+
 /* ============================================
    Borders (no shadows)
    ============================================ */


### PR DESCRIPTION
## Summary
- Adds a mobile media query (`max-width: 768px`) to reduce horizontal padding on content pages
- `#content-area` padding reduced from `4rem` to `1rem`
- Removes extra `1rem` padding on `body > div, main` at mobile widths

## Test plan
- [ ] Open any docs page on a mobile-width viewport and verify reduced side padding
- [ ] Confirm desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)