### PR TITLE
fix(scripts): parse slashless .mintignore directory globs

### DIFF
--- a/scripts/__tests__/docs-utils-mintignore.test.mjs
+++ b/scripts/__tests__/docs-utils-mintignore.test.mjs
@@ -1,0 +1,40 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { loadMintIgnore } = require("../lib/docs-utils.js");
+
+function writeMintignore(contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mintignore-"));
+  const file = path.join(dir, ".mintignore");
+  fs.writeFileSync(file, contents);
+  return file;
+}
+
+test("loadMintIgnore keeps directory names for leading-slash globs", () => {
+  const file = writeMintignore("/draft-notes/*\n");
+  const ignored = loadMintIgnore(file);
+  assert.deepEqual([...ignored.dirs], ["draft-notes"]);
+});
+
+test("loadMintIgnore keeps directory names for slashless globs", () => {
+  const file = writeMintignore("draft-notes/*\n");
+  const ignored = loadMintIgnore(file);
+  assert.deepEqual([...ignored.dirs], ["draft-notes"]);
+});
+
+test("loadMintIgnore still supports nested directory globs with or without slash", () => {
+  const file = writeMintignore("/apps/legacy/*\napps/draft/*\n");
+  const ignored = loadMintIgnore(file);
+  assert.deepEqual([...ignored.dirs].sort(), ["apps/draft", "apps/legacy"]);
+});
+
+test("loadMintIgnore ignores empty /* patterns", () => {
+  const file = writeMintignore("/*\n");
+  const ignored = loadMintIgnore(file);
+  assert.deepEqual([...ignored.dirs], []);
+});

--- a/scripts/lib/docs-utils.js
+++ b/scripts/lib/docs-utils.js
@@ -80,7 +80,10 @@ function loadMintIgnore(mintignorePath) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;
     if (trimmed.endsWith('/*')) {
-      ignored.dirs.add(trimmed.slice(1, -2));
+      // Accept both `/foo/*` and `foo/*`. The previous `slice(1, -2)` assumed a
+      // leading slash, so `draft-notes/*` was stored as `raft-notes`.
+      const dir = trimmed.replace(/^\//, '').slice(0, -2);
+      if (dir) ignored.dirs.add(dir);
     } else if (trimmed.startsWith('/')) {
       ignored.files.add(trimmed.slice(1));
     } else {


### PR DESCRIPTION
## Summary
- Fix `loadMintIgnore()` so directory patterns work with or without a leading `/` (e.g. `draft-notes/*` no longer becomes `raft-notes`).
- Add unit coverage for leading-slash, slashless, nested, and empty `/*` patterns.

Fixes #1819

## Test plan
- [x] `cd scripts && node --test __tests__/docs-utils-mintignore.test.mjs` (4/4 pass)
- [ ] Confirm existing `/dir/*` entries in `docs/.mintignore` still exclude the same pages in lint