### PR TITLE
docs: add Upcoming Features page for planned protocol work

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -91,7 +91,7 @@ npx skills add base/base-skills
 |SDKs & APIs/Base MCP/Guides:agents/guides/check-balance,agents/guides/send-tokens,agents/guides/swap-tokens,agents/guides/view-history,agents/guides/sign-messages,agents/guides/batch-calls,agents/guides/x402-payments
 |SDKs & APIs/Base MCP/Skill & Plugins:agents/plugins/index,agents/plugins/custom-plugins
 |SDKs & APIs/Base MCP/Skill & Plugins/Native Plugins:agents/plugins/native/index,agents/plugins/native/aerodrome,agents/plugins/native/avantis,agents/plugins/native/balancer,agents/plugins/native/bankr,agents/plugins/native/bitrefill,agents/plugins/native/brickken,agents/plugins/native/clawnch,agents/plugins/native/flaunch,agents/plugins/native/gmgn,agents/plugins/native/hydrex,agents/plugins/native/kyberswap,agents/plugins/native/moonwell,agents/plugins/native/morpho,agents/plugins/native/o1-exchange,agents/plugins/native/opensea,agents/plugins/native/printr,agents/plugins/native/uniswap,agents/plugins/native/venice,agents/plugins/native/virtuals,agents/plugins/native/yo
-|Upgrades/Overview:upgrades/overview,base-chain/network-information/configuration-changelog
+|Upgrades/Overview:upgrades/overview,upgrades/upcoming-features,base-chain/network-information/configuration-changelog
 |Upgrades/Denim:upgrades/denim/overview,upgrades/denim/200ms-blocks,upgrades/denim/migrate-from-flashblocks
 |Upgrades/Cobalt:upgrades/cobalt/overview,upgrades/cobalt/dynamic-upgrades,base-chain/specs/reference/b20/changelog/02-cobalt-b20asset-multiplier,base-chain/specs/reference/b20/changelog/02-cobalt-b20-seize,base-chain/specs/reference/b20/changelog/02-cobalt-policyregistry-composite-policy
 |Upgrades/Beryl:upgrades/beryl/overview,upgrades/beryl/reth-v2,upgrades/beryl/reducing-canonical-withdrawal-delay,upgrades/beryl/b20

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -685,6 +685,7 @@
             "group": "Overview",
             "pages": [
               "upgrades/overview",
+              "upgrades/upcoming-features",
               "base-chain/network-information/configuration-changelog"
             ]
           },

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -834,6 +834,8 @@ const client = createPublicClient({ chain: base, transport: http() })
 
 - [Upgrades](https://docs.base.org/upgrades/overview): Track Base network upgrades, activation dates, and the protocol changes included in each release.
 
+- [Upcoming Features](https://docs.base.org/upgrades/upcoming-features): Planned Base protocol features and their ballpark target quarters, tracked independently of a specific network upgrade.
+
 - [Configuration Changelog](https://docs.base.org/base-chain/network-information/configuration-changelog): A log of configuration changes to the Base networks.
 
 ### Denim

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -768,6 +768,8 @@
 
 - [Upgrades](https://docs.base.org/upgrades/overview): Track Base network upgrades, activation dates, and the protocol changes included in each release.
 
+- [Upcoming Features](https://docs.base.org/upgrades/upcoming-features): Planned Base protocol features and their ballpark target quarters, tracked independently of a specific network upgrade.
+
 - [Configuration Changelog](https://docs.base.org/base-chain/network-information/configuration-changelog): A log of configuration changes to the Base networks.
 
 ### Denim

--- a/docs/upgrades/overview.mdx
+++ b/docs/upgrades/overview.mdx
@@ -7,6 +7,10 @@ Base evolves through named network upgrades. Each release introduces protocol ch
 
 A month without a confirmed activation timestamp is a planning target and may change.
 
+<Note>
+For planned protocol features that are not yet tied to a scheduled upgrade, see [Upcoming Features](/upgrades/upcoming-features).
+</Note>
+
 <Update label="October 2026" tags={["Planning"]}>
 ## Denim
 

--- a/docs/upgrades/upcoming-features.mdx
+++ b/docs/upgrades/upcoming-features.mdx
@@ -1,0 +1,27 @@
+---
+title: "Upcoming Features"
+description: "Planned Base protocol features and their ballpark target quarters, tracked independently of a specific network upgrade."
+---
+
+This page lists Base protocol features that are planned or in development, independent of the named upgrade that eventually ships them. Each entry links to its specification where one exists.
+
+<Note>
+Targets are ballpark quarters and may change. A feature moves onto a named upgrade page (for example, [Cobalt](/upgrades/cobalt/overview)) only once that upgrade is scheduled and locked in, at which point the official activation dates and final feature list are published.
+</Note>
+
+## Planned Features
+
+| Feature | Summary | Details | Target |
+|---------|---------|---------|--------|
+| 200ms Native Blocks | Five canonical blocks per second, replacing Flashblocks with canonical block and RPC streams. | [200ms Native Blocks](/upgrades/denim/200ms-blocks) | Q4 2026 |
+| B20 Improvements | Pay fees in B20s, scheduled multiplier updates, and composite policies for the B20 token standard. | [B20 changelog](/specifications/b20/changelog) | Q3 2026 |
+| Validity Transactions | A transaction type with onchain predicate checks for safer, conditional execution. | [Validity Transactions](/specifications/build-transaction/validity-transactions) | Q3 2026 |
+| Dynamic Upgrades | An onchain upgrade schedule that lets nodes activate forks live, without a client restart. | [Dynamic Upgrades](/upgrades/cobalt/dynamic-upgrades) | Q3 2026 |
+| TEE Migration | Migrate Base infrastructure to run inside a Trusted Execution Environment. | Specification pending | Q3 2026 |
+| Native Account Abstraction (EIP-8130) | Onchain smart accounts, scoped session keys, and native gas sponsorship, with no bundlers or relays. | [Native Account Abstraction](/specifications/native-account-abstraction) | TBD |
+
+## How Features Ship
+
+1. **Proposed** — a feature is designed and, where applicable, written up as a specification. It appears in the table above with a ballpark target.
+2. **Scheduled** — once an upgrade that carries the feature is locked in, a named upgrade page is published with official Base Sepolia and Base Mainnet activation dates.
+3. **Live** — the upgrade activates and moves to the [Upgrades](/upgrades/overview) timeline.


### PR DESCRIPTION
**What changed? Why?**

Adds `upgrades/upcoming-features.mdx`, a feature-first list (200ms blocks, B20 improvements, validity transactions, dynamic upgrades, TEE migration, EIP-8130) with ballpark quarter targets and spec links, decoupled from any named upgrade, per Henri's proposal to only publish a named upgrade page once that upgrade is scheduled and locked in.

**Notes to reviewers**

First draft to visualize the concept and iterate; open decisions are whether to pull the still-"Planning" Cobalt/Denim entries off the timeline, whether to relocate their spec pages out of the named groups, and the exact quarter targets (EIP-8130 is currently TBD since it's parked for a later upgrade).

**How has it been tested?**

`node scripts/validate-docs-structure.js` passes and the AGENTS.md / llms.txt indexes were regenerated.

**Screenshots**

Pending — I can run `/screenshot` to capture the new page and the updated Upgrades landing once you want them in the body; the Mintlify PR preview also renders both.