### PR TITLE
docs: fix broken cross-reference links after the docs restructure

### DIFF
--- a/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_call.mdx
+++ b/docs/base-chain/api-reference/ethereum-json-rpc-api/eth_call.mdx
@@ -11,7 +11,7 @@ Executes a message call immediately without broadcasting a transaction to the ne
 </Tip>
 
 <Note>
-**`eth_call "pending"` block context on Flashblocks nodes:** Block-context properties (`block.number`, `block.timestamp`, `block.basefee`) may reflect a block several behind tip due to how nodes cache historical Flashblocks. See the [FAQ](/specifications/flashblocks#why-does-eth_call-pending-report-a-block-number-several-blocks-behind-tip) for details.
+**`eth_call "pending"` block context on Flashblocks nodes:** Block-context properties (`block.number`, `block.timestamp`, `block.basefee`) may reflect a block several behind tip due to how nodes cache historical Flashblocks. See the [FAQ](/specifications/flashblocks#rpc) for details.
 </Note>
 
 ## Parameters

--- a/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
+++ b/docs/base-chain/api-reference/flashblocks-api/flashblocks-api-overview.mdx
@@ -54,7 +54,7 @@ Unique identifier for the block being built. Remains consistent across all Flash
 </ParamField>
 
 <ParamField path="index" type="number">
-Flashblock index within the current block. Starts at 0 (system transactions only). User transactions begin at index 1. Typically reaches 9–10 per block, but [may exceed 10](/specifications/flashblocks#can-the-flashblock-index-exceed-10-is-that-a-bug) during sequencer timing drift.
+Flashblock index within the current block. Starts at 0 (system transactions only). User transactions begin at index 1. Typically reaches 9–10 per block, but [may exceed 10](/specifications/flashblocks#websocket) during sequencer timing drift.
 </ParamField>
 
 <ParamField path="base" type="Base Object">

--- a/docs/upgrades/denim/200ms-blocks.mdx
+++ b/docs/upgrades/denim/200ms-blocks.mdx
@@ -19,7 +19,7 @@ Denim replaces [Flashblocks](/specifications/flashblocks), which publish increme
 Denim keeps the Ethereum block header and its seconds-based `timestamp` unchanged. A BaseTime metadata deposit supplies the sub-second component. Together, these values identify a canonical block's full millisecond timestamp.
 
 <Info>
-If your application uses Flashblocks, see [Migrate From Flashblocks](/base-chain/specs/upgrades/denim/migrate-from-flashblocks) for the required API changes.
+If your application uses Flashblocks, see [Migrate From Flashblocks](/upgrades/denim/migrate-from-flashblocks) for the required API changes.
 </Info>
 
 ## Network Availability

--- a/docs/upgrades/denim/migrate-from-flashblocks.mdx
+++ b/docs/upgrades/denim/migrate-from-flashblocks.mdx
@@ -39,4 +39,4 @@ The `"pending"` block tag and Flashblocks preconfirmation state have no direct e
 
 ## Test on Vibenet
 
-Test your migrated integration on [Vibenet](/build-on-base/test-on-vibenet). For the protocol design and RPC behavior, see [200ms Native Blocks](/base-chain/specs/upgrades/denim/200ms-blocks).
+Test your migrated integration on [Vibenet](/build-on-base/test-on-vibenet). For the protocol design and RPC behavior, see [200ms Native Blocks](/upgrades/denim/200ms-blocks).

--- a/docs/upgrades/fjord/overview.mdx
+++ b/docs/upgrades/fjord/overview.mdx
@@ -13,7 +13,7 @@ description: "Overview of the Fjord hardfork, introducing FastLZ-based L1 fee es
 
 ## Execution Layer
 
-- [RIP-7212: Precompile for secp256r1 Curve Support](/specifications/base-protocol/execution/precompiles#P256VERIFY)
+- [RIP-7212: Precompile for secp256r1 Curve Support](/specifications/base-protocol/execution/precompiles#p256verify)
 - [FastLZ compression for L1 data fee calculation](/upgrades/fjord/exec-engine#fees)
 - [Deprecate the `getL1GasUsed` method on the `GasPriceOracle` contract](/upgrades/fjord/predeploys#l1-gas-usage-estimation)
 - [Deprecate the `L1GasUsed` field on the transaction receipt](/upgrades/fjord/exec-engine#l1-gas-usage-estimation)

--- a/docs/upgrades/jovian/overview.mdx
+++ b/docs/upgrades/jovian/overview.mdx
@@ -14,7 +14,7 @@ description: "Overview of the Jovian hardfork, introducing a configurable minimu
 ## Execution Layer
 
 - [Minimum Base Fee](/upgrades/jovian/exec-engine#minimum-base-fee)
-- [DA Footprint Limit](/upgrades/jovian/exec-engine#da-footprint-limit)
+- [DA Footprint Limit](/upgrades/jovian/exec-engine#da-footprint-block-limit)
 - [Operator Fee](/upgrades/jovian/exec-engine#operator-fee)
 
 ## Consensus Layer


### PR DESCRIPTION
**What changed? Why?**

The recent information-architecture restructure moved several pages under new paths but left some cross-references pointing at the old locations or at anchors that no longer resolve. This repairs six of them:

- **Denim pages** linked to each other via the pre-restructure `/base-chain/specs/upgrades/denim/...` paths, which no longer exist. Updated to `/upgrades/denim/...`.
  - `upgrades/denim/200ms-blocks.mdx` → `migrate-from-flashblocks`
  - `upgrades/denim/migrate-from-flashblocks.mdx` → `200ms-blocks`
- **Fjord overview** linked to `precompiles#P256VERIFY`; generated anchors are lowercased, so the heading `## P256VERIFY` resolves as `#p256verify`. Fixed the fragment case (the sibling links in the same list already use lowercase).
- **Jovian overview** linked to `exec-engine#da-footprint-limit`, but the heading is `## DA Footprint Block Limit` → `#da-footprint-block-limit`.
- **Flashblocks FAQ links** from `eth_call` and the Flashblocks API overview targeted `<Accordion>` titles, which do not generate anchors. Repointed to the headings of the sections that contain those accordions (`#rpc` and `#websocket`).

**Notes to reviewers**

All six are one-line fragment/path fixes; no page content changes. Verified each target: the Denim pages exist under `/upgrades/denim/` (the old paths are not covered by any redirect), `## P256VERIFY` and `## DA Footprint Block Limit` exist on their pages, and the two FAQ answers sit under the `## RPC` and `## WebSocket` headings on `/specifications/flashblocks`. This supersedes my four earlier single-fix PRs (#1838, #1841, #1843, #1844), which were opened against the pre-restructure paths; I'm closing those in favor of this one.

**How has it been tested?**

Ran a repo-wide link/anchor pass against the current `master`; these six links resolve to no existing target, and the replacements match existing headings/paths.